### PR TITLE
feat(nvr): swarm-native service POC with secure session + operator automation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,2431 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "base64",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
+ "sync_wrapper",
+ "tokio",
+ "tokio-tungstenite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
 name = "constitute-nvr"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64",
+ "chacha20poly1305",
+ "clap",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+ "walkdir",
+ "x25519-dalek",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "typenum",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+
+[[package]]
+name = "icu_properties"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+
+[[package]]
+name = "icu_provider"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itoa"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "js-sys"
+version = "0.3.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dc6f6450b3f6d4ed5b16327f38fed626d375a886159ca555bd7822c0c3a5a6"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.182"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.49.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror",
+ "utf-8",
+]
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60722a937f594b7fde9adb894d7c092fc1bb6612897c46368d18e7a20208eff2"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a89f4650b770e4521aa6573724e2aed4704372151bd0de9d16a3bbabb87441a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac8c6395094b6b91c4af293f4c79371c163f9a6f56184d2c9a85f5a95f3950"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3fabce6159dc20728033842636887e4877688ae94382766e00b180abac9d60"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0e091bdb824da87dc01d967388880d017a0a9bc4f3bdc0d86ee9f9336e3bb5"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.90"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "705eceb4ce901230f8625bd1d665128056ccbe4b7408faa625eec1ba80f59a97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,26 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = "1.0"
+axum = { version = "0.8", features = ["ws"] }
+base64 = "0.22"
+chacha20poly1305 = { version = "0.10", features = ["std"] }
+clap = { version = "4.5", features = ["derive"] }
+futures-util = "0.3"
+hex = "0.4"
+hkdf = "0.12"
+hmac = "0.12"
+rand = "0.8"
+regex = "1"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+secp256k1 = { version = "0.29", features = ["rand", "global-context"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+sha2 = "0.10"
+tokio = { version = "1.44", features = ["full"] }
+tokio-tungstenite = "0.28"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
+uuid = { version = "1", features = ["v4"] }
+walkdir = "2"
+x25519-dalek = { version = "2", features = ["static_secrets"] }

--- a/config.example.json
+++ b/config.example.json
@@ -1,9 +1,54 @@
 {
-  "service": "constitute-nvr",
-  "bind": "127.0.0.1:4500",
-  "data_dir": "./data",
+  "node_id": "nvr-local",
   "node_role": "native",
-  "capabilities": ["nvr"],
-  "gateway_relays": [],
-  "zones": []
+  "device_label": "Constitute NVR",
+  "service_version": "0.1.0",
+  "nostr_pubkey": "",
+  "nostr_sk_hex": "",
+  "swarm": {
+    "bind": "0.0.0.0:4050",
+    "peers": [
+      "127.0.0.1:4040"
+    ],
+    "announce_interval_secs": 20,
+    "zones": [
+      {
+        "key": "replace_zone_key",
+        "name": "Default Zone"
+      }
+    ],
+    "endpoint_hint": "udp://replace-host:4050"
+  },
+  "api": {
+    "bind": "0.0.0.0:8456",
+    "identity_id": "REPLACE_WITH_IDENTITY_ID",
+    "authorized_device_pks": [],
+    "identity_secret_hex": "",
+    "server_secret_hex": ""
+  },
+  "storage": {
+    "root": "/mnt/REPLACE_WITH_STORAGE_MOUNT/constitute-nvr",
+    "encryption_key_hex": "",
+    "encrypt_interval_secs": 5
+  },
+  "update": {
+    "enabled": true,
+    "interval_secs": 300,
+    "source_dir": "/opt/constitute-nvr-src",
+    "branch": "main",
+    "script_path": "/usr/local/bin/constitute-nvr-self-update"
+  },
+  "cameras": [
+    {
+      "source_id": "cam-reolink-e1",
+      "name": "Reolink E1",
+      "onvif_host": "10.60.0.11",
+      "onvif_port": 8000,
+      "rtsp_url": "rtsp://user:pass@10.60.0.11:554/h264Preview_01_main",
+      "username": "user",
+      "password": "pass",
+      "enabled": true,
+      "segment_secs": 10
+    }
+  ]
 }

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -1,24 +1,27 @@
-# Camera Compatibility Matrix
+# Camera Compatibility Matrix (Iteration-1)
 
-Status legend:
-- `Planned`: model is in scope but not validated
-- `In Test`: active validation in progress
-- `Validated`: baseline ingest works for iteration criteria
-- `Blocked`: model-specific blocker tracked in issue
+## Validation Target Models
 
-## Iteration-1 Target Models (ONVIF)
+### Anypiz IPC-B8743-S (4MP PoE U series)
+- ONVIF discovery: pending lab validation
+- ONVIF service endpoint auth: pending
+- RTSP ingest: pending
+- Recommended status: test candidate
 
-| Vendor | Model | Protocol | Status | Notes |
-|---|---|---|---|---|
-| Anypiz | IPC-B8743-S (4MP PoE U series) | ONVIF | Planned | First-pass target for fixed PoE stream ingest |
-| Reolink | E1 Outdoor SE PoE Pan Cam | ONVIF | Planned | First-pass target for PTZ-capable stream ingest |
+### Reolink E1 Outdoor SE PoE Pan Cam
+- ONVIF port surfaced in probe observations: yes
+- Reolink cloud/P2P endpoint behavior observed: yes (expected vendor default)
+- RTSP ingest path: pending lab validation in this repo
+- Recommended status: test candidate with camera-jail policy enabled
 
-## Validation Criteria (Baseline)
-- ONVIF discovery/connection succeeds with configured credentials.
-- Primary stream is ingestible for sustained test interval.
-- Basic metadata (codec/resolution/framerate) is captured.
-- Stream reconnect behavior is deterministic after interruption.
-- No plaintext credentials are persisted.
+## Validation Gates
+A model is considered **supported for iteration-1** when all pass:
+1. ONVIF WS-Discovery returns stable endpoint(s)
+2. ONVIF auth works with configured credentials
+3. RTSP ingest records continuous segments for >= 20 minutes
+4. encrypted segment conversion pass succeeds without data loss
+5. retrieval command returns decrypted segment bytes to authorized session client
 
-## Tracking
-Camera-specific defects should be filed as separate issues and linked to the iteration umbrella.
+## Security Notes
+- Vendor cloud/P2P features should be disabled when camera firmware allows.
+- Regardless of vendor settings, enforce camera network isolation + egress policy.

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -1,0 +1,88 @@
+# Operations (POC)
+
+## 1) Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-wizard.sh | bash
+```
+
+Wizard prompts for:
+- storage root path (default placeholder)
+- self-update timer interval
+- optional camera hardening settings
+
+## 2) Service Checks
+
+```bash
+systemctl status constitute-nvr
+journalctl -u constitute-nvr -n 100 --no-pager
+systemctl status constitute-nvr-update.timer
+systemctl list-timers | grep constitute-nvr-update
+```
+
+## 3) Config Checks
+File:
+- `/etc/constitute-nvr/config.json`
+
+Critical fields before ingest:
+- `api.identity_id`
+- `swarm.peers`
+- `swarm.zones[]`
+- `storage.root`
+- `cameras[]`
+
+## 4) ONVIF Discovery Smoke
+
+```bash
+constitute-nvr --config /etc/constitute-nvr/config.json --discover-onvif
+```
+
+## 5) Health Endpoint
+
+```bash
+curl -s http://127.0.0.1:8456/health | jq .
+```
+
+## 6) Camera Hardening Script
+Audit-only:
+
+```bash
+sudo bash scripts/linux/harden-camera-interface.sh
+```
+
+Apply:
+
+```bash
+sudo bash scripts/linux/harden-camera-interface.sh \
+  --apply \
+  --iface enp2s0 \
+  --camera-cidr 10.60.0.0/24
+```
+
+Expected effect:
+- camera NIC zone target `DROP`
+- host egress on camera NIC restricted to ONVIF/RTSP (+ optional WS-Discovery, optional NTP)
+
+## 7) Manual Session Protocol Test (Identity-bound)
+Connect websocket to `/session` and perform:
+1. plaintext `hello`
+2. receive `hello_ack`
+3. switch to encrypted `cipher` envelopes
+4. issue `list_sources` and `list_segments`
+
+Use the configured values:
+- `api.identity_id`
+- `api.identity_secret_hex`
+- `api.server_secret_hex`
+
+## 8) Self-Update
+Manual run:
+
+```bash
+sudo /usr/local/bin/constitute-nvr-self-update --source-dir /opt/constitute-nvr-src --branch main --service-name constitute-nvr --try-restart
+```
+
+## Known POC Limits
+- depends on host `ffmpeg`
+- source-build update flow (no signed release artifact path yet)
+- segment-serving path implemented before live stream relay path

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -1,51 +1,107 @@
-# Protocol Notes (Draft)
+# Protocol Notes (Iteration-1 Draft)
 
-This file defines iteration-1 NVR contract intent.
+## Purpose
+Define the active contract surface for `constitute-nvr` POC integration.
 
-## Direction
-- Host baseline: Fedora systemd service
-- Ingest baseline: ONVIF-first
+## Service Identity
+- runtime role: `native`
+- service capability: `nvr`
+- swarm records include:
+  - `role`
+  - `service`
+  - `serviceVersion`
 
-## Capability Advertisement (Draft)
-Planned capability record fields:
-- `service`: `nvr`
-- `version`
-- `controlEndpoint` (if exposed)
-- `ingestProtocols`: `['onvif']`
-- `zones`
-- `healthSummary` (optional)
+## Swarm Transport (Native)
+- channel: UDP
+- protocol version: `v=1`
+- message kinds:
+  - `hello`
+  - `ack`
+  - `record`
 
-## Source Registration Contract (Draft)
-Planned required fields:
-- `sourceId`
-- `protocol` (`onvif`)
-- `endpoint` (host/IP/port)
-- `authRef` (reference handle, not raw secret)
-- `zoneScope`
-- `retentionPolicyId`
+### `hello`
+```json
+{
+  "kind": "hello",
+  "v": 1,
+  "node_id": "nvr-...",
+  "device_pk": "<nostr pubkey>",
+  "zones": ["<zone-key>"],
+  "ts": 1700000000000
+}
+```
 
-## Retention Policy Contract (Draft)
-Planned required fields:
-- `policyId`
-- `maxAge`
-- `maxStorage`
-- `pruneMode`
+### `record`
+Carries signed Nostr event payloads for:
+- device discovery (`kind=30078`, `t=swarm_discovery`, `type=device`, `role=native`, `service=nvr`)
+- zone presence (`kind=1`, `t=constitute`, `z=<zone>`)
 
-## Control Plane (Draft)
-Planned operations:
-- `source.add`
-- `source.update`
-- `source.remove`
-- `retention.set`
-- `status.get`
-- `recording.list`
+## ONVIF Discovery
+- WS-Discovery probe to `239.255.255.250:3702`
+- ONVIF endpoint extraction from `XAddrs`
+- command surface supports discovery trigger from authenticated session
 
-## Auth Envelope
-- signed request metadata expected
-- no plaintext long-term secrets in control payloads
-- service-side authorization must be explicit and test-backed
+## Session Negotiation (`/session`)
 
-## Guardrail
-Protocol additions here must remain compatible with Constitution shared contracts and should be reviewed against:
+### 1) Client hello (plaintext frame)
+```json
+{
+  "type": "hello",
+  "identityId": "<identity>",
+  "devicePk": "<client-device-pk>",
+  "clientKey": "<base64 x25519 pubkey>",
+  "ts": 1700000000,
+  "proof": "<hex hmac-sha256>"
+}
+```
+
+Proof input material:
+- `identityId|devicePk|clientKey|ts`
+- key: `api.identity_secret_hex`
+
+Admission checks:
+- identity match (`api.identity_id`)
+- optional allowlist match (`api.authorized_device_pks`)
+- timestamp skew <= 300s
+- valid HMAC proof
+
+### 2) Server ack (plaintext frame)
+```json
+{
+  "type": "hello_ack",
+  "sessionId": "<uuid>",
+  "serverKey": "<base64 x25519 pubkey>",
+  "ts": 1700000000000
+}
+```
+
+### 3) Encrypted command envelope
+```json
+{
+  "type": "cipher",
+  "nonce": "<base64 24-byte nonce>",
+  "data": "<base64 xchacha20poly1305 ciphertext>"
+}
+```
+
+Session key derivation:
+- X25519 shared secret (server static secret + client key)
+- HKDF-SHA256 with `identity_secret_hex` as salt
+- context: `constitute-nvr:<identity>:<sessionId>`
+
+## Encrypted Commands
+- `list_sources`
+- `discover_onvif`
+- `list_segments` (`sourceId`, `limit`)
+- `get_segment` (`sourceId`, `name`)
+
+## Storage Contract
+- segment root: `storage.root/segments/<source_id>/`
+- plaintext extension: `.mp4`
+- encrypted extension: `.cnv`
+- encrypted blob format: `CNRV1 || nonce(24) || ciphertext`
+
+## Compatibility Guardrail
+Any breaking changes to session/swarm payloads must be version-gated and coordinated with:
 - `constitute-gateway/docs/PROTOCOL.md`
-- `constitute` swarm and identity event handling
+- `constitute` swarm client handling

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,20 +5,28 @@
 - [x] project architecture baseline
 - [x] initial project tracking issues
 
-## Iteration 1: Fedora + ONVIF Contract Freeze
-- [ ] define capability advertisement fields for `nvr`
-- [ ] define control-plane request/response contract draft
-- [ ] define ONVIF source model and auth boundary
-- [ ] define camera compatibility matrix and validation criteria
+## Iteration 1: Contract + Service POC
+- [x] capability + control contract draft (`docs/PROTOCOL.md`)
+- [x] Fedora systemd service baseline wizard
+- [x] camera-interface hardening script (RTSP/ONVIF + optional NTP lane)
+- [x] swarm-native client bootstrap path (`role=native`, `service=nvr`)
+- [x] identity-bound symmetric websocket session negotiation
+- [x] encrypted segment-at-rest storage pass
 
-## Iteration 2: ONVIF Ingest + Secure Storage Core
-- [ ] ONVIF ingest adapter trait and mock adapter
-- [ ] ONVIF discovery/profile negotiation baseline
-- [ ] encrypted segment/index store abstraction
-- [ ] retention policy engine and pruning behavior
+## Iteration 2: Ingest Reliability
+- [ ] ONVIF source lifecycle (register/update/remove) with explicit state machine
+- [ ] reconnect/backoff policy with bounded retries and observability
+- [ ] ingest validation on target camera matrix
+- [ ] service metrics publication in swarm records
 
-## Iteration 3: Fedora Service + Integration
-- [ ] Fedora systemd service profile and operator runbook
-- [ ] control endpoints with auth checks
-- [ ] gateway/web integration tests
-- [ ] camera validation pass for initial target models
+## Iteration 3: Web/Gateway Convergence
+- [ ] exact identity/device auth parity with `constitute` + `constitute-gateway`
+- [ ] browser client integration test for encrypted session channel
+- [ ] segment retrieval UX/API convergence in web repo
+- [ ] zone routing and discovery resilience test matrix
+
+## Iteration 4: Productionization
+- [ ] signed release artifact update path (replace source-build updater default)
+- [ ] hardware-backed key options and sealed secret handling
+- [ ] vendor-specific P2P disable automation hooks (where camera APIs allow)
+- [ ] full operator runbooks for fedora lab + vps deployment profiles

--- a/scripts/linux/harden-camera-interface.sh
+++ b/scripts/linux/harden-camera-interface.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPLY=0
+IFACE=""
+CAMERA_CIDR=""
+ONVIF_PORTS="80,443,8000,8080,8899"
+RTSP_PORTS="554"
+ALLOW_NTP_HOST=1
+ALLOW_ONVIF_DISCOVERY=1
+NO_EGRESS_LOCK=0
+ZONE_NAME="constitute-camera"
+NFT_TABLE="constitute_nvr_cam"
+
+usage() {
+  cat <<'EOF'
+Usage: harden-camera-interface.sh [options]
+
+Audit/apply camera-network hardening for constitute-nvr.
+
+Goals:
+- bind the camera NIC to a drop-by-default firewalld zone
+- allow only explicit camera->host ingress (optional NTP)
+- lock host egress over that NIC to ONVIF/RTSP (+ optional WS-Discovery + NTP)
+
+Options:
+  --apply                     Apply changes (default is audit-only)
+  --iface <name>              Camera network interface (required with --apply)
+  --camera-cidr <CIDR>        Camera subnet CIDR (required with --apply)
+  --onvif-ports <csv>         ONVIF TCP port list (default: 80,443,8000,8080,8899)
+  --rtsp-ports <csv>          RTSP TCP port list (default: 554)
+  --no-ntp-host               Do not allow camera->host UDP/123
+  --no-onvif-discovery        Do not allow host->camera UDP/3702
+  --no-egress-lock            Skip nftables egress restriction stage
+  -h, --help                  Show help
+
+Examples:
+  ./scripts/linux/harden-camera-interface.sh
+  sudo ./scripts/linux/harden-camera-interface.sh --apply --iface enp2s0 --camera-cidr 10.60.0.0/24
+EOF
+}
+
+log() {
+  echo "[harden-camera] $*"
+}
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    log "missing dependency: $cmd"
+    return 1
+  fi
+}
+
+normalize_csv_ports() {
+  local csv="$1"
+  local -a raw
+  local -a clean=()
+  IFS=',' read -r -a raw <<<"$csv"
+
+  if [[ "${#raw[@]}" -eq 0 ]]; then
+    return 1
+  fi
+
+  for p in "${raw[@]}"; do
+    p="${p//[[:space:]]/}"
+    [[ -z "$p" ]] && continue
+    if ! [[ "$p" =~ ^[0-9]+$ ]]; then
+      return 1
+    fi
+    if (( p < 1 || p > 65535 )); then
+      return 1
+    fi
+    clean+=("$p")
+  done
+
+  if [[ "${#clean[@]}" -eq 0 ]]; then
+    return 1
+  fi
+
+  printf '%s\n' "${clean[@]}" | sort -n -u | paste -sd, -
+}
+
+merge_csv_ports() {
+  local a="$1"
+  local b="$2"
+  {
+    echo "$a"
+    echo "$b"
+  } | tr "," "\n" | sed '/^$/d' | sort -n -u | paste -sd, -
+}
+
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --apply)
+      APPLY=1
+      shift
+      ;;
+    --iface)
+      IFACE="${2:?missing value for --iface}"
+      shift 2
+      ;;
+    --camera-cidr)
+      CAMERA_CIDR="${2:?missing value for --camera-cidr}"
+      shift 2
+      ;;
+    --onvif-ports)
+      ONVIF_PORTS="${2:?missing value for --onvif-ports}"
+      shift 2
+      ;;
+    --rtsp-ports)
+      RTSP_PORTS="${2:?missing value for --rtsp-ports}"
+      shift 2
+      ;;
+    --no-ntp-host)
+      ALLOW_NTP_HOST=0
+      shift
+      ;;
+    --no-onvif-discovery)
+      ALLOW_ONVIF_DISCOVERY=0
+      shift
+      ;;
+    --no-egress-lock)
+      NO_EGRESS_LOCK=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! ONVIF_PORTS="$(normalize_csv_ports "$ONVIF_PORTS")"; then
+  echo "Invalid ONVIF ports list" >&2
+  exit 1
+fi
+if ! RTSP_PORTS="$(normalize_csv_ports "$RTSP_PORTS")"; then
+  echo "Invalid RTSP ports list" >&2
+  exit 1
+fi
+ALLOWED_TCP_PORTS="$(merge_csv_ports "$ONVIF_PORTS" "$RTSP_PORTS")"
+
+if [[ "$APPLY" -eq 1 ]]; then
+  if [[ -z "$IFACE" || -z "$CAMERA_CIDR" ]]; then
+    echo "--iface and --camera-cidr are required with --apply" >&2
+    exit 1
+  fi
+  if ! [[ "$CAMERA_CIDR" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}/[0-9]{1,2}$ ]]; then
+    echo "--camera-cidr must be IPv4 CIDR format (example: 10.60.0.0/24)" >&2
+    exit 1
+  fi
+fi
+
+log "mode: $([[ "$APPLY" -eq 1 ]] && echo apply || echo audit)"
+log "iface: ${IFACE:-<unset>}"
+log "camera-cidr: ${CAMERA_CIDR:-<unset>}"
+log "allowed tcp ports (ONVIF+RTSP): $ALLOWED_TCP_PORTS"
+log "camera->host ntp: $([[ "$ALLOW_NTP_HOST" -eq 1 ]] && echo enabled || echo disabled)"
+log "host->camera ws-discovery (udp/3702): $([[ "$ALLOW_ONVIF_DISCOVERY" -eq 1 ]] && echo enabled || echo disabled)"
+log "egress lock: $([[ "$NO_EGRESS_LOCK" -eq 0 ]] && echo enabled || echo disabled)"
+
+if [[ "$APPLY" -eq 0 ]]; then
+  if command -v firewall-cmd >/dev/null 2>&1; then
+    if systemctl is-active --quiet firewalld; then
+      log "firewalld active"
+      firewall-cmd --get-active-zones || true
+    else
+      log "firewalld installed but inactive"
+    fi
+  else
+    log "firewalld not installed"
+  fi
+
+  if command -v nft >/dev/null 2>&1; then
+    if nft list table inet "$NFT_TABLE" >/dev/null 2>&1; then
+      log "nft table $NFT_TABLE present"
+      nft list table inet "$NFT_TABLE" || true
+    else
+      log "nft table $NFT_TABLE not present"
+    fi
+  else
+    log "nft not installed"
+  fi
+
+  exit 0
+fi
+
+require_cmd firewall-cmd >/dev/null
+require_cmd nft >/dev/null
+
+if ! systemctl is-active --quiet firewalld; then
+  echo "firewalld must be active for --apply" >&2
+  exit 1
+fi
+
+if ! ip link show "$IFACE" >/dev/null 2>&1; then
+  echo "Interface $IFACE not found" >&2
+  exit 1
+fi
+
+if ! run_sudo firewall-cmd --permanent --get-zones | tr ' ' '\n' | grep -qx "$ZONE_NAME"; then
+  log "creating firewalld zone: $ZONE_NAME"
+  run_sudo firewall-cmd --permanent --new-zone="$ZONE_NAME" >/dev/null
+fi
+
+log "setting zone target DROP: $ZONE_NAME"
+run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --set-target=DROP >/dev/null
+
+if ! run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --query-interface="$IFACE" >/dev/null 2>&1; then
+  log "binding interface $IFACE to zone $ZONE_NAME"
+  run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-interface="$IFACE" >/dev/null
+fi
+
+ntp_rule="rule family=\"ipv4\" source address=\"${CAMERA_CIDR}\" port protocol=\"udp\" port=\"123\" accept"
+run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --remove-rich-rule="$ntp_rule" >/dev/null 2>&1 || true
+if [[ "$ALLOW_NTP_HOST" -eq 1 ]]; then
+  log "allowing camera->host NTP (udp/123) from $CAMERA_CIDR"
+  run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-rich-rule="$ntp_rule" >/dev/null
+fi
+
+log "reloading firewalld"
+run_sudo firewall-cmd --reload >/dev/null
+
+log "configuring nft egress restrictions"
+run_sudo nft "add table inet ${NFT_TABLE}" >/dev/null 2>&1 || true
+run_sudo nft "delete chain inet ${NFT_TABLE} output" >/dev/null 2>&1 || true
+run_sudo nft "add chain inet ${NFT_TABLE} output { type filter hook output priority 0; policy accept; }"
+
+run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} tcp dport { ${ALLOWED_TCP_PORTS//,/ , } } accept"
+if [[ "$ALLOW_ONVIF_DISCOVERY" -eq 1 ]]; then
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport 3702 accept"
+fi
+if [[ "$ALLOW_NTP_HOST" -eq 1 ]]; then
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport 123 accept"
+fi
+if [[ "$NO_EGRESS_LOCK" -eq 0 ]]; then
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} drop"
+fi
+
+log "applied"
+run_sudo firewall-cmd --zone="$ZONE_NAME" --list-all || true
+run_sudo nft list table inet "$NFT_TABLE" || true
+

--- a/scripts/linux/install-wizard.sh
+++ b/scripts/linux/install-wizard.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${REPO_OWNER:-Aux0x7F}"
+REPO_NAME="${REPO_NAME:-constitute-nvr}"
+REF="${REF:-main}"
+REPO_URL="${REPO_URL:-https://github.com/${REPO_OWNER}/${REPO_NAME}.git}"
+NON_INTERACTIVE=0
+APPLY_HARDENING="ask"
+CAMERA_IFACE=""
+CAMERA_CIDR=""
+ONVIF_PORTS="80,443,8000,8080,8899"
+RTSP_PORTS="554"
+ALLOW_NTP_HOST=1
+INSTALL_PREFIX="/opt/constitute-nvr"
+SOURCE_DIR="/opt/constitute-nvr-src"
+BIN_LINK="/usr/local/bin/constitute-nvr"
+SELF_UPDATE_BIN="/usr/local/bin/constitute-nvr-self-update"
+SERVICE_NAME="constitute-nvr"
+SERVICE_USER="constitute-nvr"
+NOLOGIN_PATH="$(command -v nologin || echo /sbin/nologin)"
+STORAGE_ROOT="/mnt/REPLACE_WITH_STORAGE_MOUNT/constitute-nvr"
+UPDATE_INTERVAL_SECS=300
+
+usage() {
+  cat <<'EOF'
+Usage: install-wizard.sh [options]
+
+Build and install constitute-nvr as a Fedora/Linux systemd service,
+configure self-update timer, and optionally apply camera-interface hardening.
+
+Options:
+  --repo-owner <owner>       GitHub owner (default: Aux0x7F)
+  --repo-name <name>         GitHub repo (default: constitute-nvr)
+  --repo-url <url>           Git URL override
+  --ref <git-ref>            Git ref to build (default: main)
+  --source-dir <path>        Source clone location (default: /opt/constitute-nvr-src)
+  --storage-root <path>      Storage root path (default placeholder)
+  --update-interval <secs>   Self-update poll interval in seconds (default: 300)
+  --non-interactive          No prompts
+  --apply-hardening          Apply camera hardening
+  --skip-hardening           Skip camera hardening
+  --camera-iface <iface>     Camera interface (e.g. enp2s0)
+  --camera-cidr <cidr>       Camera subnet (e.g. 10.60.0.0/24)
+  --onvif-ports <csv>        ONVIF TCP ports (default: 80,443,8000,8080,8899)
+  --rtsp-ports <csv>         RTSP TCP ports (default: 554)
+  --no-ntp-host              Do not allow camera->host UDP/123
+  -h, --help                 Show help
+EOF
+}
+
+log() {
+  echo "[install-nvr] $*"
+}
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+confirm() {
+  local prompt="$1"
+  local default_yes="$2"
+
+  if [[ "$NON_INTERACTIVE" -eq 1 ]]; then
+    [[ "$default_yes" -eq 1 ]] && return 0 || return 1
+  fi
+
+  local suffix="[y/N]"
+  [[ "$default_yes" -eq 1 ]] && suffix="[Y/n]"
+  read -r -p "$prompt $suffix " reply
+
+  if [[ -z "$reply" ]]; then
+    [[ "$default_yes" -eq 1 ]] && return 0 || return 1
+  fi
+
+  case "$reply" in
+    [Yy]|[Yy][Ee][Ss]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-owner)
+      REPO_OWNER="${2:?missing value for --repo-owner}"
+      shift 2
+      ;;
+    --repo-name)
+      REPO_NAME="${2:?missing value for --repo-name}"
+      shift 2
+      ;;
+    --repo-url)
+      REPO_URL="${2:?missing value for --repo-url}"
+      shift 2
+      ;;
+    --ref)
+      REF="${2:?missing value for --ref}"
+      shift 2
+      ;;
+    --source-dir)
+      SOURCE_DIR="${2:?missing value for --source-dir}"
+      shift 2
+      ;;
+    --storage-root)
+      STORAGE_ROOT="${2:?missing value for --storage-root}"
+      shift 2
+      ;;
+    --update-interval)
+      UPDATE_INTERVAL_SECS="${2:?missing value for --update-interval}"
+      shift 2
+      ;;
+    --non-interactive)
+      NON_INTERACTIVE=1
+      shift
+      ;;
+    --apply-hardening)
+      APPLY_HARDENING=1
+      shift
+      ;;
+    --skip-hardening)
+      APPLY_HARDENING=0
+      shift
+      ;;
+    --camera-iface)
+      CAMERA_IFACE="${2:?missing value for --camera-iface}"
+      shift 2
+      ;;
+    --camera-cidr)
+      CAMERA_CIDR="${2:?missing value for --camera-cidr}"
+      shift 2
+      ;;
+    --onvif-ports)
+      ONVIF_PORTS="${2:?missing value for --onvif-ports}"
+      shift 2
+      ;;
+    --rtsp-ports)
+      RTSP_PORTS="${2:?missing value for --rtsp-ports}"
+      shift 2
+      ;;
+    --no-ntp-host)
+      ALLOW_NTP_HOST=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ "$APPLY_HARDENING" == "ask" ]]; then
+  if confirm "Apply camera-network hardening (RTSP/ONVIF-only + optional NTP lane)?" 1; then
+    APPLY_HARDENING=1
+  else
+    APPLY_HARDENING=0
+  fi
+fi
+
+if [[ "$NON_INTERACTIVE" -eq 0 ]]; then
+  read -r -p "Storage root path [${STORAGE_ROOT}]: " input_storage
+  if [[ -n "$input_storage" ]]; then
+    STORAGE_ROOT="$input_storage"
+  fi
+
+  read -r -p "Self-update interval seconds [${UPDATE_INTERVAL_SECS}]: " input_interval
+  if [[ -n "$input_interval" ]]; then
+    UPDATE_INTERVAL_SECS="$input_interval"
+  fi
+fi
+
+if [[ "$APPLY_HARDENING" -eq 1 ]]; then
+  if [[ -z "$CAMERA_IFACE" && "$NON_INTERACTIVE" -eq 0 ]]; then
+    read -r -p "Camera interface (e.g. enp2s0): " CAMERA_IFACE
+  fi
+  if [[ -z "$CAMERA_CIDR" && "$NON_INTERACTIVE" -eq 0 ]]; then
+    read -r -p "Camera subnet CIDR (e.g. 10.60.0.0/24): " CAMERA_CIDR
+  fi
+  if [[ -z "$CAMERA_IFACE" || -z "$CAMERA_CIDR" ]]; then
+    echo "camera interface and CIDR are required when hardening is enabled" >&2
+    exit 1
+  fi
+fi
+
+if ! [[ "$UPDATE_INTERVAL_SECS" =~ ^[0-9]+$ ]]; then
+  echo "update interval must be integer seconds" >&2
+  exit 1
+fi
+
+require_cmd git
+require_cmd systemctl
+require_cmd curl
+require_cmd python3
+
+if ! command -v cargo >/dev/null 2>&1; then
+  log "cargo not found"
+  if confirm "Install Rust toolchain with rustup now?" 1; then
+    curl -fsSL https://sh.rustup.rs | sh -s -- -y
+    # shellcheck source=/dev/null
+    source "$HOME/.cargo/env"
+  else
+    echo "cargo is required" >&2
+    exit 1
+  fi
+fi
+
+SRC_DIR=""
+TMP_DIR=""
+
+if [[ -f "./Cargo.toml" && -f "./src/main.rs" ]]; then
+  SRC_DIR="$(pwd)"
+  log "using local repository: $SRC_DIR"
+else
+  TMP_DIR="$(mktemp -d)"
+  SRC_DIR="$TMP_DIR/repo"
+  log "cloning source: $REPO_URL"
+  git clone --depth 1 --branch "$REF" "$REPO_URL" "$SRC_DIR"
+fi
+
+cleanup() {
+  if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+log "syncing source clone at ${SOURCE_DIR}"
+run_sudo mkdir -p "$(dirname "$SOURCE_DIR")"
+if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+  run_sudo git clone --depth 1 --branch "$REF" "$REPO_URL" "$SOURCE_DIR"
+else
+  run_sudo git -C "$SOURCE_DIR" fetch --depth 1 origin "$REF"
+  run_sudo git -C "$SOURCE_DIR" checkout "$REF"
+  run_sudo git -C "$SOURCE_DIR" reset --hard "origin/$REF"
+fi
+
+log "building release binary"
+(
+  cd "$SRC_DIR"
+  cargo build --release --locked
+)
+
+BIN_SRC="$SRC_DIR/target/release/constitute-nvr"
+if [[ ! -x "$BIN_SRC" ]]; then
+  echo "build succeeded but binary not found at $BIN_SRC" >&2
+  exit 1
+fi
+
+log "installing binary to ${INSTALL_PREFIX}"
+run_sudo install -d "$INSTALL_PREFIX/bin"
+run_sudo install -m 0755 "$BIN_SRC" "$INSTALL_PREFIX/bin/constitute-nvr"
+run_sudo ln -sf "$INSTALL_PREFIX/bin/constitute-nvr" "$BIN_LINK"
+
+log "installing self-update helper"
+run_sudo install -m 0755 "$SRC_DIR/scripts/linux/self-update.sh" "$SELF_UPDATE_BIN"
+
+if ! id -u "$SERVICE_USER" >/dev/null 2>&1; then
+  log "creating service user: $SERVICE_USER"
+  run_sudo useradd --system --no-create-home --home-dir "$INSTALL_PREFIX" --shell "$NOLOGIN_PATH" "$SERVICE_USER"
+fi
+
+run_sudo install -d -o "$SERVICE_USER" -g "$SERVICE_USER" /var/lib/constitute-nvr
+run_sudo install -d /etc/constitute-nvr
+run_sudo install -d "$STORAGE_ROOT"
+run_sudo chown "$SERVICE_USER":"$SERVICE_USER" "$STORAGE_ROOT"
+
+if [[ ! -f /etc/constitute-nvr/config.json && -f "$SRC_DIR/config.example.json" ]]; then
+  log "installing config template to /etc/constitute-nvr/config.json"
+  run_sudo install -m 0644 "$SRC_DIR/config.example.json" /etc/constitute-nvr/config.json
+fi
+
+log "patching config defaults"
+run_sudo python3 - <<PY
+import json
+from pathlib import Path
+
+path = Path('/etc/constitute-nvr/config.json')
+raw = json.loads(path.read_text(encoding='utf-8'))
+raw.setdefault('storage', {})['root'] = '${STORAGE_ROOT}'
+raw.setdefault('update', {})['enabled'] = True
+raw['update']['interval_secs'] = int('${UPDATE_INTERVAL_SECS}')
+raw['update']['source_dir'] = '${SOURCE_DIR}'
+raw['update']['branch'] = '${REF}'
+raw['update']['script_path'] = '${SELF_UPDATE_BIN}'
+path.write_text(json.dumps(raw, indent=2) + '\n', encoding='utf-8')
+PY
+
+UNIT_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
+log "writing systemd unit: ${UNIT_PATH}"
+cat <<EOF | run_sudo tee "$UNIT_PATH" >/dev/null
+[Unit]
+Description=Constitute NVR Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=${SERVICE_USER}
+Group=${SERVICE_USER}
+WorkingDirectory=/var/lib/constitute-nvr
+ExecStart=${BIN_LINK}
+Restart=always
+RestartSec=2
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=full
+ProtectHome=true
+ReadWritePaths=/var/lib/constitute-nvr /etc/constitute-nvr ${STORAGE_ROOT}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+UPD_SERVICE="/etc/systemd/system/${SERVICE_NAME}-update.service"
+UPD_TIMER="/etc/systemd/system/${SERVICE_NAME}-update.timer"
+
+cat <<EOF | run_sudo tee "$UPD_SERVICE" >/dev/null
+[Unit]
+Description=Constitute NVR Self Update
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=${SELF_UPDATE_BIN} --source-dir ${SOURCE_DIR} --branch ${REF} --service-name ${SERVICE_NAME} --try-restart
+EOF
+
+cat <<EOF | run_sudo tee "$UPD_TIMER" >/dev/null
+[Unit]
+Description=Constitute NVR Self Update Timer
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=${UPDATE_INTERVAL_SECS}s
+Unit=${SERVICE_NAME}-update.service
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+run_sudo systemctl daemon-reload
+run_sudo systemctl enable --now "$SERVICE_NAME"
+run_sudo systemctl enable --now "${SERVICE_NAME}-update.timer"
+
+if [[ "$APPLY_HARDENING" -eq 1 ]]; then
+  log "applying camera hardening"
+  harden_args=(
+    --apply
+    --iface "$CAMERA_IFACE"
+    --camera-cidr "$CAMERA_CIDR"
+    --onvif-ports "$ONVIF_PORTS"
+    --rtsp-ports "$RTSP_PORTS"
+  )
+  if [[ "$ALLOW_NTP_HOST" -eq 0 ]]; then
+    harden_args+=(--no-ntp-host)
+  fi
+  run_sudo bash "$SRC_DIR/scripts/linux/harden-camera-interface.sh" "${harden_args[@]}"
+fi
+
+log "installation complete"
+run_sudo systemctl --no-pager --full status "$SERVICE_NAME" | sed -n '1,20p' || true
+run_sudo systemctl --no-pager --full status "${SERVICE_NAME}-update.timer" | sed -n '1,20p' || true
+cat <<'EOF'
+
+Manual test quick checks:
+1) systemctl status constitute-nvr
+2) journalctl -u constitute-nvr -n 100 --no-pager
+3) systemctl list-timers | grep constitute-nvr-update
+4) curl -s http://127.0.0.1:8456/health
+EOF

--- a/scripts/linux/self-update.sh
+++ b/scripts/linux/self-update.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/Aux0x7F/constitute-nvr.git}"
+SOURCE_DIR="${SOURCE_DIR:-/opt/constitute-nvr-src}"
+BRANCH="${BRANCH:-main}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/opt/constitute-nvr}"
+SERVICE_NAME="${SERVICE_NAME:-constitute-nvr}"
+TRY_RESTART=0
+FORCE=0
+
+usage() {
+  cat <<'EOF'
+Usage: self-update.sh [options]
+
+Update constitute-nvr from git source, rebuild, and install binary.
+
+Options:
+  --repo-url <url>           Git repo URL (default: Aux0x7F/constitute-nvr)
+  --source-dir <path>        Local source clone path
+  --branch <name>            Git branch to track (default: main)
+  --install-prefix <path>    Install prefix (default: /opt/constitute-nvr)
+  --service-name <name>      systemd service to restart (default: constitute-nvr)
+  --try-restart              Restart service when binary changed
+  --force                    Rebuild/install even if commit unchanged
+  -h, --help                 Show help
+EOF
+}
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-url)
+      REPO_URL="${2:?missing value for --repo-url}"
+      shift 2
+      ;;
+    --source-dir)
+      SOURCE_DIR="${2:?missing value for --source-dir}"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="${2:?missing value for --branch}"
+      shift 2
+      ;;
+    --install-prefix)
+      INSTALL_PREFIX="${2:?missing value for --install-prefix}"
+      shift 2
+      ;;
+    --service-name)
+      SERVICE_NAME="${2:?missing value for --service-name}"
+      shift 2
+      ;;
+    --try-restart)
+      TRY_RESTART=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required" >&2
+  exit 1
+fi
+if ! command -v cargo >/dev/null 2>&1; then
+  echo "cargo is required" >&2
+  exit 1
+fi
+
+if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+  run_sudo mkdir -p "$(dirname "$SOURCE_DIR")"
+  run_sudo git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$SOURCE_DIR"
+fi
+
+run_sudo git -C "$SOURCE_DIR" fetch --depth 1 origin "$BRANCH"
+local_rev="$(git -C "$SOURCE_DIR" rev-parse HEAD)"
+remote_rev="$(git -C "$SOURCE_DIR" rev-parse "origin/$BRANCH")"
+
+if [[ "$FORCE" -ne 1 && "$local_rev" == "$remote_rev" ]]; then
+  echo "[self-update] no new commit on $BRANCH ($local_rev)"
+  exit 0
+fi
+
+run_sudo git -C "$SOURCE_DIR" checkout "$BRANCH"
+run_sudo git -C "$SOURCE_DIR" reset --hard "origin/$BRANCH"
+
+echo "[self-update] building $remote_rev"
+run_sudo bash -lc "cd '$SOURCE_DIR' && cargo build --release --locked"
+
+BIN_SRC="$SOURCE_DIR/target/release/constitute-nvr"
+if [[ ! -f "$BIN_SRC" ]]; then
+  echo "build succeeded but binary missing: $BIN_SRC" >&2
+  exit 1
+fi
+
+run_sudo install -d "$INSTALL_PREFIX/bin"
+run_sudo install -m 0755 "$BIN_SRC" "$INSTALL_PREFIX/bin/constitute-nvr"
+run_sudo ln -sf "$INSTALL_PREFIX/bin/constitute-nvr" /usr/local/bin/constitute-nvr
+
+echo "[self-update] installed $remote_rev"
+if [[ "$TRY_RESTART" -eq 1 ]]; then
+  run_sudo systemctl restart "$SERVICE_NAME" || true
+fi

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,0 +1,405 @@
+use crate::camera;
+use crate::config::Config;
+use crate::crypto;
+use crate::storage::StorageManager;
+use crate::util;
+use anyhow::{Result, anyhow};
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{State, WebSocketUpgrade};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use axum::{Json, Router};
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use tokio::net::TcpListener;
+use tracing::{debug, info, warn};
+
+#[derive(Clone)]
+pub struct ApiState {
+    pub cfg: Config,
+    pub storage: StorageManager,
+}
+
+pub async fn run(cfg: Config, storage: StorageManager) -> Result<()> {
+    let bind = cfg.api.bind.clone();
+    let state = Arc::new(ApiState { cfg, storage });
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/session", get(ws_session))
+        .with_state(state);
+
+    let listener = TcpListener::bind(&bind).await?;
+    info!(bind = %bind, "api listener ready");
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn health(State(state): State<Arc<ApiState>>) -> Json<Value> {
+    let sources = state.storage.list_sources().await.unwrap_or_default();
+    Json(json!({
+        "ok": true,
+        "service": "nvr",
+        "version": state.cfg.service_version,
+        "nodeRole": state.cfg.node_role,
+        "identityId": state.cfg.api.identity_id,
+        "sources": sources,
+    }))
+}
+
+async fn ws_session(ws: WebSocketUpgrade, State(state): State<Arc<ApiState>>) -> impl IntoResponse {
+    ws.on_upgrade(move |socket| handle_ws(socket, state))
+}
+
+#[derive(Debug, Deserialize)]
+struct HelloReq {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(rename = "identityId")]
+    identity_id: String,
+    #[serde(rename = "devicePk")]
+    device_pk: String,
+    #[serde(rename = "clientKey")]
+    client_key: String,
+    ts: u64,
+    proof: String,
+}
+
+#[derive(Debug, Serialize)]
+struct HelloAck {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    #[serde(rename = "sessionId")]
+    session_id: String,
+    #[serde(rename = "serverKey")]
+    server_key: String,
+    ts: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct CipherEnvelope {
+    #[serde(rename = "type")]
+    kind: String,
+    nonce: String,
+    data: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "cmd", rename_all = "snake_case")]
+enum ClientCommand {
+    ListSources,
+    DiscoverOnvif,
+    ListSegments {
+        #[serde(rename = "sourceId")]
+        source_id: String,
+        limit: Option<usize>,
+    },
+    GetSegment {
+        #[serde(rename = "sourceId")]
+        source_id: String,
+        name: String,
+    },
+}
+
+async fn handle_ws(mut socket: WebSocket, state: Arc<ApiState>) {
+    let hello_msg = match socket.next().await {
+        Some(Ok(Message::Text(text))) => text,
+        _ => {
+            let _ = socket.close().await;
+            return;
+        }
+    };
+
+    let hello: HelloReq = match serde_json::from_str(&hello_msg) {
+        Ok(v) => v,
+        Err(_) => {
+            let _ = socket
+                .send(Message::Text(error_json("invalid hello payload").into()))
+                .await;
+            let _ = socket.close().await;
+            return;
+        }
+    };
+
+    if hello.kind != "hello" {
+        let _ = socket
+            .send(Message::Text(error_json("expected hello frame").into()))
+            .await;
+        let _ = socket.close().await;
+        return;
+    }
+
+    if let Err(err) = validate_hello(&state.cfg, &hello) {
+        let _ = socket
+            .send(Message::Text(error_json(&err.to_string()).into()))
+            .await;
+        let _ = socket.close().await;
+        return;
+    }
+
+    let session_id = uuid::Uuid::new_v4().to_string();
+    let context = format!(
+        "constitute-nvr:{}:{}",
+        state.cfg.api.identity_id, session_id
+    );
+
+    let (session_key, server_key) = match crypto::derive_session_key(
+        &state.cfg.api.server_secret_hex,
+        &state.cfg.api.identity_secret_hex,
+        &hello.client_key,
+        &context,
+    ) {
+        Ok(v) => v,
+        Err(err) => {
+            let _ = socket
+                .send(Message::Text(
+                    error_json(&format!("key derivation failed: {}", err)).into(),
+                ))
+                .await;
+            let _ = socket.close().await;
+            return;
+        }
+    };
+
+    let ack = HelloAck {
+        kind: "hello_ack",
+        session_id: session_id.clone(),
+        server_key,
+        ts: util::now_ms(),
+    };
+    let _ = socket
+        .send(Message::Text(
+            serde_json::to_string(&ack)
+                .unwrap_or_else(|_| "{}".to_string())
+                .into(),
+        ))
+        .await;
+
+    debug!(session_id = %session_id, device = %hello.device_pk, "session established");
+
+    while let Some(frame) = socket.next().await {
+        let text = match frame {
+            Ok(Message::Text(t)) => t,
+            Ok(Message::Close(_)) => break,
+            Ok(_) => continue,
+            Err(_) => break,
+        };
+
+        let env: CipherEnvelope = match serde_json::from_str(&text) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ =
+                    send_cipher_error(&mut socket, &session_key, "invalid cipher envelope").await;
+                continue;
+            }
+        };
+
+        if env.kind != "cipher" {
+            let _ = send_cipher_error(&mut socket, &session_key, "expected cipher envelope").await;
+            continue;
+        }
+
+        let nonce_bytes = match base64::engine::general_purpose::STANDARD.decode(&env.nonce) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ =
+                    send_cipher_error(&mut socket, &session_key, "invalid nonce encoding").await;
+                continue;
+            }
+        };
+
+        let nonce: [u8; 24] = match nonce_bytes.try_into() {
+            Ok(v) => v,
+            Err(_) => {
+                let _ = send_cipher_error(&mut socket, &session_key, "invalid nonce length").await;
+                continue;
+            }
+        };
+
+        let cipher = match base64::engine::general_purpose::STANDARD.decode(&env.data) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ = send_cipher_error(&mut socket, &session_key, "invalid cipher data").await;
+                continue;
+            }
+        };
+
+        let plain = match crypto::decrypt_payload(&session_key, &nonce, &cipher) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ = send_cipher_error(&mut socket, &session_key, "decrypt failed").await;
+                continue;
+            }
+        };
+
+        let cmd: ClientCommand = match serde_json::from_slice(&plain) {
+            Ok(v) => v,
+            Err(_) => {
+                let _ =
+                    send_cipher_error(&mut socket, &session_key, "invalid command payload").await;
+                continue;
+            }
+        };
+
+        if let Err(err) = handle_command(cmd, &mut socket, &session_key, &state).await {
+            warn!(session_id = %session_id, error = %err, "command handling failed");
+            let _ = send_cipher_error(&mut socket, &session_key, &err.to_string()).await;
+        }
+    }
+}
+
+fn validate_hello(cfg: &Config, hello: &HelloReq) -> Result<()> {
+    if hello.identity_id != cfg.api.identity_id {
+        return Err(anyhow!("identity mismatch"));
+    }
+
+    if !cfg.api.authorized_device_pks.is_empty()
+        && !cfg
+            .api
+            .authorized_device_pks
+            .iter()
+            .any(|pk| pk == &hello.device_pk)
+    {
+        return Err(anyhow!("device is not authorized for this identity"));
+    }
+
+    let now = util::now_unix_seconds();
+    let ts = hello.ts;
+    let skew = now.abs_diff(ts);
+    if skew > 300 {
+        return Err(anyhow!("hello timestamp outside allowed skew"));
+    }
+
+    let proof_ok = crypto::verify_hello_proof(
+        &cfg.api.identity_secret_hex,
+        &hello.identity_id,
+        &hello.device_pk,
+        &hello.client_key,
+        hello.ts,
+        &hello.proof,
+    )?;
+
+    if !proof_ok {
+        return Err(anyhow!("invalid hello proof"));
+    }
+
+    Ok(())
+}
+
+async fn handle_command(
+    cmd: ClientCommand,
+    socket: &mut WebSocket,
+    key: &[u8],
+    state: &ApiState,
+) -> Result<()> {
+    match cmd {
+        ClientCommand::ListSources => {
+            let sources = state.storage.list_sources().await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "list_sources",
+                    "sources": sources,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::DiscoverOnvif => {
+            let found = camera::discover_onvif(3).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "discover_onvif",
+                    "cameras": found,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::ListSegments { source_id, limit } => {
+            let segments = state
+                .storage
+                .list_segments(&source_id, limit.unwrap_or(30))
+                .await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "list_segments",
+                    "sourceId": source_id,
+                    "segments": segments,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::GetSegment { source_id, name } => {
+            let data = state.storage.read_segment(&source_id, &name).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "segment_start",
+                    "sourceId": source_id,
+                    "name": name,
+                    "bytes": data.len(),
+                }),
+            )
+            .await?;
+
+            for (idx, chunk) in data.chunks(48 * 1024).enumerate() {
+                send_cipher_json(
+                    socket,
+                    key,
+                    &json!({
+                        "ok": true,
+                        "cmd": "segment_chunk",
+                        "seq": idx,
+                        "data": base64::engine::general_purpose::STANDARD.encode(chunk),
+                    }),
+                )
+                .await?;
+            }
+
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "segment_end",
+                    "name": name,
+                }),
+            )
+            .await?;
+        }
+    }
+    Ok(())
+}
+
+async fn send_cipher_error(socket: &mut WebSocket, key: &[u8], message: &str) -> Result<()> {
+    send_cipher_json(socket, key, &json!({"ok": false, "error": message})).await
+}
+
+async fn send_cipher_json(socket: &mut WebSocket, key: &[u8], value: &Value) -> Result<()> {
+    let plain = serde_json::to_vec(value)?;
+    let nonce = crypto::random_nonce_24();
+    let cipher = crypto::encrypt_payload(key, &nonce, &plain)?;
+    let frame = json!({
+        "type": "cipher",
+        "nonce": base64::engine::general_purpose::STANDARD.encode(nonce),
+        "data": base64::engine::general_purpose::STANDARD.encode(cipher),
+    });
+    socket.send(Message::Text(frame.to_string().into())).await?;
+    Ok(())
+}
+
+fn error_json(message: &str) -> String {
+    json!({"ok": false, "error": message}).to_string()
+}

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,0 +1,199 @@
+use crate::config::{CameraConfig, Config};
+use anyhow::{Result, anyhow};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tokio::net::UdpSocket;
+use tokio::process::Command;
+use tokio::sync::Mutex;
+use tokio::time::{Duration, sleep, timeout};
+use tracing::{info, warn};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DiscoveredCamera {
+    pub endpoint: String,
+    pub from: String,
+}
+
+#[derive(Clone)]
+pub struct RecorderManager {
+    inner: Arc<Mutex<HashMap<String, tokio::task::JoinHandle<()>>>>,
+}
+
+impl RecorderManager {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub async fn ensure_started(&self, cfg: &Config) {
+        for cam in &cfg.cameras {
+            if !cam.enabled {
+                continue;
+            }
+            self.start_camera(cfg, cam).await;
+        }
+    }
+
+    async fn start_camera(&self, cfg: &Config, cam: &CameraConfig) {
+        let mut guard = self.inner.lock().await;
+        if guard.contains_key(&cam.source_id) {
+            return;
+        }
+
+        let source_id = cam.source_id.clone();
+        let camera = cam.clone();
+        let storage_root = cfg.storage_root();
+
+        let handle = tokio::spawn(async move {
+            if let Err(err) = record_loop(storage_root, camera).await {
+                warn!(error = %err, source = %source_id, "camera recorder exited");
+            }
+        });
+
+        guard.insert(cam.source_id.clone(), handle);
+    }
+}
+
+async fn record_loop(storage_root: PathBuf, cam: CameraConfig) -> Result<()> {
+    let out_dir = storage_root.join("segments").join(sanitize(&cam.source_id));
+    tokio::fs::create_dir_all(&out_dir).await?;
+
+    let output_pattern = out_dir.join("%Y%m%dT%H%M%S.mp4");
+
+    loop {
+        let mut cmd = Command::new("ffmpeg");
+        cmd.arg("-hide_banner")
+            .arg("-loglevel")
+            .arg("warning")
+            .arg("-rtsp_transport")
+            .arg("tcp")
+            .arg("-i")
+            .arg(&cam.rtsp_url)
+            .arg("-c")
+            .arg("copy")
+            .arg("-f")
+            .arg("segment")
+            .arg("-segment_time")
+            .arg(cam.segment_secs.to_string())
+            .arg("-reset_timestamps")
+            .arg("1")
+            .arg("-strftime")
+            .arg("1")
+            .arg(output_pattern.to_string_lossy().to_string());
+
+        info!(source = %cam.source_id, rtsp = %cam.rtsp_url, "starting ffmpeg recorder");
+        match cmd.status().await {
+            Ok(status) => {
+                warn!(source = %cam.source_id, code = ?status.code(), "ffmpeg exited; restarting");
+            }
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    return Err(anyhow!("ffmpeg not found in PATH"));
+                }
+                warn!(source = %cam.source_id, error = %err, "failed to launch ffmpeg; retrying");
+            }
+        }
+
+        sleep(Duration::from_secs(3)).await;
+    }
+}
+
+pub async fn discover_onvif(timeout_secs: u64) -> Result<Vec<DiscoveredCamera>> {
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    let probe = build_probe_xml();
+
+    socket
+        .send_to(probe.as_bytes(), "239.255.255.250:3702")
+        .await?;
+
+    let mut seen = HashMap::<String, String>::new();
+    let deadline = Duration::from_secs(timeout_secs.max(1));
+    let mut buf = vec![0u8; 16 * 1024];
+
+    while let Ok(recv) = timeout(deadline, socket.recv_from(&mut buf)).await {
+        match recv {
+            Ok((len, from)) => {
+                let payload = String::from_utf8_lossy(&buf[..len]);
+                for xaddr in extract_xaddrs(&payload) {
+                    seen.entry(xaddr).or_insert_with(|| from.to_string());
+                }
+            }
+            Err(_) => break,
+        }
+    }
+
+    let out = seen
+        .into_iter()
+        .map(|(endpoint, from)| DiscoveredCamera { endpoint, from })
+        .collect::<Vec<_>>();
+
+    Ok(out)
+}
+
+fn build_probe_xml() -> String {
+    format!(
+        r#"<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<e:Envelope xmlns:e=\"http://www.w3.org/2003/05/soap-envelope\"
+            xmlns:w=\"http://schemas.xmlsoap.org/ws/2004/08/addressing\"
+            xmlns:d=\"http://schemas.xmlsoap.org/ws/2005/04/discovery\"
+            xmlns:dn=\"http://www.onvif.org/ver10/network/wsdl\">
+  <e:Header>
+    <w:MessageID>uuid:{}</w:MessageID>
+    <w:To>urn:schemas-xmlsoap-org:ws:2005:04:discovery</w:To>
+    <w:Action>http://schemas.xmlsoap.org/ws/2005/04/discovery/Probe</w:Action>
+  </e:Header>
+  <e:Body>
+    <d:Probe>
+      <d:Types>dn:NetworkVideoTransmitter</d:Types>
+    </d:Probe>
+  </e:Body>
+</e:Envelope>"#,
+        uuid::Uuid::new_v4()
+    )
+}
+
+fn extract_xaddrs(xml: &str) -> Vec<String> {
+    let re = Regex::new(r"<[^>]*XAddrs[^>]*>([^<]+)</[^>]*XAddrs>").expect("regex");
+    let mut out = Vec::new();
+    for cap in re.captures_iter(xml) {
+        if let Some(m) = cap.get(1) {
+            for entry in m.as_str().split_whitespace() {
+                if entry.starts_with("http://") || entry.starts_with("https://") {
+                    out.push(entry.to_string());
+                }
+            }
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn sanitize(value: &str) -> String {
+    value
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_xaddr() {
+        let xml = "<XAddrs>http://10.0.0.2/onvif/device_service https://10.0.0.2/ws</XAddrs>";
+        let out = extract_xaddrs(xml);
+        assert_eq!(out.len(), 2);
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,316 @@
+use crate::nostr;
+use anyhow::{Context, Result};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use x25519_dalek::StaticSecret;
+
+pub const DEFAULT_STORAGE_PLACEHOLDER: &str = "/mnt/REPLACE_WITH_STORAGE_MOUNT/constitute-nvr";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ZoneConfig {
+    pub key: String,
+    pub name: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SwarmConfig {
+    pub bind: String,
+    #[serde(default)]
+    pub peers: Vec<String>,
+    #[serde(default = "default_announce_interval_secs")]
+    pub announce_interval_secs: u64,
+    #[serde(default)]
+    pub zones: Vec<ZoneConfig>,
+    #[serde(default)]
+    pub endpoint_hint: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ApiConfig {
+    pub bind: String,
+    pub identity_id: String,
+    #[serde(default)]
+    pub authorized_device_pks: Vec<String>,
+    pub identity_secret_hex: String,
+    pub server_secret_hex: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct StorageConfig {
+    pub root: String,
+    pub encryption_key_hex: String,
+    #[serde(default = "default_segment_encrypt_interval_secs")]
+    pub encrypt_interval_secs: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct UpdateConfig {
+    #[serde(default = "default_update_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_update_interval_secs")]
+    pub interval_secs: u64,
+    #[serde(default = "default_update_source_dir")]
+    pub source_dir: String,
+    #[serde(default = "default_update_branch")]
+    pub branch: String,
+    #[serde(default = "default_update_script")]
+    pub script_path: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CameraConfig {
+    pub source_id: String,
+    pub name: String,
+    pub onvif_host: String,
+    #[serde(default = "default_onvif_port")]
+    pub onvif_port: u16,
+    pub rtsp_url: String,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default = "default_camera_enabled")]
+    pub enabled: bool,
+    #[serde(default = "default_segment_secs")]
+    pub segment_secs: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Config {
+    pub node_id: String,
+    #[serde(default = "default_node_role")]
+    pub node_role: String,
+    #[serde(default = "default_device_label")]
+    pub device_label: String,
+    pub service_version: String,
+    pub nostr_pubkey: String,
+    pub nostr_sk_hex: String,
+    pub swarm: SwarmConfig,
+    pub api: ApiConfig,
+    pub storage: StorageConfig,
+    pub update: UpdateConfig,
+    #[serde(default)]
+    pub cameras: Vec<CameraConfig>,
+}
+
+impl Config {
+    pub fn load_or_create(path: &Path) -> Result<(Self, bool)> {
+        if path.exists() {
+            let raw = fs::read_to_string(path)
+                .with_context(|| format!("failed reading config: {}", path.display()))?;
+            let mut cfg: Self = serde_json::from_str(&raw).context("failed parsing config.json")?;
+            let changed = cfg.apply_defaults();
+            if changed {
+                cfg.persist(path)?;
+            }
+            Ok((cfg, false))
+        } else {
+            let mut cfg = Self::default_generated();
+            cfg.apply_defaults();
+            cfg.persist(path)?;
+            Ok((cfg, true))
+        }
+    }
+
+    pub fn persist(&self, path: &Path) -> Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed creating config dir: {}", parent.display()))?;
+        }
+        let content = serde_json::to_string_pretty(self).context("failed serializing config")?;
+        fs::write(path, content)
+            .with_context(|| format!("failed writing config: {}", path.display()))?;
+        Ok(())
+    }
+
+    pub fn apply_defaults(&mut self) -> bool {
+        let mut changed = false;
+
+        if self.node_id.trim().is_empty() {
+            self.node_id = format!("nvr-{}", short_hex(4));
+            changed = true;
+        }
+
+        if self.node_role.trim().is_empty() {
+            self.node_role = default_node_role();
+            changed = true;
+        }
+
+        if self.device_label.trim().is_empty() {
+            self.device_label = default_device_label();
+            changed = true;
+        }
+
+        if self.nostr_sk_hex.trim().is_empty() {
+            let (pk, sk) = nostr::generate_keypair();
+            self.nostr_pubkey = pk;
+            self.nostr_sk_hex = sk;
+            changed = true;
+        } else if self.nostr_pubkey.trim().is_empty() {
+            if let Ok(pk) = nostr::pubkey_from_sk_hex(&self.nostr_sk_hex) {
+                self.nostr_pubkey = pk;
+                changed = true;
+            }
+        }
+
+        if self.storage.encryption_key_hex.trim().is_empty() {
+            self.storage.encryption_key_hex = random_hex(32);
+            changed = true;
+        }
+
+        if self.storage.root.trim().is_empty() {
+            self.storage.root = DEFAULT_STORAGE_PLACEHOLDER.to_string();
+            changed = true;
+        }
+
+        if self.api.identity_secret_hex.trim().is_empty() {
+            self.api.identity_secret_hex = random_hex(32);
+            changed = true;
+        }
+
+        if self.api.server_secret_hex.trim().is_empty() {
+            let mut bytes = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut bytes);
+            let _ = StaticSecret::from(bytes);
+            self.api.server_secret_hex = hex::encode(bytes);
+            changed = true;
+        }
+
+        if self.swarm.zones.is_empty() {
+            self.swarm.zones.push(ZoneConfig {
+                key: short_hex(10),
+                name: "Default Zone".to_string(),
+            });
+            changed = true;
+        }
+
+        changed
+    }
+
+    pub fn storage_root(&self) -> PathBuf {
+        PathBuf::from(self.storage.root.clone())
+    }
+
+    fn default_generated() -> Self {
+        let (pk, sk) = nostr::generate_keypair();
+        Self {
+            node_id: format!("nvr-{}", short_hex(4)),
+            node_role: default_node_role(),
+            device_label: default_device_label(),
+            service_version: env!("CARGO_PKG_VERSION").to_string(),
+            nostr_pubkey: pk,
+            nostr_sk_hex: sk,
+            swarm: SwarmConfig {
+                bind: "0.0.0.0:4050".to_string(),
+                peers: Vec::new(),
+                announce_interval_secs: default_announce_interval_secs(),
+                zones: vec![ZoneConfig {
+                    key: short_hex(10),
+                    name: "Default Zone".to_string(),
+                }],
+                endpoint_hint: String::new(),
+            },
+            api: ApiConfig {
+                bind: "0.0.0.0:8456".to_string(),
+                identity_id: "REPLACE_WITH_IDENTITY_ID".to_string(),
+                authorized_device_pks: Vec::new(),
+                identity_secret_hex: random_hex(32),
+                server_secret_hex: random_hex(32),
+            },
+            storage: StorageConfig {
+                root: DEFAULT_STORAGE_PLACEHOLDER.to_string(),
+                encryption_key_hex: random_hex(32),
+                encrypt_interval_secs: default_segment_encrypt_interval_secs(),
+            },
+            update: UpdateConfig {
+                enabled: default_update_enabled(),
+                interval_secs: default_update_interval_secs(),
+                source_dir: default_update_source_dir(),
+                branch: default_update_branch(),
+                script_path: default_update_script(),
+            },
+            cameras: Vec::new(),
+        }
+    }
+}
+
+fn default_node_role() -> String {
+    "native".to_string()
+}
+
+fn default_device_label() -> String {
+    "Constitute NVR".to_string()
+}
+
+fn default_announce_interval_secs() -> u64 {
+    20
+}
+
+fn default_segment_encrypt_interval_secs() -> u64 {
+    5
+}
+
+fn default_camera_enabled() -> bool {
+    true
+}
+
+fn default_segment_secs() -> u64 {
+    10
+}
+
+fn default_onvif_port() -> u16 {
+    80
+}
+
+fn default_update_enabled() -> bool {
+    true
+}
+
+fn default_update_interval_secs() -> u64 {
+    300
+}
+
+fn default_update_source_dir() -> String {
+    "/opt/constitute-nvr-src".to_string()
+}
+
+fn default_update_branch() -> String {
+    "main".to_string()
+}
+
+fn default_update_script() -> String {
+    "/usr/local/bin/constitute-nvr-self-update".to_string()
+}
+
+fn random_hex(len: usize) -> String {
+    let mut bytes = vec![0u8; len];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+fn short_hex(len: usize) -> String {
+    random_hex(len).chars().take(len * 2).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_expected_role() {
+        let cfg = Config::default_generated();
+        assert_eq!(cfg.node_role, "native");
+        assert!(!cfg.nostr_pubkey.is_empty());
+        assert!(!cfg.nostr_sk_hex.is_empty());
+    }
+
+    #[test]
+    fn apply_defaults_populates_keys() {
+        let mut cfg = Config::default_generated();
+        cfg.nostr_pubkey.clear();
+        cfg.apply_defaults();
+        assert!(!cfg.nostr_pubkey.is_empty());
+    }
+}

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,0 +1,152 @@
+use anyhow::{Result, anyhow};
+use base64::Engine;
+use chacha20poly1305::aead::{Aead, KeyInit};
+use chacha20poly1305::{Key, XChaCha20Poly1305, XNonce};
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use sha2::Sha256;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+pub const SESSION_KEY_LEN: usize = 32;
+
+pub fn random_nonce_24() -> [u8; 24] {
+    let mut nonce = [0u8; 24];
+    rand::thread_rng().fill_bytes(&mut nonce);
+    nonce
+}
+
+pub fn compute_hello_proof(
+    identity_secret_hex: &str,
+    identity_id: &str,
+    device_pk: &str,
+    client_key_b64: &str,
+    ts: u64,
+) -> Result<String> {
+    let key = parse_hex_exact(identity_secret_hex, 32)?;
+    let mut mac: Hmac<Sha256> =
+        <Hmac<Sha256> as Mac>::new_from_slice(&key).map_err(|_| anyhow!("hmac key"))?;
+    let material = format!("{}|{}|{}|{}", identity_id, device_pk, client_key_b64, ts);
+    mac.update(material.as_bytes());
+    Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+pub fn verify_hello_proof(
+    identity_secret_hex: &str,
+    identity_id: &str,
+    device_pk: &str,
+    client_key_b64: &str,
+    ts: u64,
+    proof_hex: &str,
+) -> Result<bool> {
+    let expected = compute_hello_proof(
+        identity_secret_hex,
+        identity_id,
+        device_pk,
+        client_key_b64,
+        ts,
+    )?;
+    Ok(expected.eq_ignore_ascii_case(proof_hex))
+}
+
+pub fn derive_session_key(
+    server_secret_hex: &str,
+    identity_secret_hex: &str,
+    client_key_b64: &str,
+    context: &str,
+) -> Result<(Vec<u8>, String)> {
+    let server_secret_bytes = parse_hex_exact(server_secret_hex, 32)?;
+    let identity_secret = parse_hex_exact(identity_secret_hex, 32)?;
+    let client_key = decode_b64_exact(client_key_b64, 32)?;
+
+    let mut ss = [0u8; 32];
+    ss.copy_from_slice(&server_secret_bytes);
+    let server_secret = StaticSecret::from(ss);
+    let server_pub = PublicKey::from(&server_secret);
+
+    let mut cp = [0u8; 32];
+    cp.copy_from_slice(&client_key);
+    let client_pub = PublicKey::from(cp);
+
+    let shared = server_secret.diffie_hellman(&client_pub);
+    let hk = Hkdf::<Sha256>::new(Some(&identity_secret), shared.as_bytes());
+
+    let mut out = [0u8; SESSION_KEY_LEN];
+    hk.expand(context.as_bytes(), &mut out)
+        .map_err(|_| anyhow!("hkdf expand failed"))?;
+
+    let server_pub_b64 = base64::engine::general_purpose::STANDARD.encode(server_pub.as_bytes());
+    Ok((out.to_vec(), server_pub_b64))
+}
+
+pub fn encrypt_payload(session_key: &[u8], nonce: &[u8; 24], plaintext: &[u8]) -> Result<Vec<u8>> {
+    if session_key.len() != SESSION_KEY_LEN {
+        return Err(anyhow!("invalid session key length"));
+    }
+    let key = Key::from_slice(session_key);
+    let cipher = XChaCha20Poly1305::new(key);
+    let nonce = XNonce::from_slice(nonce);
+    cipher
+        .encrypt(nonce, plaintext)
+        .map_err(|_| anyhow!("encrypt failed"))
+}
+
+pub fn decrypt_payload(session_key: &[u8], nonce: &[u8; 24], ciphertext: &[u8]) -> Result<Vec<u8>> {
+    if session_key.len() != SESSION_KEY_LEN {
+        return Err(anyhow!("invalid session key length"));
+    }
+    let key = Key::from_slice(session_key);
+    let cipher = XChaCha20Poly1305::new(key);
+    let nonce = XNonce::from_slice(nonce);
+    cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|_| anyhow!("decrypt failed"))
+}
+
+pub fn parse_hex_exact(hex_in: &str, expected_len: usize) -> Result<Vec<u8>> {
+    let bytes = hex::decode(hex_in.trim()).map_err(|_| anyhow!("invalid hex"))?;
+    if bytes.len() != expected_len {
+        return Err(anyhow!(
+            "expected {} bytes, got {}",
+            expected_len,
+            bytes.len()
+        ));
+    }
+    Ok(bytes)
+}
+
+pub fn decode_b64_exact(b64: &str, expected_len: usize) -> Result<Vec<u8>> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(b64.trim())
+        .map_err(|_| anyhow!("invalid base64"))?;
+    if bytes.len() != expected_len {
+        return Err(anyhow!(
+            "expected {} bytes, got {}",
+            expected_len,
+            bytes.len()
+        ));
+    }
+    Ok(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proof_roundtrip() {
+        let identity_secret = "11".repeat(32);
+        let p = compute_hello_proof(&identity_secret, "id", "dev", "abcd", 10).unwrap();
+        assert!(verify_hello_proof(&identity_secret, "id", "dev", "abcd", 10, &p).unwrap());
+    }
+
+    #[test]
+    fn encrypt_roundtrip() {
+        let key = vec![7u8; 32];
+        let nonce = random_nonce_24();
+        let input = b"hello world";
+        let enc = encrypt_payload(&key, &nonce, input).unwrap();
+        let dec = decrypt_payload(&key, &nonce, &enc).unwrap();
+        assert_eq!(input.to_vec(), dec);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,110 @@
-fn main() {
-    println!("constitute-nvr: scaffold runtime");
-    println!("target: fedora systemd service");
-    println!("ingest baseline: onvif-first");
-    println!("status: not production-ready");
+mod api;
+mod camera;
+mod config;
+mod crypto;
+mod nostr;
+mod storage;
+mod swarm;
+mod update;
+mod util;
+
+use anyhow::Result;
+use clap::Parser;
+use config::Config;
+use std::path::PathBuf;
+use tracing::{info, warn};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "constitute-nvr",
+    version,
+    about = "Constitute NVR service (ONVIF ingest + swarm-native presence)"
+)]
+struct Args {
+    #[arg(long)]
+    config: Option<PathBuf>,
+    #[arg(long, default_value = "info")]
+    log_level: String,
+    #[arg(long)]
+    once: bool,
+    #[arg(long)]
+    discover_onvif: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    init_logging(&args.log_level);
+
+    let cfg_path = args
+        .config
+        .unwrap_or_else(|| PathBuf::from("/etc/constitute-nvr/config.json"));
+    let (cfg, created) = Config::load_or_create(&cfg_path)?;
+
+    if created {
+        warn!(path = %cfg_path.display(), "created new config file; update placeholders before production use");
+    }
+
+    if cfg.storage.root == config::DEFAULT_STORAGE_PLACEHOLDER {
+        warn!(
+            placeholder = %config::DEFAULT_STORAGE_PLACEHOLDER,
+            "storage root is still placeholder; set a dedicated mount path"
+        );
+    }
+
+    let storage =
+        storage::StorageManager::new(cfg.storage_root(), &cfg.storage.encryption_key_hex)?;
+    storage.ensure_dirs().await?;
+    storage.start_encryptor(cfg.storage.encrypt_interval_secs);
+
+    if args.discover_onvif {
+        let discovered = camera::discover_onvif(3).await?;
+        println!("{}", serde_json::to_string_pretty(&discovered)?);
+        return Ok(());
+    }
+
+    let recorder = camera::RecorderManager::new();
+    recorder.ensure_started(&cfg).await;
+
+    let swarm_handle = swarm::start(cfg.clone()).await?;
+
+    if args.once {
+        let sources = storage.list_sources().await.unwrap_or_default();
+        println!("constitute-nvr: startup check complete");
+        println!("node_id: {}", cfg.node_id);
+        println!("role: {}", cfg.node_role);
+        println!("identity_id: {}", cfg.api.identity_id);
+        println!("storage_root: {}", cfg.storage.root);
+        println!("sources: {}", sources.len());
+        println!(
+            "swarm_confirmed_peers: {}",
+            swarm_handle.confirmed_peers().await
+        );
+        return Ok(());
+    }
+
+    update::spawn_update_poller(cfg.clone());
+
+    info!(
+        node_id = %cfg.node_id,
+        role = %cfg.node_role,
+        identity_id = %cfg.api.identity_id,
+        storage = %cfg.storage.root,
+        camera_count = cfg.cameras.len(),
+        "constitute-nvr starting"
+    );
+
+    api::run(cfg, storage).await
+}
+
+fn init_logging(level: &str) {
+    let env = tracing_subscriber::EnvFilter::try_new(level)
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env)
+        .with_target(false)
+        .compact()
+        .init();
 }

--- a/src/nostr.rs
+++ b/src/nostr.rs
@@ -1,0 +1,174 @@
+use anyhow::{Result, anyhow};
+use secp256k1::rand::thread_rng;
+use secp256k1::schnorr::Signature;
+use secp256k1::{Keypair, Message, Secp256k1, SecretKey, XOnlyPublicKey};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NostrEvent {
+    pub id: String,
+    pub pubkey: String,
+    pub created_at: u64,
+    pub kind: u32,
+    pub tags: Vec<Vec<String>>,
+    pub content: String,
+    pub sig: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct NostrUnsignedEvent {
+    pub pubkey: String,
+    pub created_at: u64,
+    pub kind: u32,
+    pub tags: Vec<Vec<String>>,
+    pub content: String,
+}
+
+pub fn generate_keypair() -> (String, String) {
+    let secp = Secp256k1::new();
+    let (sk, _pk) = secp.generate_keypair(&mut thread_rng());
+    let sk_hex = bytes_to_hex(&sk.secret_bytes());
+    let keypair = Keypair::from_secret_key(&secp, &sk);
+    let pk_hex = xonly_pk_hex(&keypair);
+    (pk_hex, sk_hex)
+}
+
+pub fn pubkey_from_sk_hex(sk_hex: &str) -> Result<String> {
+    let sk_bytes = hex_to_bytes(sk_hex)?;
+    let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| anyhow!("invalid nostr sk"))?;
+    let secp = Secp256k1::new();
+    let keypair = Keypair::from_secret_key(&secp, &sk);
+    Ok(xonly_pk_hex(&keypair))
+}
+
+pub fn build_unsigned_event(
+    pubkey: &str,
+    kind: u32,
+    tags: Vec<Vec<String>>,
+    content: String,
+    created_at: u64,
+) -> NostrUnsignedEvent {
+    NostrUnsignedEvent {
+        pubkey: pubkey.to_string(),
+        created_at,
+        kind,
+        tags,
+        content,
+    }
+}
+
+pub fn sign_event(unsigned: &NostrUnsignedEvent, sk_hex: &str) -> Result<NostrEvent> {
+    let id = event_id_hex(unsigned)?;
+    let hash = hex_to_bytes(&id)?;
+    if hash.len() != 32 {
+        return Err(anyhow!("invalid event hash length"));
+    }
+    let msg = Message::from_digest_slice(&hash).map_err(|_| anyhow!("invalid message digest"))?;
+
+    let secp = Secp256k1::new();
+    let sk_bytes = hex_to_bytes(sk_hex)?;
+    let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| anyhow!("invalid nostr sk"))?;
+    let keypair = Keypair::from_secret_key(&secp, &sk);
+    let sig = secp.sign_schnorr_with_rng(&msg, &keypair, &mut thread_rng());
+    let sig_hex = bytes_to_hex(sig.as_ref());
+
+    Ok(NostrEvent {
+        id,
+        pubkey: unsigned.pubkey.clone(),
+        created_at: unsigned.created_at,
+        kind: unsigned.kind,
+        tags: unsigned.tags.clone(),
+        content: unsigned.content.clone(),
+        sig: sig_hex,
+    })
+}
+
+pub fn verify_event(ev: &NostrEvent) -> Result<bool> {
+    let unsigned = NostrUnsignedEvent {
+        pubkey: ev.pubkey.clone(),
+        created_at: ev.created_at,
+        kind: ev.kind,
+        tags: ev.tags.clone(),
+        content: ev.content.clone(),
+    };
+
+    let expected_id = event_id_hex(&unsigned)?;
+    if expected_id != ev.id {
+        return Ok(false);
+    }
+
+    let hash = hex_to_bytes(&ev.id)?;
+    if hash.len() != 32 {
+        return Err(anyhow!("invalid event hash length"));
+    }
+    let msg = Message::from_digest_slice(&hash).map_err(|_| anyhow!("invalid message digest"))?;
+
+    let sig_bytes = hex_to_bytes(&ev.sig)?;
+    let sig = Signature::from_slice(&sig_bytes).map_err(|_| anyhow!("invalid signature"))?;
+
+    let pk_bytes = hex_to_bytes(&ev.pubkey)?;
+    let pk = XOnlyPublicKey::from_slice(&pk_bytes).map_err(|_| anyhow!("invalid pubkey"))?;
+
+    let secp = Secp256k1::new();
+    Ok(secp.verify_schnorr(&sig, &msg, &pk).is_ok())
+}
+
+pub fn event_id_hex(unsigned: &NostrUnsignedEvent) -> Result<String> {
+    let payload = json!([
+        0,
+        unsigned.pubkey,
+        unsigned.created_at,
+        unsigned.kind,
+        unsigned.tags,
+        unsigned.content,
+    ]);
+    let raw = serde_json::to_string(&payload).map_err(|_| anyhow!("event serialize failed"))?;
+    let digest = Sha256::digest(raw.as_bytes());
+    Ok(bytes_to_hex(digest.as_slice()))
+}
+
+fn hex_to_bytes(hex: &str) -> Result<Vec<u8>> {
+    let h = hex.trim();
+    if h.len() % 2 != 0 {
+        return Err(anyhow!("invalid hex"));
+    }
+    let mut out = Vec::with_capacity(h.len() / 2);
+    for i in (0..h.len()).step_by(2) {
+        let b = u8::from_str_radix(&h[i..i + 2], 16).map_err(|_| anyhow!("invalid hex"))?;
+        out.push(b);
+    }
+    Ok(out)
+}
+
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|b| format!("{:02x}", b))
+        .collect::<String>()
+}
+
+fn xonly_pk_hex(keypair: &Keypair) -> String {
+    let (pk, _) = XOnlyPublicKey::from_keypair(keypair);
+    bytes_to_hex(&pk.serialize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sign_and_verify_roundtrip() {
+        let (pk, sk) = generate_keypair();
+        let unsigned = build_unsigned_event(
+            &pk,
+            1,
+            vec![vec!["t".into(), "constitute".into()]],
+            "{}".into(),
+            10,
+        );
+        let ev = sign_event(&unsigned, &sk).expect("sign");
+        assert!(verify_event(&ev).expect("verify"));
+    }
+}

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,208 @@
+use crate::crypto;
+use anyhow::{Context, Result, anyhow};
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::{Duration, interval};
+use tracing::{debug, warn};
+use walkdir::WalkDir;
+
+const MAGIC: &[u8] = b"CNRV1";
+
+#[derive(Clone)]
+pub struct StorageManager {
+    root: PathBuf,
+    key: Vec<u8>,
+    pub last_error: Arc<RwLock<Option<String>>>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SegmentEntry {
+    pub name: String,
+    pub bytes: u64,
+    pub modified_unix: u64,
+}
+
+impl StorageManager {
+    pub fn new(root: PathBuf, key_hex: &str) -> Result<Self> {
+        let key = crypto::parse_hex_exact(key_hex, 32)?;
+        Ok(Self {
+            root,
+            key,
+            last_error: Arc::new(RwLock::new(None)),
+        })
+    }
+
+    pub async fn ensure_dirs(&self) -> Result<()> {
+        tokio::fs::create_dir_all(self.root.join("segments")).await?;
+        Ok(())
+    }
+
+    pub fn start_encryptor(&self, interval_secs: u64) {
+        let this = self.clone();
+        tokio::spawn(async move {
+            let mut tick = interval(Duration::from_secs(interval_secs.max(2)));
+            loop {
+                tick.tick().await;
+                if let Err(err) = this.encrypt_pending_once().await {
+                    warn!(error = %err, "segment encryption pass failed");
+                    *this.last_error.write().await = Some(err.to_string());
+                }
+            }
+        });
+    }
+
+    pub async fn encrypt_pending_once(&self) -> Result<()> {
+        let root = self.root.join("segments");
+        let key = self.key.clone();
+        tokio::task::spawn_blocking(move || encrypt_pass(&root, &key))
+            .await
+            .context("join encrypt pass")??;
+        Ok(())
+    }
+
+    pub async fn list_sources(&self) -> Result<Vec<String>> {
+        let dir = self.root.join("segments");
+        let mut out = Vec::new();
+        let mut rd = tokio::fs::read_dir(&dir)
+            .await
+            .with_context(|| format!("read_dir {}", dir.display()))?;
+        while let Some(entry) = rd.next_entry().await? {
+            if entry.file_type().await?.is_dir() {
+                out.push(entry.file_name().to_string_lossy().to_string());
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
+    pub async fn list_segments(&self, source_id: &str, limit: usize) -> Result<Vec<SegmentEntry>> {
+        let dir = self.root.join("segments").join(source_id);
+        let mut out = Vec::new();
+        let mut rd = match tokio::fs::read_dir(&dir).await {
+            Ok(v) => v,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(err) => return Err(err.into()),
+        };
+
+        while let Some(entry) = rd.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            if !file_type.is_file() {
+                continue;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if !(name.ends_with(".cnv") || name.ends_with(".mp4")) {
+                continue;
+            }
+
+            let md = entry.metadata().await?;
+            let modified = md
+                .modified()
+                .ok()
+                .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|d| d.as_secs())
+                .unwrap_or(0);
+
+            out.push(SegmentEntry {
+                name,
+                bytes: md.len(),
+                modified_unix: modified,
+            });
+        }
+
+        out.sort_by(|a, b| b.modified_unix.cmp(&a.modified_unix));
+        out.truncate(limit.max(1));
+        Ok(out)
+    }
+
+    pub async fn read_segment(&self, source_id: &str, name: &str) -> Result<Vec<u8>> {
+        let path = self.root.join("segments").join(source_id).join(name);
+        let bytes = tokio::fs::read(&path)
+            .await
+            .with_context(|| format!("read segment {}", path.display()))?;
+
+        if name.ends_with(".cnv") {
+            decrypt_blob(&self.key, &bytes)
+        } else {
+            Ok(bytes)
+        }
+    }
+}
+
+fn encrypt_pass(root: &Path, key: &[u8]) -> Result<()> {
+    if !root.exists() {
+        return Ok(());
+    }
+
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        if path.extension().and_then(|s| s.to_str()) != Some("mp4") {
+            continue;
+        }
+
+        let enc_path = path.with_extension("cnv");
+        if enc_path.exists() {
+            continue;
+        }
+
+        let raw = std::fs::read(path)
+            .with_context(|| format!("read plain segment {}", path.display()))?;
+        if raw.is_empty() {
+            continue;
+        }
+
+        let nonce = crypto::random_nonce_24();
+        let cipher = crypto::encrypt_payload(key, &nonce, &raw)?;
+
+        let mut out = Vec::with_capacity(MAGIC.len() + nonce.len() + cipher.len());
+        out.extend_from_slice(MAGIC);
+        out.extend_from_slice(&nonce);
+        out.extend_from_slice(&cipher);
+
+        std::fs::write(&enc_path, out)
+            .with_context(|| format!("write encrypted segment {}", enc_path.display()))?;
+        std::fs::remove_file(path)
+            .with_context(|| format!("remove plain segment {}", path.display()))?;
+        debug!(path = %enc_path.display(), "encrypted segment");
+    }
+
+    Ok(())
+}
+
+fn decrypt_blob(key: &[u8], blob: &[u8]) -> Result<Vec<u8>> {
+    if blob.len() < MAGIC.len() + 24 {
+        return Err(anyhow!("encrypted blob too short"));
+    }
+    if &blob[..MAGIC.len()] != MAGIC {
+        return Err(anyhow!("invalid encrypted blob magic"));
+    }
+    let nonce: [u8; 24] = blob[MAGIC.len()..MAGIC.len() + 24]
+        .try_into()
+        .map_err(|_| anyhow!("nonce decode"))?;
+    let cipher = &blob[MAGIC.len() + 24..];
+    crypto::decrypt_payload(key, &nonce, cipher)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encrypt_decrypt_blob_roundtrip() {
+        let key = vec![42u8; 32];
+        let plain = b"abc123";
+        let nonce = crypto::random_nonce_24();
+        let enc = crypto::encrypt_payload(&key, &nonce, plain).unwrap();
+        let mut blob = Vec::new();
+        blob.extend_from_slice(MAGIC);
+        blob.extend_from_slice(&nonce);
+        blob.extend_from_slice(&enc);
+
+        let dec = decrypt_blob(&key, &blob).unwrap();
+        assert_eq!(dec, plain);
+    }
+}

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -1,0 +1,375 @@
+use crate::config::Config;
+use crate::nostr::{self, NostrEvent};
+use crate::util;
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::net::{UdpSocket, lookup_host};
+use tokio::sync::Mutex;
+use tokio::time::{Duration, Instant, interval};
+use tracing::{debug, info, warn};
+
+const PROTOCOL_VERSION: u8 = 1;
+const RECORD_KIND: u32 = 30078;
+const APP_KIND: u32 = 1;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+enum UdpMessage {
+    Hello {
+        v: u8,
+        node_id: String,
+        device_pk: String,
+        zones: Vec<String>,
+        ts: u64,
+    },
+    Ack {
+        v: u8,
+        node_id: String,
+        device_pk: String,
+        zones: Vec<String>,
+        ts: u64,
+    },
+    Record {
+        v: u8,
+        zone: String,
+        record_type: String,
+        event: NostrEvent,
+        ts: u64,
+    },
+}
+
+#[derive(Clone, Debug)]
+struct PeerState {
+    last_seen: Instant,
+    confirmed: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DeviceRecordPayload {
+    device_pk: String,
+    identity_id: String,
+    device_label: String,
+    updated_at: u64,
+    expires_at: u64,
+    role: String,
+    service: String,
+    service_version: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ZonePresencePayload {
+    #[serde(rename = "type")]
+    kind: String,
+    zone: String,
+    device_pk: String,
+    swarm: String,
+    role: String,
+    service: String,
+    service_version: String,
+    ts: u64,
+    ttl: u64,
+}
+
+#[derive(Clone)]
+pub struct SwarmHandle {
+    peers: Arc<Mutex<HashMap<SocketAddr, PeerState>>>,
+}
+
+impl SwarmHandle {
+    pub async fn confirmed_peers(&self) -> usize {
+        let guard = self.peers.lock().await;
+        guard.values().filter(|p| p.confirmed).count()
+    }
+}
+
+pub async fn start(cfg: Config) -> Result<SwarmHandle> {
+    let bind: SocketAddr = cfg
+        .swarm
+        .bind
+        .parse()
+        .with_context(|| format!("invalid swarm.bind: {}", cfg.swarm.bind))?;
+
+    let socket = Arc::new(UdpSocket::bind(bind).await?);
+    let peers = Arc::new(Mutex::new(resolve_peers(&cfg.swarm.peers).await));
+    let table = Arc::new(Mutex::new(HashMap::<SocketAddr, PeerState>::new()));
+
+    let recv_socket = Arc::clone(&socket);
+    let recv_peers = Arc::clone(&peers);
+    let recv_table = Arc::clone(&table);
+    let recv_cfg = cfg.clone();
+
+    tokio::spawn(async move {
+        if let Err(err) = recv_loop(recv_socket, recv_peers, recv_table, recv_cfg).await {
+            warn!(error = %err, "swarm recv loop exited");
+        }
+    });
+
+    let tx_socket = Arc::clone(&socket);
+    let tx_peers = Arc::clone(&peers);
+    let tx_cfg = cfg.clone();
+
+    tokio::spawn(async move {
+        if let Err(err) = announce_loop(tx_socket, tx_peers, tx_cfg).await {
+            warn!(error = %err, "swarm announce loop exited");
+        }
+    });
+
+    info!(bind = %bind, "swarm udp runtime started");
+
+    Ok(SwarmHandle { peers: table })
+}
+
+async fn resolve_peers(raw: &[String]) -> Vec<SocketAddr> {
+    let mut out = Vec::new();
+    for peer in raw {
+        match lookup_host(peer).await {
+            Ok(addrs) => out.extend(addrs),
+            Err(err) => warn!(peer = %peer, error = %err, "failed resolving swarm peer"),
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    out
+}
+
+async fn announce_loop(
+    socket: Arc<UdpSocket>,
+    peers: Arc<Mutex<Vec<SocketAddr>>>,
+    cfg: Config,
+) -> Result<()> {
+    let mut hello_tick = interval(Duration::from_secs(5));
+    let mut announce_tick = interval(Duration::from_secs(cfg.swarm.announce_interval_secs.max(5)));
+    let zones = cfg
+        .swarm
+        .zones
+        .iter()
+        .map(|z| z.key.clone())
+        .collect::<Vec<_>>();
+
+    loop {
+        tokio::select! {
+            _ = hello_tick.tick() => {
+                let hello = UdpMessage::Hello {
+                    v: PROTOCOL_VERSION,
+                    node_id: cfg.node_id.clone(),
+                    device_pk: cfg.nostr_pubkey.clone(),
+                    zones: zones.clone(),
+                    ts: util::now_ms(),
+                };
+                broadcast_json(&socket, &peers, &hello).await;
+            }
+            _ = announce_tick.tick() => {
+                for zone in &zones {
+                    if let Ok(ev) = build_device_record(&cfg) {
+                        let msg = UdpMessage::Record {
+                            v: PROTOCOL_VERSION,
+                            zone: zone.clone(),
+                            record_type: "device".to_string(),
+                            event: ev,
+                            ts: util::now_ms(),
+                        };
+                        broadcast_json(&socket, &peers, &msg).await;
+                    }
+                    if let Ok(ev) = build_zone_presence(&cfg, zone) {
+                        let msg = UdpMessage::Record {
+                            v: PROTOCOL_VERSION,
+                            zone: zone.clone(),
+                            record_type: "zone_presence".to_string(),
+                            event: ev,
+                            ts: util::now_ms(),
+                        };
+                        broadcast_json(&socket, &peers, &msg).await;
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn recv_loop(
+    socket: Arc<UdpSocket>,
+    peers: Arc<Mutex<Vec<SocketAddr>>>,
+    table: Arc<Mutex<HashMap<SocketAddr, PeerState>>>,
+    cfg: Config,
+) -> Result<()> {
+    let mut buf = vec![0u8; 65_535];
+    loop {
+        let (len, from) = socket.recv_from(&mut buf).await?;
+        let raw = &buf[..len];
+        let msg: UdpMessage = match serde_json::from_slice(raw) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        match msg {
+            UdpMessage::Hello {
+                v,
+                node_id,
+                device_pk,
+                zones,
+                ..
+            } => {
+                if v != PROTOCOL_VERSION {
+                    continue;
+                }
+                {
+                    let mut guard = table.lock().await;
+                    guard.insert(
+                        from,
+                        PeerState {
+                            last_seen: Instant::now(),
+                            confirmed: true,
+                        },
+                    );
+                }
+
+                let ack = UdpMessage::Ack {
+                    v: PROTOCOL_VERSION,
+                    node_id: cfg.node_id.clone(),
+                    device_pk: cfg.nostr_pubkey.clone(),
+                    zones: cfg.swarm.zones.iter().map(|z| z.key.clone()).collect(),
+                    ts: util::now_ms(),
+                };
+                send_json(&socket, from, &ack).await;
+
+                add_peer(peers.clone(), from).await;
+                debug!(from = %from, node_id = %node_id, device_pk = %device_pk, zones = ?zones, "swarm hello received");
+            }
+            UdpMessage::Ack {
+                v,
+                device_pk,
+                zones,
+                ..
+            } => {
+                if v != PROTOCOL_VERSION {
+                    continue;
+                }
+                {
+                    let mut guard = table.lock().await;
+                    guard.insert(
+                        from,
+                        PeerState {
+                            last_seen: Instant::now(),
+                            confirmed: true,
+                        },
+                    );
+                }
+                add_peer(peers.clone(), from).await;
+                debug!(from = %from, device_pk = %device_pk, zones = ?zones, "swarm ack received");
+            }
+            UdpMessage::Record {
+                v,
+                zone,
+                record_type,
+                event,
+                ..
+            } => {
+                if v != PROTOCOL_VERSION {
+                    continue;
+                }
+                match nostr::verify_event(&event) {
+                    Ok(true) => {
+                        debug!(from = %from, zone = %zone, record_type = %record_type, "swarm record received");
+                        let mut guard = table.lock().await;
+                        if let Some(entry) = guard.get_mut(&from) {
+                            entry.last_seen = Instant::now();
+                        }
+                    }
+                    Ok(false) => {
+                        debug!(from = %from, "swarm record rejected: invalid signature");
+                    }
+                    Err(err) => {
+                        debug!(from = %from, error = %err, "swarm record rejected: verify error");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn add_peer(peers: Arc<Mutex<Vec<SocketAddr>>>, addr: SocketAddr) {
+    let mut guard = peers.lock().await;
+    if !guard.contains(&addr) {
+        guard.push(addr);
+    }
+}
+
+async fn broadcast_json(socket: &UdpSocket, peers: &Arc<Mutex<Vec<SocketAddr>>>, msg: &UdpMessage) {
+    let payload = match serde_json::to_vec(msg) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+    let list = peers.lock().await.clone();
+    for peer in list {
+        let _ = socket.send_to(&payload, peer).await;
+    }
+}
+
+async fn send_json(socket: &UdpSocket, to: SocketAddr, msg: &UdpMessage) {
+    if let Ok(payload) = serde_json::to_vec(msg) {
+        let _ = socket.send_to(&payload, to).await;
+    }
+}
+
+fn build_device_record(cfg: &Config) -> Result<NostrEvent> {
+    let now = util::now_ms();
+    let payload = DeviceRecordPayload {
+        device_pk: cfg.nostr_pubkey.clone(),
+        identity_id: cfg.api.identity_id.clone(),
+        device_label: cfg.device_label.clone(),
+        updated_at: now,
+        expires_at: now + 24 * 60 * 60 * 1000,
+        role: cfg.node_role.clone(),
+        service: "nvr".to_string(),
+        service_version: cfg.service_version.clone(),
+    };
+    let content = serde_json::to_string(&payload)?;
+    let tags = vec![
+        vec!["t".to_string(), "swarm_discovery".to_string()],
+        vec!["type".to_string(), "device".to_string()],
+        vec!["role".to_string(), cfg.node_role.clone()],
+        vec!["service".to_string(), "nvr".to_string()],
+    ];
+    let unsigned = nostr::build_unsigned_event(
+        &cfg.nostr_pubkey,
+        RECORD_KIND,
+        tags,
+        content,
+        util::now_unix_seconds(),
+    );
+    nostr::sign_event(&unsigned, &cfg.nostr_sk_hex)
+}
+
+fn build_zone_presence(cfg: &Config, zone: &str) -> Result<NostrEvent> {
+    let payload = ZonePresencePayload {
+        kind: "zone_presence".to_string(),
+        zone: zone.to_string(),
+        device_pk: cfg.nostr_pubkey.clone(),
+        swarm: cfg.swarm.endpoint_hint.clone(),
+        role: cfg.node_role.clone(),
+        service: "nvr".to_string(),
+        service_version: cfg.service_version.clone(),
+        ts: util::now_ms(),
+        ttl: 120,
+    };
+
+    let content = serde_json::to_string(&payload)?;
+    let tags = vec![
+        vec!["t".to_string(), "constitute".to_string()],
+        vec!["z".to_string(), zone.to_string()],
+    ];
+
+    let unsigned = nostr::build_unsigned_event(
+        &cfg.nostr_pubkey,
+        APP_KIND,
+        tags,
+        content,
+        util::now_unix_seconds(),
+    );
+    nostr::sign_event(&unsigned, &cfg.nostr_sk_hex)
+}

--- a/src/update.rs
+++ b/src/update.rs
@@ -1,0 +1,45 @@
+use crate::config::Config;
+use tokio::process::Command;
+use tokio::time::{Duration, interval};
+use tracing::{debug, info, warn};
+
+pub fn spawn_update_poller(cfg: Config) {
+    if !cfg.update.enabled {
+        info!("update poller disabled by config");
+        return;
+    }
+
+    tokio::spawn(async move {
+        let script = cfg.update.script_path.clone();
+        let mut tick = interval(Duration::from_secs(cfg.update.interval_secs.max(60)));
+        info!(
+            interval_secs = cfg.update.interval_secs,
+            script = %script,
+            "update poller started"
+        );
+
+        loop {
+            tick.tick().await;
+            let mut cmd = Command::new(&script);
+            cmd.arg("--source-dir")
+                .arg(&cfg.update.source_dir)
+                .arg("--branch")
+                .arg(&cfg.update.branch)
+                .arg("--service-name")
+                .arg("constitute-nvr")
+                .arg("--try-restart");
+
+            match cmd.status().await {
+                Ok(status) if status.success() => {
+                    debug!("update poll executed successfully");
+                }
+                Ok(status) => {
+                    warn!(code = ?status.code(), "update poll script returned non-zero");
+                }
+                Err(err) => {
+                    warn!(error = %err, script = %script, "update poll failed to launch");
+                }
+            }
+        }
+    });
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,15 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn now_unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}


### PR DESCRIPTION
## Summary\nThis PR delivers a manual-test-ready NVR vertical slice for Constitution: swarm-native service participation, ONVIF/RTSP ingest baseline, encrypted segment storage, identity-bound encrypted session serving, and operator automation for install/hardening/self-update.\n\n## What Changed\n### Runtime and protocol\n- Added native swarm client path over UDP (hello/ck/ecord) with signed records.\n- Publishes ole=native and service=nvr in device/zone presence records.\n- Added ONVIF WS-Discovery probe flow and RTSP recorder loops (ffmpeg-backed).\n- Added encrypted segment conversion pass (.mp4 -> .cnv) for at-rest protection.\n- Added websocket session negotiation with:\n  - identity proof (HMAC)\n  - X25519 key agreement\n  - HKDF-derived symmetric key\n- Added encrypted command channel for:\n  - list_sources\n  - discover_onvif\n  - list_segments\n  - get_segment\n\n### Operator flows\n- Extended install wizard to prompt storage root (default placeholder) and update interval.\n- Added self-update helper script and systemd timer wiring.\n- Kept/updated camera hardening flow for ONVIF/RTSP-only + optional NTP lane.\n\n### Docs and config\n- Updated README.md, ARCHITECTURE.md, docs/PROTOCOL.md, docs/ROADMAP.md, docs/OPERATIONS.md, docs/CAMERA_COMPAT.md.\n- Updated config.example.json to reflect active swarm/api/storage/update/camera fields.\n\n## Validation\n- cargo test (7 passed)\n- cargo run -- --config ./config.json --once\n- cargo run -- --config ./config.json --discover-onvif\n- ash -n scripts/linux/install-wizard.sh scripts/linux/harden-camera-interface.sh scripts/linux/self-update.sh\n\n## Notes\n- This is POC-grade and ready for Fedora/manual camera lab validation.\n- Live-stream relay semantics remain follow-on; this slice is segment-oriented retrieval.\n\nCloses #4\nRelated to #2 and #1