### PR TITLE
feat(nvr): advertise UI module hints + source runtime lifecycle controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Build (Linux)
+        run: cargo build --release
+
+      - name: Package Linux artifact
+        run: bash scripts/linux/package.sh
+
+      - name: Upload Linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: constitute-nvr-linux
+          path: constitute-nvr-linux-amd64.tar.gz
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [linux]
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Collect assets
+        shell: bash
+        run: |
+          mkdir -p out
+          linux_file=$(find dist -type f -name "constitute-nvr-linux-amd64.tar.gz" | head -n 1)
+          if [ -z "$linux_file" ]; then
+            echo "linux tarball not found" >&2
+            exit 1
+          fi
+          cp "$linux_file" out/constitute-nvr-linux-amd64.tar.gz
+
+      - name: Generate checksums
+        shell: bash
+        run: |
+          cd out
+          sha256sum * > SHA256SUMS
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/*

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 Thumbs.db
 .vscode/
 .idea/
+p2pc_mem.txt
+
+# Local reverse-engineering workspace
+/scripts/windows/reolink-sdk-bridge.cjs

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,13 +10,13 @@
 ## Runtime Layers
 1. Swarm Client Layer
 - UDP swarm participation (`role=native`, `service=nvr`)
-- signed device + zone presence records
+- signed device + zone presence records (including UI module references + live metrics)
 - zone-scoped peer announcements, no public Nostr relay requirement for bootstrap in this mode
 
 2. Ingest Layer
 - ONVIF WS-Discovery probe support
-- camera source registry from config
-- RTSP ingest execution via `ffmpeg` segment loop per source
+- camera source registry from config + encrypted control-plane upsert/remove commands
+- RTSP ingest execution via `ffmpeg` segment loop per source with explicit runtime state machine + restart/backoff
 
 3. Secure Storage Layer
 - segment files written under `storage.root/segments/<source_id>/`
@@ -30,7 +30,7 @@
   - client hello + HMAC proof
   - X25519 server/client key agreement
   - HKDF-derived symmetric session key
-- encrypted command channel for source listing, discovery, segment listing, segment retrieval
+- encrypted command channel for source lifecycle, source state, discovery, segment listing, segment retrieval
 
 5. Update/Operations Layer
 - systemd service runtime (`constitute-nvr.service`)
@@ -55,3 +55,4 @@
 2. finalize identity-device authorization semantics with web contract
 3. add integration tests with gateway/web swarm records
 4. promote update flow from source-build to signed release artifacts
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb-mode"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "738b8d467867f80a71351933f70461f5b56f24d5c93e0cf216e59229c968d330"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,15 +298,18 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "constitute-nvr"
 version = "0.1.0"
 dependencies = [
+ "aes",
  "anyhow",
  "axum",
  "base64",
+ "cfb-mode",
  "chacha20poly1305",
  "clap",
  "futures-util",
  "hex",
  "hkdf",
  "hmac",
+ "md-5",
  "rand 0.8.5",
  "regex",
  "reqwest",
@@ -900,6 +923,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+aes = "0.8"
 anyhow = "1.0"
 axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
+cfb-mode = "0.8"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
 clap = { version = "4.5", features = ["derive"] }
 futures-util = "0.3"
 hex = "0.4"
 hkdf = "0.12"
 hmac = "0.12"
+md-5 = "0.10"
 rand = "0.8"
 regex = "1"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 It runs as a Fedora/Linux service, joins swarm as `role=native` with `service=nvr`, ingests camera streams, encrypts retained segments, and serves authorized identity-bound clients over a negotiated symmetric session.
 
 ## Current Iteration Scope
-- ONVIF WS-Discovery probe path
-- RTSP ingest via `ffmpeg` segment recorder
+- ONVIF WS-Discovery probe path + source lifecycle commands
+- RTSP ingest via `ffmpeg` segment recorder with restart/backoff state machine
 - encrypted segment store (`.cnv` blobs)
-- swarm-native UDP presence announcements (no Nostr relay dependency)
-- identity-gated websocket session with ECDH + symmetric payload channel
+- swarm-native UDP presence announcements with UI module advertisement + service metrics
+- identity-gated websocket session with ECDH + symmetric payload channel (`list_source_states`, `upsert_source`, `remove_source`)
 - systemd self-update timer flow
 
 ## Quick Install (Opinionated Wizard)
@@ -33,9 +33,9 @@ Wizard behavior:
 ## Config Highlights
 `config.example.json` includes:
 - `swarm.bind`, `swarm.peers`, `swarm.zones`
-- `api.identity_id`, `api.authorized_device_pks`
+- `api.identity_id`, `api.authorized_device_pks`, `api.public_ws_url`
 - `storage.root`, `storage.encryption_key_hex`
-- `update.interval_secs`
+- `update.interval_secs`\n- `ui.repo`, `ui.ref`, `ui.manifest_url`, `ui.entry`
 - `cameras[]` ONVIF/RTSP source definitions
 
 ## Security Model (Current)
@@ -64,3 +64,4 @@ cargo run -- --config ./config.json --discover-onvif
 
 ## Status
 POC-grade for manual lab validation. Not production-ready.
+

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It runs as a Fedora/Linux service, joins swarm as `role=native` with `service=nv
 - swarm-native UDP presence announcements with UI module advertisement + service metrics
 - identity-gated websocket session with ECDH + symmetric payload channel (`list_source_states`, `upsert_source`, `remove_source`)
 - systemd self-update timer flow
+- Reolink native onboarding (temporary DHCP lease, proprietary LAN discovery, native HTTP CGI bootstrap for uninitialized devices, RTSP/ONVIF enable + P2P disable, standards-readiness probe)
 
 ## Quick Install (Opinionated Wizard)
 
@@ -35,7 +36,8 @@ Wizard behavior:
 - `swarm.bind`, `swarm.peers`, `swarm.zones`
 - `api.identity_id`, `api.authorized_device_pks`, `api.public_ws_url`
 - `storage.root`, `storage.encryption_key_hex`
-- `update.interval_secs`\n- `ui.repo`, `ui.ref`, `ui.manifest_url`, `ui.entry`
+- `update.interval_secs`
+- `ui.repo`, `ui.ref`, `ui.manifest_url`, `ui.entry`
 - `cameras[]` ONVIF/RTSP source definitions
 
 ## Security Model (Current)
@@ -53,6 +55,11 @@ Wizard behavior:
 cargo test
 cargo run -- --config ./config.json --once
 cargo run -- --config ./config.json --discover-onvif
+cargo run -- --discover-reolink --discover-reolink-hint-ip 192.168.1.20
+cargo run -- --probe-reolink-ip 192.168.1.20
+cargo run -- --setup-reolink-ip 192.168.1.20 --setup-reolink-password test1234
+cargo run -- --setup-reolink-ip 192.168.1.20 --setup-reolink-password test1234 --setup-reolink-generate-password
+sudo cargo run -- --bootstrap-reolink-server-ip 192.168.1.10 --bootstrap-reolink-target-mac EC:71:DB:32:0A:8F --setup-reolink-generate-password
 ```
 
 ## Docs

--- a/README.md
+++ b/README.md
@@ -9,28 +9,38 @@ It runs as a Fedora/Linux service, joins swarm as `role=native` with `service=nv
 - RTSP ingest via `ffmpeg` segment recorder with restart/backoff state machine
 - encrypted segment store (`.cnv` blobs)
 - swarm-native UDP presence announcements with UI module advertisement + service metrics
-- identity-gated websocket session with ECDH + symmetric payload channel (`list_source_states`, `upsert_source`, `remove_source`)
+- identity-gated websocket session with ECDH + symmetric payload channel (`list_source_states`, `upsert_source`, `remove_source`, `setup_reolink`)
 - systemd self-update timer flow
 - Reolink onboarding for MVP using LAN discovery + HTTP CGI setup/read/apply (RTSP/ONVIF enable, P2P disable) while native `9000` replacement remains under R&D
 
 ## Quick Install (Opinionated Wizard)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-wizard.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-latest.sh | bash
 ```
 
-Wizard behavior:
-- builds and installs `constitute-nvr`
-- prompts for storage root path (default placeholder)
-- installs systemd service and self-update timer
+Installer behavior:
+- downloads the latest GitHub release artifact and verifies `SHA256SUMS`
+- skips reinstall/restart when installed binary hash is unchanged
+- installs systemd service and self-update timer by default
 - optionally applies camera-interface hardening (RTSP/ONVIF + NTP lane)
+
+When copied from `constitute` Appliances panel, the command includes install-time context:
+- identity binding (`--identity-id`, authorized device PKs)
+- gateway swarm peer (`--swarm-peer`) + zone keys (`--zone-key`)
+- auto-associate enrollment (`--pair-identity`, `--pair-code`, `--pair-code-hash`)
+
+Optional auto-provision flags:
+- `--enable-reolink-autoprovision`
+- `--reolink-username`, `--reolink-password` / `--reolink-desired-password`
+- `--reolink-generate-password`, `--reolink-hint-ip`
 
 ## Runtime Overview
 - Swarm transport: UDP, client mode (`native` + `nvr` capability)
 - Control/serving surface: websocket at `api.bind` (`/session`)
 - Health endpoint: `GET /health`
 - Config path default: `/etc/constitute-nvr/config.json`
-- Reolink runtime default: CGI-first (`setup_reolink`, `read_reolink_state`, `apply_reolink_state`)
+- Reolink runtime default: CGI-first (`setup_reolink`, `read_reolink_state`, `apply_reolink_state`), with `setup_reolink` auto-upserting a recorder source on success
 - Optional bridge toggle: set `CONSTITUTE_NVR_USE_SDK_BRIDGE=1` to try Windows SDK bridge fallback for lab work
 
 ## Config Highlights

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It runs as a Fedora/Linux service, joins swarm as `role=native` with `service=nv
 - swarm-native UDP presence announcements with UI module advertisement + service metrics
 - identity-gated websocket session with ECDH + symmetric payload channel (`list_source_states`, `upsert_source`, `remove_source`)
 - systemd self-update timer flow
-- Reolink native onboarding (temporary DHCP lease, proprietary LAN discovery, native HTTP CGI bootstrap for uninitialized devices, RTSP/ONVIF enable + P2P disable, standards-readiness probe)
+- Reolink onboarding for MVP using LAN discovery + HTTP CGI setup/read/apply (RTSP/ONVIF enable, P2P disable) while native `9000` replacement remains under R&D
 
 ## Quick Install (Opinionated Wizard)
 
@@ -30,11 +30,13 @@ Wizard behavior:
 - Control/serving surface: websocket at `api.bind` (`/session`)
 - Health endpoint: `GET /health`
 - Config path default: `/etc/constitute-nvr/config.json`
+- Reolink runtime default: CGI-first (`setup_reolink`, `read_reolink_state`, `apply_reolink_state`)
+- Optional bridge toggle: set `CONSTITUTE_NVR_USE_SDK_BRIDGE=1` to try Windows SDK bridge fallback for lab work
 
 ## Config Highlights
 `config.example.json` includes:
 - `swarm.bind`, `swarm.peers`, `swarm.zones`
-- `api.identity_id`, `api.authorized_device_pks`, `api.public_ws_url`
+- `api.identity_id`, `api.authorized_device_pks`, `api.public_ws_url`, `api.allow_unsigned_hello_mvp` (MVP mode for web shell launch without shipping identity secret)
 - `storage.root`, `storage.encryption_key_hex`
 - `update.interval_secs`
 - `ui.repo`, `ui.ref`, `ui.manifest_url`, `ui.entry`
@@ -46,7 +48,8 @@ Wizard behavior:
 - Session admission requires:
   - matching `identity_id`
   - optional device allowlist (`authorized_device_pks`)
-  - HMAC proof over hello envelope (`identity_secret_hex`)
+  - HMAC proof over hello envelope (`identity_secret_hex`) unless `allow_unsigned_hello_mvp=true`
+- Unsigned MVP mode is for local integration bring-up only; disable it for non-lab deployments.
 - Camera network hardening is operator-controlled and scriptable.
 
 ## Local Dev

--- a/config.example.json
+++ b/config.example.json
@@ -21,6 +21,7 @@
   },
   "api": {
     "bind": "0.0.0.0:8456",
+    "public_ws_url": "wss://replace-host:8456/session",
     "identity_id": "REPLACE_WITH_IDENTITY_ID",
     "authorized_device_pks": [],
     "identity_secret_hex": "",
@@ -37,6 +38,12 @@
     "source_dir": "/opt/constitute-nvr-src",
     "branch": "main",
     "script_path": "/usr/local/bin/constitute-nvr-self-update"
+  },
+  "ui": {
+    "repo": "Aux0x7F/constitute-nvr-ui",
+    "ref": "main",
+    "manifest_url": "https://raw.githubusercontent.com/Aux0x7F/constitute-nvr-ui/main/app.manifest.json",
+    "entry": "dist/index.html"
   },
   "cameras": [
     {

--- a/config.example.json
+++ b/config.example.json
@@ -58,5 +58,19 @@
       "enabled": true,
       "segment_secs": 10
     }
-  ]
+  ],
+  "autoprovision": {
+    "reolink_enabled": false,
+    "reolink_username": "admin",
+    "reolink_password": "",
+    "reolink_desired_password": "",
+    "reolink_generate_password": false,
+    "reolink_discover_timeout_secs": 3,
+    "reolink_hint_ip": ""
+  },
+  "pair_identity_label": "",
+  "pair_code": "",
+  "pair_code_hash": "",
+  "pair_request_interval_secs": 15,
+  "pair_request_attempts": 24
 }

--- a/config.example.json
+++ b/config.example.json
@@ -3,8 +3,8 @@
   "node_role": "native",
   "device_label": "Constitute NVR",
   "service_version": "0.1.0",
-  "nostr_pubkey": "",
-  "nostr_sk_hex": "",
+  "nostr_pubkey": "650ebf57f24bcbf7f4e0da11a48943e26a82377146343a3797c2e5356c04b00c",
+  "nostr_sk_hex": "9f09c1a637549ad6b9023c1e88971dc26cf8c771aad4d15a4997d310f6315197",
   "swarm": {
     "bind": "0.0.0.0:4050",
     "peers": [
@@ -24,12 +24,12 @@
     "public_ws_url": "wss://replace-host:8456/session",
     "identity_id": "REPLACE_WITH_IDENTITY_ID",
     "authorized_device_pks": [],
-    "identity_secret_hex": "",
-    "server_secret_hex": ""
+    "identity_secret_hex": "2c80e2f0b8c3fbdd550a47cc4bb7151c9f62d721587b768522089363da071133",
+    "server_secret_hex": "2130dde3d606451764e5151283327478461548e28d12c1462562a628fb665588"
   },
   "storage": {
     "root": "/mnt/REPLACE_WITH_STORAGE_MOUNT/constitute-nvr",
-    "encryption_key_hex": "",
+    "encryption_key_hex": "c402bbf460a252bc1e741795a7b3036d34c7fceedc9f189d1ae7e7aa873d54ac",
     "encrypt_interval_secs": 5
   },
   "update": {

--- a/config.example.json
+++ b/config.example.json
@@ -24,6 +24,7 @@
     "public_ws_url": "wss://replace-host:8456/session",
     "identity_id": "REPLACE_WITH_IDENTITY_ID",
     "authorized_device_pks": [],
+    "allow_unsigned_hello_mvp": true,
     "identity_secret_hex": "2c80e2f0b8c3fbdd550a47cc4bb7151c9f62d721587b768522089363da071133",
     "server_secret_hex": "2130dde3d606451764e5151283327478461548e28d12c1462562a628fb665588"
   },

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -17,7 +17,7 @@
 - RTSP port observed on `554/tcp` after native enablement
 - Reolink cloud/P2P endpoint behavior observed: yes (`p2p.reolink.com`, `devices-apis.reolink.com`)
 - RTSP ingest path: pending sustained validation in this repo
-- Current automation status: native DHCP + native CGI setup path implemented; first-boot HTTP availability must still be validated on a factory-reset unit
+- Current automation status: native DHCP bootstrap is implemented; configured-camera control can fall back to native CGI for ports/P2P, but first-boot provisioning still depends on the proprietary 9000 path and remains the blocking native-Rust gap
 - Recommended status: test candidate with camera-jail policy enabled
 
 ## Validation Gates

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -9,9 +9,15 @@
 - Recommended status: test candidate
 
 ### Reolink E1 Outdoor SE PoE Pan Cam
-- ONVIF port surfaced in probe observations: yes
-- Reolink cloud/P2P endpoint behavior observed: yes (expected vendor default)
-- RTSP ingest path: pending lab validation in this repo
+- First boot requires DHCP lease before the camera exposes an address
+- Proprietary LAN discovery observed on UDP `2000/3000`
+- Proprietary control plane observed on TCP `9000`
+- Native HTTP CGI control plane observed at `http://<ip>:80/cgi-bin/api.cgi`
+- ONVIF service observed at `http://<ip>:8000/onvif/device_service` after native enablement
+- RTSP port observed on `554/tcp` after native enablement
+- Reolink cloud/P2P endpoint behavior observed: yes (`p2p.reolink.com`, `devices-apis.reolink.com`)
+- RTSP ingest path: pending sustained validation in this repo
+- Current automation status: native DHCP + native CGI setup path implemented; first-boot HTTP availability must still be validated on a factory-reset unit
 - Recommended status: test candidate with camera-jail policy enabled
 
 ## Validation Gates

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -68,7 +68,7 @@ Connect websocket to `/session` and perform:
 1. plaintext `hello`
 2. receive `hello_ack`
 3. switch to encrypted `cipher` envelopes
-4. issue `list_sources` and `list_segments`
+4. issue `list_sources`, `list_source_states`, then `list_segments`
 
 Use the configured values:
 - `api.identity_id`
@@ -86,3 +86,4 @@ sudo /usr/local/bin/constitute-nvr-self-update --source-dir /opt/constitute-nvr-
 - depends on host `ffmpeg`
 - source-build update flow (no signed release artifact path yet)
 - segment-serving path implemented before live stream relay path
+

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -37,13 +37,27 @@ Critical fields before ingest:
 constitute-nvr --config /etc/constitute-nvr/config.json --discover-onvif
 ```
 
-## 5) Health Endpoint
+## 5) Reolink First-Boot Bootstrap (Camera Jail / No DHCP LAN)
+Use this only for first-boot cameras that request DHCP but do not yet expose RTSP/ONVIF.
+
+```bash
+sudo constitute-nvr --bootstrap-reolink-server-ip 192.168.1.10 --bootstrap-reolink-lease-ip 192.168.1.20 --bootstrap-reolink-target-mac EC:71:DB:32:0A:8F
+constitute-nvr --discover-reolink --discover-reolink-hint-ip 192.168.1.20
+constitute-nvr --probe-reolink-ip 192.168.1.20
+```
+
+Notes:
+- Binding UDP/67 generally requires root or `CAP_NET_BIND_SERVICE`.
+- Current automation covers lease + vendor discovery + standards readiness checks.
+- The proprietary `9000` control plane is still required for fully automatic RTSP/ONVIF/P2P toggles.
+
+## 6) Health Endpoint
 
 ```bash
 curl -s http://127.0.0.1:8456/health | jq .
 ```
 
-## 6) Camera Hardening Script
+## 7) Camera Hardening Script
 Audit-only:
 
 ```bash
@@ -63,7 +77,7 @@ Expected effect:
 - camera NIC zone target `DROP`
 - host egress on camera NIC restricted to ONVIF/RTSP (+ optional WS-Discovery, optional NTP)
 
-## 7) Manual Session Protocol Test (Identity-bound)
+## 8) Manual Session Protocol Test (Identity-bound)
 Connect websocket to `/session` and perform:
 1. plaintext `hello`
 2. receive `hello_ack`
@@ -75,7 +89,7 @@ Use the configured values:
 - `api.identity_secret_hex`
 - `api.server_secret_hex`
 
-## 8) Self-Update
+## 9) Self-Update
 Manual run:
 
 ```bash

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -3,13 +3,27 @@
 ## 1) Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-wizard.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-latest.sh | bash
 ```
 
-Wizard prompts for:
-- storage root path (default placeholder)
-- self-update timer interval
-- optional camera hardening settings
+Web-driven install (from `constitute` Appliances panel) passes context flags similar to:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-latest.sh | bash -s -- \
+  --identity-id '<identity-id>' \
+  --authorized-device-pk '<device-pk>' \
+  --swarm-peer '<gateway-host:4040>' \
+  --zone-key '<zone-key>' \
+  --pair-identity '<identity-label>' \
+  --pair-code '<code>' \
+  --pair-code-hash '<code-hash>' \
+  --allow-unsigned-hello-mvp
+```
+
+Install flow notes:
+- release tarball is verified against `SHA256SUMS`
+- unchanged binary hash skips reinstall/restart (unless install context flags are provided)
+- auto-update timer is enabled by default (`constitute-nvr-update.timer`)
 
 ## 2) Service Checks
 
@@ -26,9 +40,12 @@ File:
 
 Critical fields before ingest:
 - `api.identity_id`
+- `api.authorized_device_pks`
 - `swarm.peers`
 - `swarm.zones[]`
+- `pair_identity_label` / `pair_code_hash` (if auto-associate was armed)
 - `storage.root`
+- `autoprovision.reolink_*` (when auto-provision enabled)
 - `cameras[]`
 
 ## 4) ONVIF Discovery Smoke
@@ -49,7 +66,7 @@ constitute-nvr --probe-reolink-ip 192.168.1.20
 Notes:
 - Binding UDP/67 generally requires root or `CAP_NET_BIND_SERVICE`.
 - Current automation covers lease + vendor discovery + standards readiness checks.
-- The proprietary `9000` control plane is still required for fully automatic RTSP/ONVIF/P2P toggles.
+- CGI setup path covers RTSP/ONVIF/P2P toggles when HTTP API is available; proprietary `9000` path remains fallback/R&D for HTTP-disabled devices.
 
 ## 6) Health Endpoint
 
@@ -93,11 +110,11 @@ Use the configured values:
 Manual run:
 
 ```bash
-sudo /usr/local/bin/constitute-nvr-self-update --source-dir /opt/constitute-nvr-src --branch main --service-name constitute-nvr --try-restart
+sudo /usr/local/bin/constitute-nvr-self-update --service-name constitute-nvr --try-restart
 ```
 
 ## Known POC Limits
 - depends on host `ffmpeg`
-- source-build update flow (no signed release artifact path yet)
+- release checksums are hash-verified but not signature-verified yet
 - segment-serving path implemented before live stream relay path
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -6,10 +6,15 @@ Define the active contract surface for `constitute-nvr` POC integration.
 ## Service Identity
 - runtime role: `native`
 - service capability: `nvr`
-- swarm records include:
+- swarm device record includes:
   - `role`
   - `service`
   - `serviceVersion`
+  - `ingestProtocols` (`onvif`, `rtsp`)
+  - `capabilities` (`camera`)
+  - UI module hints (`uiRepo`, `uiRef`, optional `uiManifestUrl`, `uiEntry`)
+  - optional `sessionWsUrl`
+  - live service metrics (`uptimeSec`, peer counts, camera counts)
 
 ## Swarm Transport (Native)
 - channel: UDP
@@ -36,10 +41,16 @@ Carries signed Nostr event payloads for:
 - device discovery (`kind=30078`, `t=swarm_discovery`, `type=device`, `role=native`, `service=nvr`)
 - zone presence (`kind=1`, `t=constitute`, `z=<zone>`)
 
-## ONVIF Discovery
+## ONVIF Discovery + Source Lifecycle
 - WS-Discovery probe to `239.255.255.250:3702`
 - ONVIF endpoint extraction from `XAddrs`
-- command surface supports discovery trigger from authenticated session
+- source lifecycle command surface:
+  - `upsert_source`
+  - `remove_source`
+  - `list_source_states`
+- recorder state machine:
+  - `starting` -> `running` -> `backoff` -> retry
+  - terminal `failed` on non-recoverable runtime failures (e.g., `ffmpeg` missing)
 
 ## Session Negotiation (`/session`)
 
@@ -91,7 +102,10 @@ Session key derivation:
 
 ## Encrypted Commands
 - `list_sources`
+- `list_source_states`
 - `discover_onvif`
+- `upsert_source` (source definition)
+- `remove_source` (`sourceId`)
 - `list_segments` (`sourceId`, `limit`)
 - `get_segment` (`sourceId`, `name`)
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -52,6 +52,18 @@ Carries signed Nostr event payloads for:
   - `starting` -> `running` -> `backoff` -> retry
   - terminal `failed` on non-recoverable runtime failures (e.g., `ffmpeg` missing)
 
+## Reolink Bootstrap (Current)
+- temporary DHCP lease responder on UDP/67 for first-boot cameras that only request DHCP
+- proprietary LAN discovery probe: UDP broadcast `aaaa0000` to port `2000`, replies observed from camera `2000 -> client 3000`
+- readiness probe checks:
+  - proprietary control port `9000`
+  - RTSP port `554`
+  - ONVIF service port `8000`
+- standards-ready means:
+  - `554/tcp` open
+  - `8000/tcp` open
+  - ONVIF XAddr resolves to `http://<ip>:8000/onvif/device_service`
+
 ## Session Negotiation (`/session`)
 
 ### 1) Client hello (plaintext frame)
@@ -104,6 +116,9 @@ Session key derivation:
 - `list_sources`
 - `list_source_states`
 - `discover_onvif`
+- `discover_reolink`
+- `probe_reolink` (`ip`)
+- `bootstrap_reolink` (`request`)
 - `upsert_source` (source definition)
 - `remove_source` (`sourceId`)
 - `list_segments` (`sourceId`, `limit`)

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -40,6 +40,7 @@ Define the active contract surface for `constitute-nvr` POC integration.
 Carries signed Nostr event payloads for:
 - device discovery (`kind=30078`, `t=swarm_discovery`, `type=device`, `role=native`, `service=nvr`)
 - zone presence (`kind=1`, `t=constitute`, `z=<zone>`)
+- optional install enrollment signal (`record_type=signal`, payload `type=pair_request`) when `pair_identity_label` + `pair_code_hash` are configured
 
 ## ONVIF Discovery + Source Lifecycle
 - WS-Discovery probe to `239.255.255.250:3702`
@@ -48,6 +49,7 @@ Carries signed Nostr event payloads for:
   - `upsert_source`
   - `remove_source`
   - `list_source_states`
+  - `setup_reolink` (successful setup also auto-upserts/starts a source)
 - recorder state machine:
   - `starting` -> `running` -> `backoff` -> retry
   - terminal `failed` on non-recoverable runtime failures (e.g., `ffmpeg` missing)
@@ -118,6 +120,9 @@ Session key derivation:
 - `discover_onvif`
 - `discover_reolink`
 - `probe_reolink` (`ip`)
+- `read_reolink_state` (`request`)
+- `apply_reolink_state` (`request`)
+- `setup_reolink` (`request`)
 - `bootstrap_reolink` (`request`)
 - `upsert_source` (source definition)
 - `remove_source` (`sourceId`)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -14,10 +14,10 @@
 - [x] encrypted segment-at-rest storage pass
 
 ## Iteration 2: Ingest Reliability
-- [ ] ONVIF source lifecycle (register/update/remove) with explicit state machine
-- [ ] reconnect/backoff policy with bounded retries and observability
+- [x] ONVIF source lifecycle (register/update/remove) with explicit state machine
+- [x] reconnect/backoff policy with bounded retries and observability
 - [ ] ingest validation on target camera matrix
-- [ ] service metrics publication in swarm records
+- [x] service metrics publication in swarm records
 
 ## Iteration 3: Web/Gateway Convergence
 - [ ] exact identity/device auth parity with `constitute` + `constitute-gateway`
@@ -30,3 +30,4 @@
 - [ ] hardware-backed key options and sealed secret handling
 - [ ] vendor-specific P2P disable automation hooks (where camera APIs allow)
 - [ ] full operator runbooks for fedora lab + vps deployment profiles
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,6 +18,7 @@
 - [x] reconnect/backoff policy with bounded retries and observability
 - [ ] ingest validation on target camera matrix
 - [x] service metrics publication in swarm records
+- [x] Reolink DHCP bootstrap + proprietary discovery + standards-readiness probe
 
 ## Iteration 3: Web/Gateway Convergence
 - [ ] exact identity/device auth parity with `constitute` + `constitute-gateway`
@@ -29,5 +30,6 @@
 - [ ] signed release artifact update path (replace source-build updater default)
 - [ ] hardware-backed key options and sealed secret handling
 - [ ] vendor-specific P2P disable automation hooks (where camera APIs allow)
+- [ ] Reolink `9000` control-plane reversal for zero-manual RTSP/ONVIF/P2P toggles
 - [ ] full operator runbooks for fedora lab + vps deployment profiles
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,7 +27,8 @@
 - [ ] zone routing and discovery resilience test matrix
 
 ## Iteration 4: Productionization
-- [ ] signed release artifact update path (replace source-build updater default)
+- [ ] signed/provenance verification for release artifacts (beyond SHA256 file checks)
+- [x] GitHub release artifact update path with SHA256 verification (source-build path no longer default)
 - [ ] hardware-backed key options and sealed secret handling
 - [ ] vendor-specific P2P disable automation hooks (where camera APIs allow)
 - [ ] Reolink `9000` control-plane reversal for zero-manual RTSP/ONVIF/P2P toggles

--- a/scripts/linux/install-latest.sh
+++ b/scripts/linux/install-latest.sh
@@ -1,0 +1,300 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${REPO_OWNER:-Aux0x7F}"
+REPO_NAME="${REPO_NAME:-constitute-nvr}"
+UPDATE_INTERVAL_SECS="${UPDATE_INTERVAL_SECS:-300}"
+DEV_UPDATE_INTERVAL_SECS="${DEV_UPDATE_INTERVAL_SECS:-120}"
+FORCE=0
+FORWARD_NON_INTERACTIVE=0
+
+CURL_PROXY_URL="${CURL_PROXY_URL:-}"
+USE_TOR=0
+TOR_SOCKS_ADDR="${TOR_SOCKS_ADDR:-127.0.0.1:9050}"
+TOR_CONTROL_ADDR="${TOR_CONTROL_ADDR:-127.0.0.1:9051}"
+TOR_ROTATE_ON_RETRY=1
+
+CONFIG_MUTATING=0
+WIZARD_ARGS=()
+
+usage() {
+  cat <<'EOF'
+Usage: install-latest.sh [options]
+
+Install/update constitute-nvr from GitHub Releases.
+Auto-update remains enabled by default via constitute-nvr-update.timer.
+
+Options:
+  --repo-owner <owner>       GitHub owner (default: Aux0x7F)
+  --repo-name <name>         GitHub repo (default: constitute-nvr)
+  --update-interval <secs>   NVR self-update poll interval seconds (default: 300)
+  --non-interactive          Accepted for compatibility (default behavior)
+  --dev-poll                 Use fast dev update interval (default: 120s)
+  --force                    Reinstall even when binary hash is unchanged
+  --proxy-url <url>          Use HTTP(S) proxy for release fetches
+  --tor                      Use Tor SOCKS egress for release fetches
+  --tor-socks <host:port>    Tor SOCKS endpoint (default: 127.0.0.1:9050)
+  --tor-control <host:port>  Tor control endpoint (default: 127.0.0.1:9051)
+  --no-tor-rotate            Disable NEWNYM attempt on retry
+
+Pass-through (install context):
+  --identity-id <id>
+  --authorized-device-pk <pk>  (repeatable)
+  --zone-key <key>             (repeatable)
+  --swarm-peer <host:port>     (repeatable)
+  --public-ws-url <url>
+  --allow-unsigned-hello-mvp | --require-signed-hello
+  --pair-identity <label>
+  --pair-code <code>
+  --pair-code-hash <hash>
+  --enable-reolink-autoprovision | --disable-reolink-autoprovision
+  --reolink-username <name>
+  --reolink-password <pass>
+  --reolink-desired-password <pass>
+  --reolink-generate-password
+  --reolink-hint-ip <ip>
+  --storage-root <path>
+  --apply-hardening | --skip-hardening
+  --camera-iface <iface>
+  --camera-cidr <cidr>
+  --onvif-ports <csv>
+  --rtsp-ports <csv>
+  --no-ntp-host
+
+Examples:
+  curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-latest.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/Aux0x7F/constitute-nvr/main/scripts/linux/install-latest.sh | \
+    bash -s -- --identity-id abc --swarm-peer 127.0.0.1:4040 --zone-key z1 --pair-identity myid --pair-code 1234 --pair-code-hash deadbeef
+EOF
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+build_curl_args() {
+  CURL_ARGS=(-fsSL)
+  if [[ -n "$CURL_PROXY_URL" ]]; then
+    CURL_ARGS+=(--proxy "$CURL_PROXY_URL")
+  fi
+  if [[ "$USE_TOR" -eq 1 ]]; then
+    CURL_ARGS+=(--proxy "socks5h://${TOR_SOCKS_ADDR}")
+  fi
+}
+
+rotate_tor_exit() {
+  [[ "$USE_TOR" -eq 1 ]] || return 0
+  [[ "$TOR_ROTATE_ON_RETRY" -eq 1 ]] || return 0
+  command -v nc >/dev/null 2>&1 || return 0
+
+  local host="${TOR_CONTROL_ADDR%:*}"
+  local port="${TOR_CONTROL_ADDR##*:}"
+  [[ -n "$host" && -n "$port" && "$host" != "$port" ]] || return 0
+
+  {
+    printf 'AUTHENTICATE\r\n'
+    printf 'SIGNAL NEWNYM\r\n'
+    printf 'QUIT\r\n'
+  } | nc -w 2 "$host" "$port" >/dev/null 2>&1 || true
+}
+
+verify_tor_proxy() {
+  [[ "$USE_TOR" -eq 1 ]] || return 0
+  if ! curl "${CURL_ARGS[@]}" --max-time 12 -I https://github.com >/dev/null 2>&1; then
+    echo "Tor proxy check failed at socks5h://${TOR_SOCKS_ADDR}" >&2
+    exit 1
+  fi
+}
+
+download_with_retry() {
+  local url="$1"
+  local out="$2"
+  local attempt
+  for attempt in 1 2 3; do
+    if curl "${CURL_ARGS[@]}" "$url" -o "$out"; then
+      return 0
+    fi
+    rotate_tor_exit
+    sleep "$attempt"
+  done
+  return 1
+}
+
+parse_passthrough_flag() {
+  local flag="$1"
+  shift
+  case "$flag" in
+    --identity-id|--authorized-device-pk|--zone-key|--swarm-peer|--public-ws-url|--pair-identity|--pair-code|--pair-code-hash|--reolink-username|--reolink-password|--reolink-desired-password|--reolink-hint-ip|--storage-root|--camera-iface|--camera-cidr|--onvif-ports|--rtsp-ports)
+      local value="${1:-}"
+      if [[ -z "$value" ]]; then
+        echo "missing value for ${flag}" >&2
+        exit 1
+      fi
+      WIZARD_ARGS+=("$flag" "$value")
+      CONFIG_MUTATING=1
+      echo 2
+      return 0
+      ;;
+    --allow-unsigned-hello-mvp|--require-signed-hello|--enable-reolink-autoprovision|--disable-reolink-autoprovision|--reolink-generate-password|--apply-hardening|--skip-hardening|--no-ntp-host)
+      WIZARD_ARGS+=("$flag")
+      CONFIG_MUTATING=1
+      echo 1
+      return 0
+      ;;
+    *)
+      echo "Unknown argument: ${flag}" >&2
+      usage
+      exit 1
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-owner)
+      REPO_OWNER="${2:?missing value for --repo-owner}"
+      shift 2
+      ;;
+    --repo-name)
+      REPO_NAME="${2:?missing value for --repo-name}"
+      shift 2
+      ;;
+    --update-interval)
+      UPDATE_INTERVAL_SECS="${2:?missing value for --update-interval}"
+      shift 2
+      ;;
+    --dev-poll)
+      UPDATE_INTERVAL_SECS="$DEV_UPDATE_INTERVAL_SECS"
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --proxy-url)
+      CURL_PROXY_URL="${2:?missing value for --proxy-url}"
+      shift 2
+      ;;
+    --tor)
+      USE_TOR=1
+      shift
+      ;;
+    --tor-socks)
+      USE_TOR=1
+      TOR_SOCKS_ADDR="${2:?missing value for --tor-socks}"
+      shift 2
+      ;;
+    --tor-control)
+      TOR_CONTROL_ADDR="${2:?missing value for --tor-control}"
+      shift 2
+      ;;
+    --no-tor-rotate)
+      TOR_ROTATE_ON_RETRY=0
+      shift
+      ;;
+    --non-interactive)
+      FORWARD_NON_INTERACTIVE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      consumed="$(parse_passthrough_flag "$@")"
+      shift "$consumed"
+      ;;
+  esac
+done
+
+if ! [[ "$UPDATE_INTERVAL_SECS" =~ ^[0-9]+$ ]]; then
+  echo "update interval must be integer seconds" >&2
+  exit 1
+fi
+
+require_cmd bash
+require_cmd curl
+require_cmd grep
+require_cmd sha256sum
+require_cmd tar
+build_curl_args
+verify_tor_proxy
+
+BASE="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download"
+LINUX_ASSET="constitute-nvr-linux-amd64.tar.gz"
+SUMS_NAME="SHA256SUMS"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if ! download_with_retry "${BASE}/${LINUX_ASSET}" "${tmpdir}/${LINUX_ASSET}"; then
+  echo "Failed to download ${LINUX_ASSET}" >&2
+  exit 1
+fi
+if ! download_with_retry "${BASE}/${SUMS_NAME}" "${tmpdir}/${SUMS_NAME}"; then
+  echo "Failed to download ${SUMS_NAME}" >&2
+  exit 1
+fi
+
+if ! grep " ${LINUX_ASSET}$" "${tmpdir}/${SUMS_NAME}" | (cd "$tmpdir" && sha256sum -c -); then
+  echo "Checksum verification failed for ${LINUX_ASSET}" >&2
+  exit 1
+fi
+
+mkdir -p "$tmpdir/extract"
+tar -C "$tmpdir/extract" -xzf "${tmpdir}/${LINUX_ASSET}"
+
+installer="${tmpdir}/extract/scripts/linux/install-wizard.sh"
+binary="${tmpdir}/extract/constitute-nvr"
+update_script="${tmpdir}/extract/scripts/linux/self-update-release.sh"
+config_template="${tmpdir}/extract/config.example.json"
+
+if [[ ! -f "$installer" ]]; then
+  echo "Release artifact missing scripts/linux/install-wizard.sh" >&2
+  exit 1
+fi
+if [[ ! -f "$binary" ]]; then
+  echo "Release artifact missing constitute-nvr binary" >&2
+  exit 1
+fi
+if [[ ! -f "$update_script" ]]; then
+  echo "Release artifact missing scripts/linux/self-update-release.sh" >&2
+  exit 1
+fi
+if [[ ! -f "$config_template" ]]; then
+  echo "Release artifact missing config.example.json" >&2
+  exit 1
+fi
+
+skip_install=0
+installed_bin="/usr/local/bin/constitute-nvr"
+if [[ "$FORCE" -eq 0 && "$CONFIG_MUTATING" -eq 0 && -f "$installed_bin" ]]; then
+  if command -v systemctl >/dev/null 2>&1 && systemctl list-unit-files | grep -q '^constitute-nvr\.service'; then
+    current_hash="$(sha256sum "$installed_bin" | awk '{print $1}')"
+    incoming_hash="$(sha256sum "$binary" | awk '{print $1}')"
+    if [[ "$current_hash" == "$incoming_hash" ]]; then
+      skip_install=1
+      echo "No binary change detected; skipping reinstall/restart."
+    fi
+  fi
+fi
+
+if [[ "$skip_install" -eq 0 ]]; then
+  install_args=(
+    --binary "$binary"
+    --self-update-script "$update_script"
+    --config-template "$config_template"
+    --update-interval "$UPDATE_INTERVAL_SECS"
+  )
+  if [[ "$FORWARD_NON_INTERACTIVE" -eq 1 ]]; then
+    install_args+=(--non-interactive)
+  fi
+  install_args+=("${WIZARD_ARGS[@]}")
+  bash "$installer" "${install_args[@]}"
+fi
+
+echo "Install/update complete: constitute-nvr"

--- a/scripts/linux/install-wizard.sh
+++ b/scripts/linux/install-wizard.sh
@@ -21,6 +21,25 @@ SERVICE_USER="constitute-nvr"
 NOLOGIN_PATH="$(command -v nologin || echo /sbin/nologin)"
 STORAGE_ROOT="/mnt/REPLACE_WITH_STORAGE_MOUNT/constitute-nvr"
 UPDATE_INTERVAL_SECS=300
+EXTERNAL_BINARY=""
+EXTERNAL_UPDATE_SCRIPT=""
+EXTERNAL_CONFIG_TEMPLATE=""
+
+IDENTITY_ID=""
+PUBLIC_WS_URL=""
+SWARM_PEERS=()
+ALLOW_UNSIGNED_HELLO_MVP=1
+AUTHORIZED_DEVICE_PKS=()
+ZONE_KEYS=()
+PAIR_IDENTITY=""
+PAIR_CODE=""
+PAIR_CODE_HASH=""
+REOLINK_AUTOPROVISION="ask"
+REOLINK_USERNAME="admin"
+REOLINK_PASSWORD=""
+REOLINK_DESIRED_PASSWORD=""
+REOLINK_GENERATE_PASSWORD=0
+REOLINK_HINT_IP=""
 
 usage() {
   cat <<'EOF'
@@ -35,6 +54,9 @@ Options:
   --repo-url <url>           Git URL override
   --ref <git-ref>            Git ref to build (default: main)
   --source-dir <path>        Source clone location (default: /opt/constitute-nvr-src)
+  --binary <path>            Use prebuilt binary (skip source build)
+  --self-update-script <path> Custom self-update script to install
+  --config-template <path>   Config template path for first install
   --storage-root <path>      Storage root path (default placeholder)
   --update-interval <secs>   Self-update poll interval in seconds (default: 300)
   --non-interactive          No prompts
@@ -45,6 +67,23 @@ Options:
   --onvif-ports <csv>        ONVIF TCP ports (default: 80,443,8000,8080,8899)
   --rtsp-ports <csv>         RTSP TCP ports (default: 554)
   --no-ntp-host              Do not allow camera->host UDP/123
+  --identity-id <id>         Bind NVR session auth to identity id
+  --authorized-device-pk <pk> Add authorized identity device pk (repeatable)
+  --zone-key <key>           Join zone key for swarm announcements (repeatable)
+  --swarm-peer <host:port>   Gateway swarm UDP peer endpoint (repeatable)
+  --public-ws-url <url>      Public websocket URL for /session
+  --allow-unsigned-hello-mvp Allow unsigned hello proof mode (default)
+  --require-signed-hello     Require signed hello proof
+  --pair-identity <label>    Pairing identity label for auto-associate
+  --pair-code <code>         Pairing enrollment code
+  --pair-code-hash <hash>    Pairing enrollment code hash (base64url)
+  --enable-reolink-autoprovision Enable Reolink auto-provision at startup
+  --disable-reolink-autoprovision Disable Reolink auto-provision
+  --reolink-username <name>  Reolink admin username (default: admin)
+  --reolink-password <pass>  Reolink current password
+  --reolink-desired-password <pass> Reolink desired password
+  --reolink-generate-password Generate random Reolink password
+  --reolink-hint-ip <ip>     Hint IP for Reolink discovery
   -h, --help                 Show help
 EOF
 }
@@ -113,6 +152,18 @@ while [[ $# -gt 0 ]]; do
       SOURCE_DIR="${2:?missing value for --source-dir}"
       shift 2
       ;;
+    --binary)
+      EXTERNAL_BINARY="${2:?missing value for --binary}"
+      shift 2
+      ;;
+    --self-update-script)
+      EXTERNAL_UPDATE_SCRIPT="${2:?missing value for --self-update-script}"
+      shift 2
+      ;;
+    --config-template)
+      EXTERNAL_CONFIG_TEMPLATE="${2:?missing value for --config-template}"
+      shift 2
+      ;;
     --storage-root)
       STORAGE_ROOT="${2:?missing value for --storage-root}"
       shift 2
@@ -153,6 +204,74 @@ while [[ $# -gt 0 ]]; do
       ALLOW_NTP_HOST=0
       shift
       ;;
+    --identity-id)
+      IDENTITY_ID="${2:?missing value for --identity-id}"
+      shift 2
+      ;;
+    --authorized-device-pk)
+      AUTHORIZED_DEVICE_PKS+=("${2:?missing value for --authorized-device-pk}")
+      shift 2
+      ;;
+    --zone-key)
+      ZONE_KEYS+=("${2:?missing value for --zone-key}")
+      shift 2
+      ;;
+    --swarm-peer)
+      SWARM_PEERS+=("${2:?missing value for --swarm-peer}")
+      shift 2
+      ;;
+    --public-ws-url)
+      PUBLIC_WS_URL="${2:?missing value for --public-ws-url}"
+      shift 2
+      ;;
+    --allow-unsigned-hello-mvp)
+      ALLOW_UNSIGNED_HELLO_MVP=1
+      shift
+      ;;
+    --require-signed-hello)
+      ALLOW_UNSIGNED_HELLO_MVP=0
+      shift
+      ;;
+    --pair-identity)
+      PAIR_IDENTITY="${2:?missing value for --pair-identity}"
+      shift 2
+      ;;
+    --pair-code)
+      PAIR_CODE="${2:?missing value for --pair-code}"
+      shift 2
+      ;;
+    --pair-code-hash)
+      PAIR_CODE_HASH="${2:?missing value for --pair-code-hash}"
+      shift 2
+      ;;
+    --enable-reolink-autoprovision)
+      REOLINK_AUTOPROVISION=1
+      shift
+      ;;
+    --disable-reolink-autoprovision)
+      REOLINK_AUTOPROVISION=0
+      shift
+      ;;
+    --reolink-username)
+      REOLINK_USERNAME="${2:?missing value for --reolink-username}"
+      shift 2
+      ;;
+    --reolink-password)
+      REOLINK_PASSWORD="${2:?missing value for --reolink-password}"
+      shift 2
+      ;;
+    --reolink-desired-password)
+      REOLINK_DESIRED_PASSWORD="${2:?missing value for --reolink-desired-password}"
+      shift 2
+      ;;
+    --reolink-generate-password)
+      REOLINK_GENERATE_PASSWORD=1
+      shift
+      ;;
+    --reolink-hint-ip)
+      REOLINK_HINT_IP="${2:?missing value for --reolink-hint-ip}"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -183,6 +302,28 @@ if [[ "$NON_INTERACTIVE" -eq 0 ]]; then
   if [[ -n "$input_interval" ]]; then
     UPDATE_INTERVAL_SECS="$input_interval"
   fi
+
+  if [[ -z "$IDENTITY_ID" ]]; then
+    read -r -p "Identity id (required for session auth): " IDENTITY_ID
+  fi
+
+  if [[ ${#SWARM_PEERS[@]} -eq 0 ]]; then
+    read -r -p "Gateway swarm peer host:port (optional): " first_swarm_peer
+    if [[ -n "$first_swarm_peer" ]]; then
+      SWARM_PEERS+=("$first_swarm_peer")
+    fi
+  fi
+
+  if [[ ${#ZONE_KEYS[@]} -eq 0 ]]; then
+    read -r -p "Zone key to join (optional): " first_zone_key
+    if [[ -n "$first_zone_key" ]]; then
+      ZONE_KEYS+=("$first_zone_key")
+    fi
+  fi
+
+  if [[ -z "$PUBLIC_WS_URL" ]]; then
+    read -r -p "Public websocket URL (optional, example ws://host:8456/session): " PUBLIC_WS_URL
+  fi
 fi
 
 if [[ "$APPLY_HARDENING" -eq 1 ]]; then
@@ -198,67 +339,173 @@ if [[ "$APPLY_HARDENING" -eq 1 ]]; then
   fi
 fi
 
+if [[ "$REOLINK_AUTOPROVISION" == "ask" ]]; then
+  if [[ "$NON_INTERACTIVE" -eq 1 ]]; then
+    REOLINK_AUTOPROVISION=0
+  elif confirm "Enable Reolink auto-provision at service startup?" 0; then
+    REOLINK_AUTOPROVISION=1
+  else
+    REOLINK_AUTOPROVISION=0
+  fi
+fi
+
+if [[ "$REOLINK_AUTOPROVISION" -eq 1 && "$NON_INTERACTIVE" -eq 0 ]]; then
+  if [[ -z "$REOLINK_USERNAME" ]]; then
+    read -r -p "Reolink username [admin]: " input_reolink_user
+    REOLINK_USERNAME="${input_reolink_user:-admin}"
+  fi
+  if [[ -z "$REOLINK_PASSWORD" && "$REOLINK_GENERATE_PASSWORD" -eq 0 ]]; then
+    read -r -s -p "Reolink current password (required unless generate-password): " input_reolink_pass
+    echo
+    REOLINK_PASSWORD="$input_reolink_pass"
+  fi
+  if [[ "$REOLINK_GENERATE_PASSWORD" -eq 0 ]] && confirm "Generate new random camera password during setup?" 0; then
+    REOLINK_GENERATE_PASSWORD=1
+  fi
+  if [[ "$REOLINK_GENERATE_PASSWORD" -eq 0 && -z "$REOLINK_DESIRED_PASSWORD" ]]; then
+    read -r -s -p "Reolink desired password (optional, leave blank to keep current): " input_reolink_desired
+    echo
+    REOLINK_DESIRED_PASSWORD="$input_reolink_desired"
+  fi
+  if [[ -z "$REOLINK_HINT_IP" ]]; then
+    read -r -p "Reolink hint IP (optional): " REOLINK_HINT_IP
+  fi
+fi
+
 if ! [[ "$UPDATE_INTERVAL_SECS" =~ ^[0-9]+$ ]]; then
   echo "update interval must be integer seconds" >&2
   exit 1
 fi
 
-require_cmd git
+if [[ -z "$IDENTITY_ID" ]]; then
+  echo "identity id is required (use --identity-id or interactive prompt)" >&2
+  exit 1
+fi
+
+if [[ "$REOLINK_AUTOPROVISION" -eq 1 && -z "$REOLINK_USERNAME" ]]; then
+  REOLINK_USERNAME="admin"
+fi
+
+if [[ "$REOLINK_AUTOPROVISION" -eq 1 && "$REOLINK_GENERATE_PASSWORD" -eq 0 && -z "$REOLINK_PASSWORD" && -z "$REOLINK_DESIRED_PASSWORD" ]]; then
+  echo "reolink auto-provision enabled but no password material provided" >&2
+  exit 1
+fi
+
 require_cmd systemctl
 require_cmd curl
 require_cmd python3
 
-if ! command -v cargo >/dev/null 2>&1; then
-  log "cargo not found"
-  if confirm "Install Rust toolchain with rustup now?" 1; then
-    curl -fsSL https://sh.rustup.rs | sh -s -- -y
-    # shellcheck source=/dev/null
-    source "$HOME/.cargo/env"
-  else
-    echo "cargo is required" >&2
-    exit 1
-  fi
-fi
-
 SRC_DIR=""
 TMP_DIR=""
+BIN_SRC=""
+UPDATE_SCRIPT_SRC=""
+CONFIG_TEMPLATE_SRC=""
+HARDEN_SCRIPT_SRC=""
 
-if [[ -f "./Cargo.toml" && -f "./src/main.rs" ]]; then
-  SRC_DIR="$(pwd)"
-  log "using local repository: $SRC_DIR"
-else
-  TMP_DIR="$(mktemp -d)"
-  SRC_DIR="$TMP_DIR/repo"
-  log "cloning source: $REPO_URL"
-  git clone --depth 1 --branch "$REF" "$REPO_URL" "$SRC_DIR"
-fi
-
-cleanup() {
-  if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
-    rm -rf "$TMP_DIR"
+if [[ -n "$EXTERNAL_BINARY" ]]; then
+  if [[ ! -f "$EXTERNAL_BINARY" ]]; then
+    echo "binary not found: $EXTERNAL_BINARY" >&2
+    exit 1
   fi
-}
-trap cleanup EXIT
+  BIN_SRC="$EXTERNAL_BINARY"
 
-log "syncing source clone at ${SOURCE_DIR}"
-run_sudo mkdir -p "$(dirname "$SOURCE_DIR")"
-if [[ ! -d "$SOURCE_DIR/.git" ]]; then
-  run_sudo git clone --depth 1 --branch "$REF" "$REPO_URL" "$SOURCE_DIR"
+  if [[ -n "$EXTERNAL_UPDATE_SCRIPT" ]]; then
+    if [[ ! -f "$EXTERNAL_UPDATE_SCRIPT" ]]; then
+      echo "self-update script not found: $EXTERNAL_UPDATE_SCRIPT" >&2
+      exit 1
+    fi
+    UPDATE_SCRIPT_SRC="$EXTERNAL_UPDATE_SCRIPT"
+  elif [[ -f "$(dirname "$0")/self-update-release.sh" ]]; then
+    UPDATE_SCRIPT_SRC="$(dirname "$0")/self-update-release.sh"
+  elif [[ -f "$(dirname "$0")/self-update.sh" ]]; then
+    UPDATE_SCRIPT_SRC="$(dirname "$0")/self-update.sh"
+  else
+    echo "unable to resolve self-update script source" >&2
+    exit 1
+  fi
+
+  if [[ -n "$EXTERNAL_CONFIG_TEMPLATE" ]]; then
+    if [[ ! -f "$EXTERNAL_CONFIG_TEMPLATE" ]]; then
+      echo "config template not found: $EXTERNAL_CONFIG_TEMPLATE" >&2
+      exit 1
+    fi
+    CONFIG_TEMPLATE_SRC="$EXTERNAL_CONFIG_TEMPLATE"
+  elif [[ -f "$(dirname "$0")/../../config.example.json" ]]; then
+    CONFIG_TEMPLATE_SRC="$(dirname "$0")/../../config.example.json"
+  fi
+
+  if [[ -f "$(dirname "$0")/harden-camera-interface.sh" ]]; then
+    HARDEN_SCRIPT_SRC="$(dirname "$0")/harden-camera-interface.sh"
+  fi
+
+  log "using provided binary: $BIN_SRC"
 else
-  run_sudo git -C "$SOURCE_DIR" fetch --depth 1 origin "$REF"
-  run_sudo git -C "$SOURCE_DIR" checkout "$REF"
-  run_sudo git -C "$SOURCE_DIR" reset --hard "origin/$REF"
+  require_cmd git
+  if ! command -v cargo >/dev/null 2>&1; then
+    log "cargo not found"
+    if confirm "Install Rust toolchain with rustup now?" 1; then
+      curl -fsSL https://sh.rustup.rs | sh -s -- -y
+      # shellcheck source=/dev/null
+      source "$HOME/.cargo/env"
+    else
+      echo "cargo is required" >&2
+      exit 1
+    fi
+  fi
+
+  if [[ -f "./Cargo.toml" && -f "./src/main.rs" ]]; then
+    SRC_DIR="$(pwd)"
+    log "using local repository: $SRC_DIR"
+  else
+    TMP_DIR="$(mktemp -d)"
+    SRC_DIR="$TMP_DIR/repo"
+    log "cloning source: $REPO_URL"
+    git clone --depth 1 --branch "$REF" "$REPO_URL" "$SRC_DIR"
+  fi
+
+  cleanup() {
+    if [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]]; then
+      rm -rf "$TMP_DIR"
+    fi
+  }
+  trap cleanup EXIT
+
+  log "syncing source clone at ${SOURCE_DIR}"
+  run_sudo mkdir -p "$(dirname "$SOURCE_DIR")"
+  if [[ ! -d "$SOURCE_DIR/.git" ]]; then
+    run_sudo git clone --depth 1 --branch "$REF" "$REPO_URL" "$SOURCE_DIR"
+  else
+    run_sudo git -C "$SOURCE_DIR" fetch --depth 1 origin "$REF"
+    run_sudo git -C "$SOURCE_DIR" checkout "$REF"
+    run_sudo git -C "$SOURCE_DIR" reset --hard "origin/$REF"
+  fi
+
+  log "building release binary"
+  (
+    cd "$SRC_DIR"
+    cargo build --release --locked
+  )
+
+  BIN_SRC="$SRC_DIR/target/release/constitute-nvr"
+  UPDATE_SCRIPT_SRC="$SRC_DIR/scripts/linux/self-update.sh"
+  CONFIG_TEMPLATE_SRC="$SRC_DIR/config.example.json"
+  HARDEN_SCRIPT_SRC="$SRC_DIR/scripts/linux/harden-camera-interface.sh"
 fi
 
-log "building release binary"
-(
-  cd "$SRC_DIR"
-  cargo build --release --locked
-)
-
-BIN_SRC="$SRC_DIR/target/release/constitute-nvr"
 if [[ ! -x "$BIN_SRC" ]]; then
-  echo "build succeeded but binary not found at $BIN_SRC" >&2
+  echo "binary not executable: $BIN_SRC" >&2
+  exit 1
+fi
+if [[ ! -f "$UPDATE_SCRIPT_SRC" ]]; then
+  echo "self-update script source missing: $UPDATE_SCRIPT_SRC" >&2
+  exit 1
+fi
+if [[ -n "$CONFIG_TEMPLATE_SRC" && ! -f "$CONFIG_TEMPLATE_SRC" ]]; then
+  echo "config template source missing: $CONFIG_TEMPLATE_SRC" >&2
+  exit 1
+fi
+if [[ "$APPLY_HARDENING" -eq 1 && ( -z "$HARDEN_SCRIPT_SRC" || ! -f "$HARDEN_SCRIPT_SRC" ) ]]; then
+  echo "hardening script source missing" >&2
   exit 1
 fi
 
@@ -268,7 +515,7 @@ run_sudo install -m 0755 "$BIN_SRC" "$INSTALL_PREFIX/bin/constitute-nvr"
 run_sudo ln -sf "$INSTALL_PREFIX/bin/constitute-nvr" "$BIN_LINK"
 
 log "installing self-update helper"
-run_sudo install -m 0755 "$SRC_DIR/scripts/linux/self-update.sh" "$SELF_UPDATE_BIN"
+run_sudo install -m 0755 "$UPDATE_SCRIPT_SRC" "$SELF_UPDATE_BIN"
 
 if ! id -u "$SERVICE_USER" >/dev/null 2>&1; then
   log "creating service user: $SERVICE_USER"
@@ -280,26 +527,126 @@ run_sudo install -d /etc/constitute-nvr
 run_sudo install -d "$STORAGE_ROOT"
 run_sudo chown "$SERVICE_USER":"$SERVICE_USER" "$STORAGE_ROOT"
 
-if [[ ! -f /etc/constitute-nvr/config.json && -f "$SRC_DIR/config.example.json" ]]; then
+if [[ ! -f /etc/constitute-nvr/config.json && -n "$CONFIG_TEMPLATE_SRC" ]]; then
   log "installing config template to /etc/constitute-nvr/config.json"
-  run_sudo install -m 0644 "$SRC_DIR/config.example.json" /etc/constitute-nvr/config.json
+  run_sudo install -m 0644 "$CONFIG_TEMPLATE_SRC" /etc/constitute-nvr/config.json
 fi
 
 log "patching config defaults"
-run_sudo python3 - <<PY
+authorized_joined=""
+if [[ ${#AUTHORIZED_DEVICE_PKS[@]} -gt 0 ]]; then
+  authorized_joined="$(IFS='|'; echo "${AUTHORIZED_DEVICE_PKS[*]}")"
+fi
+zone_keys_joined=""
+if [[ ${#ZONE_KEYS[@]} -gt 0 ]]; then
+  zone_keys_joined="$(IFS='|'; echo "${ZONE_KEYS[*]}")"
+fi
+swarm_peers_joined=""
+if [[ ${#SWARM_PEERS[@]} -gt 0 ]]; then
+  swarm_peers_joined="$(IFS='|'; echo "${SWARM_PEERS[*]}")"
+fi
+
+run_sudo env \
+  CFG_STORAGE_ROOT="${STORAGE_ROOT}" \
+  CFG_UPDATE_INTERVAL="${UPDATE_INTERVAL_SECS}" \
+  CFG_SOURCE_DIR="${SOURCE_DIR}" \
+  CFG_REF="${REF}" \
+  CFG_UPDATE_SCRIPT="${SELF_UPDATE_BIN}" \
+  CFG_IDENTITY_ID="${IDENTITY_ID}" \
+  CFG_PUBLIC_WS_URL="${PUBLIC_WS_URL}" \
+  CFG_SWARM_PEERS="${swarm_peers_joined}" \
+  CFG_ALLOW_UNSIGNED_HELLO_MVP="${ALLOW_UNSIGNED_HELLO_MVP}" \
+  CFG_AUTHORIZED_DEVICE_PKS="${authorized_joined}" \
+  CFG_ZONE_KEYS="${zone_keys_joined}" \
+  CFG_PAIR_IDENTITY="${PAIR_IDENTITY}" \
+  CFG_PAIR_CODE="${PAIR_CODE}" \
+  CFG_PAIR_CODE_HASH="${PAIR_CODE_HASH}" \
+  CFG_REOLINK_AUTOPROVISION="${REOLINK_AUTOPROVISION}" \
+  CFG_REOLINK_USERNAME="${REOLINK_USERNAME}" \
+  CFG_REOLINK_PASSWORD="${REOLINK_PASSWORD}" \
+  CFG_REOLINK_DESIRED_PASSWORD="${REOLINK_DESIRED_PASSWORD}" \
+  CFG_REOLINK_GENERATE_PASSWORD="${REOLINK_GENERATE_PASSWORD}" \
+  CFG_REOLINK_HINT_IP="${REOLINK_HINT_IP}" \
+  python3 - <<'PY'
+import base64
+import hashlib
 import json
+import os
 from pathlib import Path
 
 path = Path('/etc/constitute-nvr/config.json')
 raw = json.loads(path.read_text(encoding='utf-8'))
-raw.setdefault('storage', {})['root'] = '${STORAGE_ROOT}'
+
+storage_root = os.environ.get('CFG_STORAGE_ROOT', '').strip()
+update_interval = int(os.environ.get('CFG_UPDATE_INTERVAL', '300') or '300')
+source_dir = os.environ.get('CFG_SOURCE_DIR', '').strip()
+ref = os.environ.get('CFG_REF', '').strip()
+update_script = os.environ.get('CFG_UPDATE_SCRIPT', '').strip()
+identity_id = os.environ.get('CFG_IDENTITY_ID', '').strip()
+public_ws_url = os.environ.get('CFG_PUBLIC_WS_URL', '').strip()
+swarm_peers = [x.strip() for x in os.environ.get('CFG_SWARM_PEERS', '').split('|') if x.strip()]
+allow_unsigned = os.environ.get('CFG_ALLOW_UNSIGNED_HELLO_MVP', '1').strip() == '1'
+authorized = [x.strip() for x in os.environ.get('CFG_AUTHORIZED_DEVICE_PKS', '').split('|') if x.strip()]
+zone_keys = [x.strip() for x in os.environ.get('CFG_ZONE_KEYS', '').split('|') if x.strip()]
+pair_identity = os.environ.get('CFG_PAIR_IDENTITY', '').strip()
+pair_code = os.environ.get('CFG_PAIR_CODE', '').strip()
+pair_code_hash = os.environ.get('CFG_PAIR_CODE_HASH', '').strip()
+reolink_enabled = os.environ.get('CFG_REOLINK_AUTOPROVISION', '0').strip() == '1'
+reolink_username = os.environ.get('CFG_REOLINK_USERNAME', 'admin').strip() or 'admin'
+reolink_password = os.environ.get('CFG_REOLINK_PASSWORD', '').strip()
+reolink_desired_password = os.environ.get('CFG_REOLINK_DESIRED_PASSWORD', '').strip()
+reolink_generate_password = os.environ.get('CFG_REOLINK_GENERATE_PASSWORD', '0').strip() == '1'
+reolink_hint_ip = os.environ.get('CFG_REOLINK_HINT_IP', '').strip()
+
+raw.setdefault('storage', {})['root'] = storage_root
 raw.setdefault('update', {})['enabled'] = True
-raw['update']['interval_secs'] = int('${UPDATE_INTERVAL_SECS}')
-raw['update']['source_dir'] = '${SOURCE_DIR}'
-raw['update']['branch'] = '${REF}'
-raw['update']['script_path'] = '${SELF_UPDATE_BIN}'
+raw['update']['interval_secs'] = update_interval
+raw['update']['source_dir'] = source_dir
+raw['update']['branch'] = ref
+raw['update']['script_path'] = update_script
+
+raw.setdefault('api', {})['identity_id'] = identity_id
+raw['api']['allow_unsigned_hello_mvp'] = allow_unsigned
+if public_ws_url:
+    raw['api']['public_ws_url'] = public_ws_url
+if authorized:
+    raw['api']['authorized_device_pks'] = sorted(set(authorized))
+
+swarm = raw.setdefault('swarm', {})
+if swarm_peers:
+    peers = [x for x in swarm.get('peers', []) if isinstance(x, str)]
+    for peer in swarm_peers:
+        if peer not in peers:
+            peers.append(peer)
+    swarm['peers'] = peers
+
+if zone_keys:
+    swarm['zones'] = [{'key': key, 'name': 'Configured Zone'} for key in zone_keys]
+
+if pair_identity:
+    raw['pair_identity_label'] = pair_identity
+if pair_code:
+    raw['pair_code'] = pair_code
+if not pair_code_hash and pair_identity and pair_code:
+    digest = hashlib.sha256(f"{pair_identity}|{pair_code}".encode('utf-8')).digest()
+    pair_code_hash = base64.urlsafe_b64encode(digest).decode('ascii').rstrip('=')
+if pair_code_hash:
+    raw['pair_code_hash'] = pair_code_hash
+raw.setdefault('pair_request_interval_secs', 15)
+raw.setdefault('pair_request_attempts', 24)
+
+autop = raw.setdefault('autoprovision', {})
+autop['reolink_enabled'] = reolink_enabled
+autop['reolink_username'] = reolink_username
+autop['reolink_password'] = reolink_password
+autop['reolink_desired_password'] = reolink_desired_password
+autop['reolink_generate_password'] = reolink_generate_password
+autop.setdefault('reolink_discover_timeout_secs', 3)
+autop['reolink_hint_ip'] = reolink_hint_ip
+
 path.write_text(json.dumps(raw, indent=2) + '\n', encoding='utf-8')
 PY
+
 
 UNIT_PATH="/etc/systemd/system/${SERVICE_NAME}.service"
 log "writing systemd unit: ${UNIT_PATH}"
@@ -371,7 +718,7 @@ if [[ "$APPLY_HARDENING" -eq 1 ]]; then
   if [[ "$ALLOW_NTP_HOST" -eq 0 ]]; then
     harden_args+=(--no-ntp-host)
   fi
-  run_sudo bash "$SRC_DIR/scripts/linux/harden-camera-interface.sh" "${harden_args[@]}"
+  run_sudo bash "$HARDEN_SCRIPT_SRC" "${harden_args[@]}"
 fi
 
 log "installation complete"

--- a/scripts/linux/package.sh
+++ b/scripts/linux/package.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+BIN_PATH="${BIN_PATH:-$REPO_ROOT/target/release/constitute-nvr}"
+ARTIFACT_NAME="${ARTIFACT_NAME:-constitute-nvr-linux-amd64.tar.gz}"
+STAGE_DIR="${STAGE_DIR:-$REPO_ROOT/dist/linux}"
+
+artifact_path="$ARTIFACT_NAME"
+if [[ "$artifact_path" != /* ]]; then
+  artifact_path="$REPO_ROOT/$artifact_path"
+fi
+
+if [[ ! -f "$BIN_PATH" ]]; then
+  if [[ -f "${BIN_PATH}.exe" ]]; then
+    echo "Found Windows release binary at ${BIN_PATH}.exe; Linux artifact packaging must run on Linux/WSL." >&2
+    echo "Build first on Linux/WSL: cargo build --release" >&2
+    exit 1
+  fi
+  echo "Binary not found: $BIN_PATH" >&2
+  echo "Build first: cargo build --release" >&2
+  exit 1
+fi
+
+rm -rf "$STAGE_DIR"
+mkdir -p "$STAGE_DIR"
+
+install -m 0755 "$BIN_PATH" "$STAGE_DIR/constitute-nvr"
+install -m 0644 "$REPO_ROOT/config.example.json" "$STAGE_DIR/config.example.json"
+install -m 0644 "$REPO_ROOT/README.md" "$STAGE_DIR/README.md"
+cp -R "$REPO_ROOT/scripts" "$STAGE_DIR/scripts"
+find "$STAGE_DIR/scripts" -type f -name "*.sh" -exec chmod 0755 {} \;
+
+rm -f "$artifact_path"
+tar -C "$STAGE_DIR" -czf "$artifact_path" .
+
+echo "Packaged: $artifact_path"

--- a/scripts/linux/self-update-release.sh
+++ b/scripts/linux/self-update-release.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_OWNER="${REPO_OWNER:-Aux0x7F}"
+REPO_NAME="${REPO_NAME:-constitute-nvr}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/opt/constitute-nvr}"
+SERVICE_NAME="${SERVICE_NAME:-constitute-nvr}"
+TRY_RESTART=0
+FORCE=0
+
+# Compatibility with source-based updater invocation args.
+SOURCE_DIR=""
+BRANCH=""
+REPO_URL=""
+
+CURL_PROXY_URL="${CURL_PROXY_URL:-}"
+USE_TOR=0
+TOR_SOCKS_ADDR="${TOR_SOCKS_ADDR:-127.0.0.1:9050}"
+TOR_CONTROL_ADDR="${TOR_CONTROL_ADDR:-127.0.0.1:9051}"
+TOR_ROTATE_ON_RETRY=1
+
+usage() {
+  cat <<'EOF'
+Usage: self-update-release.sh [options]
+
+Update constitute-nvr from GitHub Releases and install when binary hash changes.
+
+Options:
+  --repo-owner <owner>       GitHub owner (default: Aux0x7F)
+  --repo-name <name>         GitHub repo (default: constitute-nvr)
+  --install-prefix <path>    Install prefix (default: /opt/constitute-nvr)
+  --service-name <name>      systemd service name (default: constitute-nvr)
+  --try-restart              Restart service when binary changed
+  --force                    Reinstall even if binary hash is unchanged
+  --proxy-url <url>          Use HTTP(S) proxy for release fetches
+  --tor                      Use Tor SOCKS egress for release fetches
+  --tor-socks <host:port>    Tor SOCKS endpoint (default: 127.0.0.1:9050)
+  --tor-control <host:port>  Tor control endpoint (default: 127.0.0.1:9051)
+  --no-tor-rotate            Disable NEWNYM attempt on retry
+
+Compatibility no-op args:
+  --source-dir <path>
+  --branch <name>
+  --repo-url <url>
+EOF
+}
+
+run_sudo() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+build_curl_args() {
+  CURL_ARGS=(-fsSL)
+  if [[ -n "$CURL_PROXY_URL" ]]; then
+    CURL_ARGS+=(--proxy "$CURL_PROXY_URL")
+  fi
+  if [[ "$USE_TOR" -eq 1 ]]; then
+    CURL_ARGS+=(--proxy "socks5h://${TOR_SOCKS_ADDR}")
+  fi
+}
+
+rotate_tor_exit() {
+  [[ "$USE_TOR" -eq 1 ]] || return 0
+  [[ "$TOR_ROTATE_ON_RETRY" -eq 1 ]] || return 0
+  command -v nc >/dev/null 2>&1 || return 0
+
+  local host="${TOR_CONTROL_ADDR%:*}"
+  local port="${TOR_CONTROL_ADDR##*:}"
+  [[ -n "$host" && -n "$port" && "$host" != "$port" ]] || return 0
+
+  {
+    printf 'AUTHENTICATE\r\n'
+    printf 'SIGNAL NEWNYM\r\n'
+    printf 'QUIT\r\n'
+  } | nc -w 2 "$host" "$port" >/dev/null 2>&1 || true
+}
+
+verify_tor_proxy() {
+  [[ "$USE_TOR" -eq 1 ]] || return 0
+  if ! curl "${CURL_ARGS[@]}" --max-time 12 -I https://github.com >/dev/null 2>&1; then
+    echo "Tor proxy check failed at socks5h://${TOR_SOCKS_ADDR}" >&2
+    exit 1
+  fi
+}
+
+download_with_retry() {
+  local url="$1"
+  local out="$2"
+  local attempt
+  for attempt in 1 2 3; do
+    if curl "${CURL_ARGS[@]}" "$url" -o "$out"; then
+      return 0
+    fi
+    rotate_tor_exit
+    sleep "$attempt"
+  done
+  return 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo-owner)
+      REPO_OWNER="${2:?missing value for --repo-owner}"
+      shift 2
+      ;;
+    --repo-name)
+      REPO_NAME="${2:?missing value for --repo-name}"
+      shift 2
+      ;;
+    --install-prefix)
+      INSTALL_PREFIX="${2:?missing value for --install-prefix}"
+      shift 2
+      ;;
+    --service-name)
+      SERVICE_NAME="${2:?missing value for --service-name}"
+      shift 2
+      ;;
+    --try-restart)
+      TRY_RESTART=1
+      shift
+      ;;
+    --force)
+      FORCE=1
+      shift
+      ;;
+    --proxy-url)
+      CURL_PROXY_URL="${2:?missing value for --proxy-url}"
+      shift 2
+      ;;
+    --tor)
+      USE_TOR=1
+      shift
+      ;;
+    --tor-socks)
+      USE_TOR=1
+      TOR_SOCKS_ADDR="${2:?missing value for --tor-socks}"
+      shift 2
+      ;;
+    --tor-control)
+      TOR_CONTROL_ADDR="${2:?missing value for --tor-control}"
+      shift 2
+      ;;
+    --no-tor-rotate)
+      TOR_ROTATE_ON_RETRY=0
+      shift
+      ;;
+    --source-dir)
+      SOURCE_DIR="${2:-}"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="${2:-}"
+      shift 2
+      ;;
+    --repo-url)
+      REPO_URL="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd curl
+require_cmd grep
+require_cmd sha256sum
+require_cmd tar
+build_curl_args
+verify_tor_proxy
+
+BASE="https://github.com/${REPO_OWNER}/${REPO_NAME}/releases/latest/download"
+LINUX_ASSET="constitute-nvr-linux-amd64.tar.gz"
+SUMS_NAME="SHA256SUMS"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+if ! download_with_retry "${BASE}/${LINUX_ASSET}" "${tmpdir}/${LINUX_ASSET}"; then
+  echo "Failed to download ${LINUX_ASSET}" >&2
+  exit 1
+fi
+if ! download_with_retry "${BASE}/${SUMS_NAME}" "${tmpdir}/${SUMS_NAME}"; then
+  echo "Failed to download ${SUMS_NAME}" >&2
+  exit 1
+fi
+
+if ! grep " ${LINUX_ASSET}$" "${tmpdir}/${SUMS_NAME}" | (cd "$tmpdir" && sha256sum -c -); then
+  echo "Checksum verification failed for ${LINUX_ASSET}" >&2
+  exit 1
+fi
+
+mkdir -p "$tmpdir/extract"
+tar -C "$tmpdir/extract" -xzf "${tmpdir}/${LINUX_ASSET}"
+
+incoming_bin="$tmpdir/extract/constitute-nvr"
+incoming_update_script="$tmpdir/extract/scripts/linux/self-update-release.sh"
+
+if [[ ! -f "$incoming_bin" ]]; then
+  echo "Release artifact missing constitute-nvr binary" >&2
+  exit 1
+fi
+
+installed_bin="${INSTALL_PREFIX}/bin/constitute-nvr"
+needs_install=1
+if [[ "$FORCE" -eq 0 && -f "$installed_bin" ]]; then
+  current_hash="$(sha256sum "$installed_bin" | awk '{print $1}')"
+  incoming_hash="$(sha256sum "$incoming_bin" | awk '{print $1}')"
+  if [[ "$current_hash" == "$incoming_hash" ]]; then
+    needs_install=0
+    echo "[self-update] no binary change detected"
+  fi
+fi
+
+if [[ "$needs_install" -eq 1 ]]; then
+  run_sudo install -d "$INSTALL_PREFIX/bin"
+  run_sudo install -m 0755 "$incoming_bin" "$installed_bin"
+  run_sudo ln -sf "$installed_bin" /usr/local/bin/constitute-nvr
+
+  if [[ -f "$incoming_update_script" ]]; then
+    run_sudo install -m 0755 "$incoming_update_script" /usr/local/bin/constitute-nvr-self-update
+  fi
+
+  echo "[self-update] installed latest release"
+  if [[ "$TRY_RESTART" -eq 1 ]]; then
+    run_sudo systemctl restart "$SERVICE_NAME" || true
+  fi
+fi

--- a/src/api.rs
+++ b/src/api.rs
@@ -21,6 +21,8 @@ use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tracing::{debug, info, warn};
 
+const INSECURE_HELLO_SECRET_HEX: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
 #[derive(Clone)]
 pub struct ApiState {
     pub cfg: Arc<Mutex<Config>>,
@@ -242,7 +244,7 @@ async fn handle_ws(mut socket: WebSocket, state: Arc<ApiState>) {
 
     let (session_key, server_key) = match crypto::derive_session_key(
         &cfg_snapshot.api.server_secret_hex,
-        &cfg_snapshot.api.identity_secret_hex,
+        session_identity_secret_hex(&cfg_snapshot),
         &hello.client_key,
         &context,
     ) {
@@ -367,6 +369,10 @@ fn validate_hello(cfg: &Config, hello: &HelloReq) -> Result<()> {
         return Err(anyhow!("hello timestamp outside allowed skew"));
     }
 
+    if cfg.api.allow_unsigned_hello_mvp {
+        return Ok(());
+    }
+
     let proof_ok = crypto::verify_hello_proof(
         &cfg.api.identity_secret_hex,
         &hello.identity_id,
@@ -381,6 +387,14 @@ fn validate_hello(cfg: &Config, hello: &HelloReq) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn session_identity_secret_hex(cfg: &Config) -> &str {
+    if cfg.api.allow_unsigned_hello_mvp {
+        INSECURE_HELLO_SECRET_HEX
+    } else {
+        &cfg.api.identity_secret_hex
+    }
 }
 
 async fn handle_command(

--- a/src/api.rs
+++ b/src/api.rs
@@ -2,6 +2,7 @@ use crate::camera;
 use crate::camera::RecorderManager;
 use crate::config::{CameraConfig, Config};
 use crate::crypto;
+use crate::reolink;
 use crate::storage::StorageManager;
 use crate::util;
 use anyhow::{Result, anyhow};
@@ -112,6 +113,22 @@ enum ClientCommand {
     ListSources,
     ListSourceStates,
     DiscoverOnvif,
+    DiscoverReolink,
+    ProbeReolink {
+        ip: String,
+    },
+    ReadReolinkState {
+        request: reolink::ReolinkConnectRequest,
+    },
+    ApplyReolinkState {
+        request: reolink::ReolinkStateApplyRequest,
+    },
+    SetupReolink {
+        request: reolink::ReolinkSetupRequest,
+    },
+    BootstrapReolink {
+        request: reolink::ReolinkBootstrapRequest,
+    },
     UpsertSource {
         source: SourceUpsert,
     },
@@ -408,6 +425,84 @@ async fn handle_command(
                     "ok": true,
                     "cmd": "discover_onvif",
                     "cameras": found,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::DiscoverReolink => {
+            let found = reolink::discover(3).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "discover_reolink",
+                    "devices": found,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::ProbeReolink { ip } => {
+            let result = reolink::probe(&ip, 3).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "probe_reolink",
+                    "result": result,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::ReadReolinkState { request } => {
+            let result = reolink::read_state(request).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "read_reolink_state",
+                    "result": result,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::ApplyReolinkState { request } => {
+            let result = reolink::apply_state(request).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "apply_reolink_state",
+                    "result": result,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::SetupReolink { request } => {
+            let result = reolink::setup(request).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "setup_reolink",
+                    "result": result,
+                }),
+            )
+            .await?;
+        }
+        ClientCommand::BootstrapReolink { request } => {
+            let result = reolink::bootstrap(request).await?;
+            send_cipher_json(
+                socket,
+                key,
+                &json!({
+                    "ok": true,
+                    "cmd": "bootstrap_reolink",
+                    "result": result,
                 }),
             )
             .await?;

--- a/src/api.rs
+++ b/src/api.rs
@@ -496,7 +496,71 @@ async fn handle_command(
             .await?;
         }
         ClientCommand::SetupReolink { request } => {
-            let result = reolink::setup(request).await?;
+            let request = request.normalized()?;
+            let result = reolink::setup(request.clone()).await?;
+
+            let effective_password = if !result.generated_password.trim().is_empty() {
+                result.generated_password.clone()
+            } else if !request.desired_password.trim().is_empty() {
+                request.desired_password.clone()
+            } else {
+                request.password.clone()
+            };
+
+            let onvif_port = if result.bridge.after_advanced.i_onvif_port_enable != 0 {
+                result.bridge.after_advanced.i_onvif_port.max(1) as u16
+            } else if result.probe.onvif_port_open {
+                8000
+            } else {
+                8000
+            };
+
+            let rtsp_port = if result.bridge.after_advanced.i_rtsp_port_enable != 0 {
+                result.bridge.after_advanced.i_rtsp_port.max(1) as u16
+            } else if result.probe.rtsp_port_open {
+                554
+            } else {
+                554
+            };
+
+            let discovered = reolink::discover_with_hint(&request.ip, 2)
+                .await
+                .unwrap_or_default();
+            let discovered_entry = discovered
+                .into_iter()
+                .find(|d| d.ip.trim() == request.ip.trim());
+            let uid = discovered_entry
+                .as_ref()
+                .map(|d| d.uid.clone())
+                .unwrap_or_default();
+            let model = discovered_entry
+                .as_ref()
+                .map(|d| d.model.clone())
+                .unwrap_or_default();
+
+            let source_id = build_reolink_source_id(&uid, &request.ip);
+            let source_name = if model.trim().is_empty() {
+                format!("Reolink {}", request.ip)
+            } else {
+                model
+            };
+            let camera_cfg = CameraConfig {
+                source_id: source_id.clone(),
+                name: source_name,
+                onvif_host: request.ip.clone(),
+                onvif_port,
+                rtsp_url: format!(
+                    "rtsp://{}:{}@{}:{}/h264Preview_01_main",
+                    request.username, effective_password, request.ip, rtsp_port
+                ),
+                username: request.username.clone(),
+                password: effective_password,
+                enabled: true,
+                segment_secs: 10,
+            };
+
+            persist_camera_source(state, camera_cfg.clone()).await?;
+
             send_cipher_json(
                 socket,
                 key,
@@ -504,6 +568,7 @@ async fn handle_command(
                     "ok": true,
                     "cmd": "setup_reolink",
                     "result": result,
+                    "source": camera_cfg,
                 }),
             )
             .await?;
@@ -523,26 +588,7 @@ async fn handle_command(
         }
         ClientCommand::UpsertSource { source } => {
             let camera_cfg = source.into_camera()?;
-            let storage_root = {
-                let mut guard = state.cfg.lock().await;
-                if let Some(existing) = guard
-                    .cameras
-                    .iter_mut()
-                    .find(|c| c.source_id == camera_cfg.source_id)
-                {
-                    *existing = camera_cfg.clone();
-                } else {
-                    guard.cameras.push(camera_cfg.clone());
-                }
-                let snapshot = guard.clone();
-                snapshot.persist(&state.cfg_path)?;
-                snapshot.storage_root()
-            };
-
-            state
-                .recorder
-                .upsert_camera(storage_root, camera_cfg.clone())
-                .await;
+            persist_camera_source(state, camera_cfg.clone()).await?;
 
             send_cipher_json(
                 socket,
@@ -641,6 +687,46 @@ async fn handle_command(
         }
     }
     Ok(())
+}
+
+async fn persist_camera_source(state: &ApiState, camera_cfg: CameraConfig) -> Result<()> {
+    let storage_root = {
+        let mut guard = state.cfg.lock().await;
+        if let Some(existing) = guard
+            .cameras
+            .iter_mut()
+            .find(|c| c.source_id == camera_cfg.source_id || c.onvif_host == camera_cfg.onvif_host)
+        {
+            *existing = camera_cfg.clone();
+        } else {
+            guard.cameras.push(camera_cfg.clone());
+        }
+        let snapshot = guard.clone();
+        snapshot.persist(&state.cfg_path)?;
+        snapshot.storage_root()
+    };
+
+    state
+        .recorder
+        .upsert_camera(storage_root, camera_cfg)
+        .await;
+
+    Ok(())
+}
+
+fn build_reolink_source_id(uid: &str, ip: &str) -> String {
+    let key = if uid.trim().is_empty() { ip.trim() } else { uid.trim() };
+    let sanitized = key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>();
+    format!("reolink-{}", sanitized.trim_matches('-'))
 }
 
 async fn send_cipher_error(socket: &mut WebSocket, key: &[u8], message: &str) -> Result<()> {

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -75,14 +75,8 @@ impl RecorderManager {
             Some(tokio::spawn(async move {
                 if let Err(err) = record_loop(storage_root, camera, Arc::clone(&state_ref)).await {
                     warn!(error = %err, source = %source_id, "camera recorder exited");
-                    update_state(
-                        &state_ref,
-                        "failed",
-                        0,
-                        String::from(err.to_string()),
-                        None,
-                    )
-                    .await;
+                    update_state(&state_ref, "failed", 0, String::from(err.to_string()), None)
+                        .await;
                 }
             }))
         } else {
@@ -90,13 +84,7 @@ impl RecorderManager {
         };
 
         let mut guard = self.inner.lock().await;
-        guard.insert(
-            cam.source_id.clone(),
-            RuntimeEntry {
-                state,
-                handle,
-            },
-        );
+        guard.insert(cam.source_id.clone(), RuntimeEntry { state, handle });
     }
 
     pub async fn remove_camera(&self, source_id: &str) -> bool {

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,6 +35,8 @@ pub struct ApiConfig {
     pub identity_id: String,
     #[serde(default)]
     pub authorized_device_pks: Vec<String>,
+    #[serde(default)]
+    pub allow_unsigned_hello_mvp: bool,
     pub identity_secret_hex: String,
     pub server_secret_hex: String,
 }
@@ -266,6 +268,7 @@ impl Config {
                 public_ws_url: String::new(),
                 identity_id: "REPLACE_WITH_IDENTITY_ID".to_string(),
                 authorized_device_pks: Vec::new(),
+                allow_unsigned_hello_mvp: false,
                 identity_secret_hex: random_hex(32),
                 server_secret_hex: random_hex(32),
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,6 +64,38 @@ pub struct UpdateConfig {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AutoProvisionConfig {
+    #[serde(default)]
+    pub reolink_enabled: bool,
+    #[serde(default = "default_reolink_username")]
+    pub reolink_username: String,
+    #[serde(default)]
+    pub reolink_password: String,
+    #[serde(default)]
+    pub reolink_desired_password: String,
+    #[serde(default)]
+    pub reolink_generate_password: bool,
+    #[serde(default = "default_reolink_discover_timeout_secs")]
+    pub reolink_discover_timeout_secs: u64,
+    #[serde(default)]
+    pub reolink_hint_ip: String,
+}
+
+impl Default for AutoProvisionConfig {
+    fn default() -> Self {
+        Self {
+            reolink_enabled: false,
+            reolink_username: default_reolink_username(),
+            reolink_password: String::new(),
+            reolink_desired_password: String::new(),
+            reolink_generate_password: false,
+            reolink_discover_timeout_secs: default_reolink_discover_timeout_secs(),
+            reolink_hint_ip: String::new(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CameraConfig {
     pub source_id: String,
     pub name: String,
@@ -119,7 +151,19 @@ pub struct Config {
     pub storage: StorageConfig,
     pub update: UpdateConfig,
     #[serde(default)]
+    pub pair_identity_label: String,
+    #[serde(default)]
+    pub pair_code: String,
+    #[serde(default)]
+    pub pair_code_hash: String,
+    #[serde(default = "default_pair_request_interval_secs")]
+    pub pair_request_interval_secs: u64,
+    #[serde(default = "default_pair_request_attempts")]
+    pub pair_request_attempts: u32,
+    #[serde(default)]
     pub ui: UiModuleConfig,
+    #[serde(default)]
+    pub autoprovision: AutoProvisionConfig,
     #[serde(default)]
     pub cameras: Vec<CameraConfig>,
 }
@@ -229,11 +273,31 @@ impl Config {
             }
         }
 
+        if self.autoprovision.reolink_username.trim().is_empty() {
+            self.autoprovision.reolink_username = default_reolink_username();
+            changed = true;
+        }
+
+        if self.autoprovision.reolink_discover_timeout_secs == 0 {
+            self.autoprovision.reolink_discover_timeout_secs = default_reolink_discover_timeout_secs();
+            changed = true;
+        }
+
         if self.swarm.zones.is_empty() {
             self.swarm.zones.push(ZoneConfig {
                 key: short_hex(10),
                 name: "Default Zone".to_string(),
             });
+            changed = true;
+        }
+
+        if self.pair_request_interval_secs == 0 {
+            self.pair_request_interval_secs = default_pair_request_interval_secs();
+            changed = true;
+        }
+
+        if self.pair_request_attempts == 0 {
+            self.pair_request_attempts = default_pair_request_attempts();
             changed = true;
         }
 
@@ -284,7 +348,13 @@ impl Config {
                 branch: default_update_branch(),
                 script_path: default_update_script(),
             },
+            pair_identity_label: String::new(),
+            pair_code: String::new(),
+            pair_code_hash: String::new(),
+            pair_request_interval_secs: default_pair_request_interval_secs(),
+            pair_request_attempts: default_pair_request_attempts(),
             ui: UiModuleConfig::default(),
+            autoprovision: AutoProvisionConfig::default(),
             cameras: Vec::new(),
         }
     }
@@ -318,6 +388,14 @@ fn default_onvif_port() -> u16 {
     80
 }
 
+fn default_reolink_username() -> String {
+    "admin".to_string()
+}
+
+fn default_reolink_discover_timeout_secs() -> u64 {
+    3
+}
+
 fn default_update_enabled() -> bool {
     true
 }
@@ -336,6 +414,14 @@ fn default_update_branch() -> String {
 
 fn default_update_script() -> String {
     "/usr/local/bin/constitute-nvr-self-update".to_string()
+}
+
+fn default_pair_request_interval_secs() -> u64 {
+    15
+}
+
+fn default_pair_request_attempts() -> u32 {
+    24
 }
 
 fn default_ui_repo() -> String {
@@ -419,5 +505,15 @@ mod tests {
         cfg.apply_defaults();
         assert!(cfg.ui.manifest_url.contains("raw.githubusercontent.com"));
         assert!(cfg.ui.manifest_url.ends_with("/app.manifest.json"));
+    }
+
+    #[test]
+    fn apply_defaults_sets_pair_enrollment_defaults() {
+        let mut cfg = Config::default_generated();
+        cfg.pair_request_interval_secs = 0;
+        cfg.pair_request_attempts = 0;
+        cfg.apply_defaults();
+        assert_eq!(cfg.pair_request_interval_secs, 15);
+        assert_eq!(cfg.pair_request_attempts, 24);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,7 +94,7 @@ async fn main() -> Result<()> {
         "constitute-nvr starting"
     );
 
-    api::run(cfg, storage).await
+    api::run(cfg, cfg_path, storage, recorder).await
 }
 
 fn init_logging(level: &str) {
@@ -108,3 +108,4 @@ fn init_logging(level: &str) {
         .compact()
         .init();
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,8 +14,8 @@ mod util;
 
 use anyhow::Result;
 use clap::Parser;
-use config::Config;
-use std::path::PathBuf;
+use config::{CameraConfig, Config};
+use std::path::{Path, PathBuf};
 use tracing::{info, warn};
 
 #[derive(Parser, Debug)]
@@ -154,7 +154,7 @@ async fn main() -> Result<()> {
     let cfg_path = args
         .config
         .unwrap_or_else(|| PathBuf::from("/etc/constitute-nvr/config.json"));
-    let (cfg, created) = Config::load_or_create(&cfg_path)?;
+    let (mut cfg, created) = Config::load_or_create(&cfg_path)?;
 
     if created {
         warn!(path = %cfg_path.display(), "created new config file; update placeholders before production use");
@@ -165,6 +165,10 @@ async fn main() -> Result<()> {
             placeholder = %config::DEFAULT_STORAGE_PLACEHOLDER,
             "storage root is still placeholder; set a dedicated mount path"
         );
+    }
+
+    if let Err(err) = run_reolink_autoprovision(&mut cfg, &cfg_path).await {
+        warn!(error = %err, "reolink auto-provision failed");
     }
 
     let storage =
@@ -206,6 +210,154 @@ async fn main() -> Result<()> {
     api::run(cfg, cfg_path, storage, recorder).await
 }
 
+
+async fn run_reolink_autoprovision(cfg: &mut Config, cfg_path: &Path) -> Result<()> {
+    if !cfg.autoprovision.reolink_enabled {
+        return Ok(());
+    }
+
+    let username = cfg.autoprovision.reolink_username.trim().to_string();
+    if username.is_empty() {
+        warn!("reolink auto-provision skipped: username is empty");
+        return Ok(());
+    }
+
+    if cfg.autoprovision.reolink_password.trim().is_empty()
+        && cfg.autoprovision.reolink_desired_password.trim().is_empty()
+        && !cfg.autoprovision.reolink_generate_password
+    {
+        warn!("reolink auto-provision skipped: no password material configured");
+        return Ok(());
+    }
+
+    let timeout = cfg.autoprovision.reolink_discover_timeout_secs.max(1);
+    let hint_ip = cfg.autoprovision.reolink_hint_ip.trim().to_string();
+    let discovered = if hint_ip.is_empty() {
+        reolink::discover(timeout).await?
+    } else {
+        reolink::discover_with_hint(&hint_ip, timeout).await?
+    };
+
+    if discovered.is_empty() {
+        info!("reolink auto-provision: no cameras discovered");
+        return Ok(());
+    }
+
+    let mut changed = false;
+    for device in discovered {
+        let ip = device.ip.trim().to_string();
+        if ip.is_empty() {
+            continue;
+        }
+
+        let setup_req = reolink::ReolinkSetupRequest {
+            ip: ip.clone(),
+            username: username.clone(),
+            password: cfg.autoprovision.reolink_password.clone(),
+            desired_password: cfg.autoprovision.reolink_desired_password.clone(),
+            generate_password: cfg.autoprovision.reolink_generate_password,
+            normal: None,
+            advanced: None,
+            p2p: None,
+        };
+
+        let setup = match reolink::setup(setup_req).await {
+            Ok(result) => result,
+            Err(err) => {
+                warn!(ip = %ip, error = %err, "reolink auto-provision setup failed");
+                continue;
+            }
+        };
+
+        let effective_password = if !setup.generated_password.is_empty() {
+            setup.generated_password.clone()
+        } else if !cfg.autoprovision.reolink_desired_password.trim().is_empty() {
+            cfg.autoprovision.reolink_desired_password.clone()
+        } else {
+            cfg.autoprovision.reolink_password.clone()
+        };
+
+        let onvif_port = if setup.bridge.after_advanced.i_onvif_port_enable != 0 {
+            setup.bridge.after_advanced.i_onvif_port.max(1)
+        } else if setup.probe.onvif_port_open {
+            8000
+        } else {
+            8000
+        };
+        let rtsp_port = if setup.bridge.after_advanced.i_rtsp_port_enable != 0 {
+            setup.bridge.after_advanced.i_rtsp_port.max(1)
+        } else if setup.probe.rtsp_port_open {
+            554
+        } else {
+            554
+        };
+
+        let source_id = reolink_source_id(&device.uid, &ip);
+        let source_name = if device.model.trim().is_empty() {
+            format!("Reolink {}", ip)
+        } else {
+            device.model.clone()
+        };
+        let rtsp_url = format!(
+            "rtsp://{}:{}@{}:{}/h264Preview_01_main",
+            username,
+            effective_password,
+            ip,
+            rtsp_port
+        );
+
+        let mut found = false;
+        for cam in &mut cfg.cameras {
+            if cam.source_id == source_id || cam.onvif_host == ip {
+                cam.source_id = source_id.clone();
+                cam.name = source_name.clone();
+                cam.onvif_host = ip.clone();
+                cam.onvif_port = onvif_port as u16;
+                cam.rtsp_url = rtsp_url.clone();
+                cam.username = username.clone();
+                cam.password = effective_password.clone();
+                cam.enabled = true;
+                found = true;
+                changed = true;
+                break;
+            }
+        }
+
+        if !found {
+            cfg.cameras.push(CameraConfig {
+                source_id: source_id.clone(),
+                name: source_name.clone(),
+                onvif_host: ip.clone(),
+                onvif_port: onvif_port as u16,
+                rtsp_url: rtsp_url.clone(),
+                username: username.clone(),
+                password: effective_password.clone(),
+                enabled: true,
+                segment_secs: 10,
+            });
+            changed = true;
+        }
+
+        info!(source_id = %source_id, ip = %ip, onvif_port, rtsp_port, "reolink auto-provisioned camera source");
+    }
+
+    if changed {
+        cfg.persist(cfg_path)?;
+        info!(path = %cfg_path.display(), camera_count = cfg.cameras.len(), "persisted auto-provisioned camera config");
+    }
+
+    Ok(())
+}
+
+fn reolink_source_id(uid: &str, ip: &str) -> String {
+    let key = if uid.trim().is_empty() { ip.trim() } else { uid.trim() };
+    let sanitized = key
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch.to_ascii_lowercase() } else { '-' })
+        .collect::<String>();
+    format!("reolink-{}", sanitized.trim_matches('-'))
+}
+
 fn init_logging(level: &str) {
     let env = tracing_subscriber::EnvFilter::try_new(level)
         .or_else(|_| tracing_subscriber::EnvFilter::try_new("info"))
@@ -217,3 +369,4 @@ fn init_logging(level: &str) {
         .compact()
         .init();
 }
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,10 @@ mod camera;
 mod config;
 mod crypto;
 mod nostr;
+mod reolink;
+mod reolink_cgi;
+#[allow(dead_code)]
+mod reolink_proto;
 mod storage;
 mod swarm;
 mod update;
@@ -29,12 +33,123 @@ struct Args {
     once: bool,
     #[arg(long)]
     discover_onvif: bool,
+    #[arg(long)]
+    discover_reolink: bool,
+    #[arg(long)]
+    discover_reolink_hint_ip: Option<String>,
+    #[arg(long)]
+    probe_reolink_ip: Option<String>,
+    #[arg(long)]
+    setup_reolink_ip: Option<String>,
+    #[arg(long, default_value = "admin")]
+    setup_reolink_username: String,
+    #[arg(long)]
+    setup_reolink_password: Option<String>,
+    #[arg(long)]
+    setup_reolink_desired_password: Option<String>,
+    #[arg(long)]
+    setup_reolink_generate_password: bool,
+    #[arg(long)]
+    bootstrap_reolink_server_ip: Option<String>,
+    #[arg(long, default_value = "192.168.1.20")]
+    bootstrap_reolink_lease_ip: String,
+    #[arg(long)]
+    bootstrap_reolink_target_mac: Option<String>,
+    #[arg(long, default_value_t = 20)]
+    bootstrap_reolink_timeout_secs: u64,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse();
     init_logging(&args.log_level);
+
+    if args.discover_onvif {
+        let discovered = camera::discover_onvif(3).await?;
+        println!("{}", serde_json::to_string_pretty(&discovered)?);
+        return Ok(());
+    }
+
+    if args.discover_reolink {
+        let discovered = if let Some(hint) = &args.discover_reolink_hint_ip {
+            reolink::discover_with_hint(hint, 3).await?
+        } else {
+            reolink::discover(3).await?
+        };
+        println!("{}", serde_json::to_string_pretty(&discovered)?);
+        return Ok(());
+    }
+
+    if let Some(ip) = &args.probe_reolink_ip {
+        let probe = reolink::probe(ip, 3).await?;
+        println!("{}", serde_json::to_string_pretty(&probe)?);
+        return Ok(());
+    }
+
+    if let Some(ip) = &args.setup_reolink_ip {
+        let result = reolink::setup(reolink::ReolinkSetupRequest {
+            ip: ip.clone(),
+            username: args.setup_reolink_username.clone(),
+            password: args.setup_reolink_password.clone().unwrap_or_default(),
+            desired_password: args
+                .setup_reolink_desired_password
+                .clone()
+                .unwrap_or_default(),
+            generate_password: args.setup_reolink_generate_password,
+            normal: None,
+            advanced: None,
+            p2p: None,
+        })
+        .await?;
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    if let Some(server_ip) = &args.bootstrap_reolink_server_ip {
+        let bootstrap = reolink::bootstrap(reolink::ReolinkBootstrapRequest {
+            server_ip: server_ip.clone(),
+            lease_ip: args.bootstrap_reolink_lease_ip.clone(),
+            target_mac: args
+                .bootstrap_reolink_target_mac
+                .clone()
+                .unwrap_or_default(),
+            timeout_secs: args.bootstrap_reolink_timeout_secs,
+            subnet_mask: "255.255.255.0".to_string(),
+            router_ip: String::new(),
+            dns_ip: String::new(),
+        })
+        .await?;
+
+        let should_setup = args.setup_reolink_password.is_some()
+            || args.setup_reolink_desired_password.is_some()
+            || args.setup_reolink_generate_password;
+        if should_setup {
+            let setup = reolink::setup(reolink::ReolinkSetupRequest {
+                ip: bootstrap.assigned_ip.clone(),
+                username: args.setup_reolink_username.clone(),
+                password: args.setup_reolink_password.clone().unwrap_or_default(),
+                desired_password: args
+                    .setup_reolink_desired_password
+                    .clone()
+                    .unwrap_or_default(),
+                generate_password: args.setup_reolink_generate_password,
+                normal: None,
+                advanced: None,
+                p2p: None,
+            })
+            .await?;
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&serde_json::json!({
+                    "bootstrap": bootstrap,
+                    "setup": setup,
+                }))?
+            );
+        } else {
+            println!("{}", serde_json::to_string_pretty(&bootstrap)?);
+        }
+        return Ok(());
+    }
 
     let cfg_path = args
         .config
@@ -56,12 +171,6 @@ async fn main() -> Result<()> {
         storage::StorageManager::new(cfg.storage_root(), &cfg.storage.encryption_key_hex)?;
     storage.ensure_dirs().await?;
     storage.start_encryptor(cfg.storage.encrypt_interval_secs);
-
-    if args.discover_onvif {
-        let discovered = camera::discover_onvif(3).await?;
-        println!("{}", serde_json::to_string_pretty(&discovered)?);
-        return Ok(());
-    }
 
     let recorder = camera::RecorderManager::new();
     recorder.ensure_started(&cfg).await;
@@ -108,4 +217,3 @@ fn init_logging(level: &str) {
         .compact()
         .init();
 }
-

--- a/src/reolink.rs
+++ b/src/reolink.rs
@@ -1,0 +1,1195 @@
+use crate::{camera, reolink_cgi, reolink_proto};
+use anyhow::{Context, Result, anyhow};
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::env;
+use std::net::{Ipv4Addr, SocketAddrV4};
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::str::FromStr;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use tokio::net::{TcpStream, UdpSocket};
+use tokio::process::Command;
+use tokio::time::{Duration, Instant, sleep, timeout};
+
+const DISCOVERY_PROBE: [u8; 4] = [0xaa, 0xaa, 0x00, 0x00];
+const DHCP_COOKIE: [u8; 4] = [0x63, 0x82, 0x53, 0x63];
+const DHCP_DISCOVER: u8 = 1;
+const DHCP_OFFER: u8 = 2;
+const DHCP_REQUEST: u8 = 3;
+const DHCP_ACK: u8 = 5;
+const DHCP_END: u8 = 255;
+const GENERATED_DEVICE_PASSWORD_LEN: usize = 24;
+const DEVICE_PASSWORD_CHARSET: &[u8] =
+    b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789-_";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkDiscovery {
+    pub ip: String,
+    pub mac: String,
+    pub uid: String,
+    pub model: String,
+    pub from: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkProbe {
+    pub ip: String,
+    pub proprietary_port_open: bool,
+    pub rtsp_port_open: bool,
+    pub onvif_port_open: bool,
+    pub onvif_xaddr: String,
+    pub standards_ready: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkNormalPortConfig {
+    pub i_surv_port_enable: i32,
+    pub i_surv_port: i32,
+    pub i_http_port_enable: i32,
+    pub i_http_port: i32,
+    pub i_https_port_enable: i32,
+    pub i_https_port: i32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkAdvancedPortConfig {
+    pub i_onvif_port_enable: i32,
+    pub i_onvif_port: i32,
+    pub i_rtsp_port_enable: i32,
+    pub i_rtsp_port: i32,
+    pub i_rtmp_port_enable: i32,
+    pub i_rtmp_port: i32,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkP2PConfig {
+    pub i_enable: i32,
+    pub i_port: i32,
+    #[serde(default)]
+    pub server_domain_name: String,
+}
+
+impl From<ReolinkNormalPortConfig> for reolink_proto::ReolinkNetNormalPort {
+    fn from(value: ReolinkNormalPortConfig) -> Self {
+        Self {
+            surv_enabled: value.i_surv_port_enable != 0,
+            surv_port: value.i_surv_port.max(0) as u32,
+            http_enabled: value.i_http_port_enable != 0,
+            http_port: value.i_http_port.max(0) as u32,
+            https_enabled: value.i_https_port_enable != 0,
+            https_port: value.i_https_port.max(0) as u32,
+        }
+    }
+}
+
+impl From<reolink_proto::ReolinkNetNormalPort> for ReolinkNormalPortConfig {
+    fn from(value: reolink_proto::ReolinkNetNormalPort) -> Self {
+        Self {
+            i_surv_port_enable: i32::from(value.surv_enabled),
+            i_surv_port: value.surv_port as i32,
+            i_http_port_enable: i32::from(value.http_enabled),
+            i_http_port: value.http_port as i32,
+            i_https_port_enable: i32::from(value.https_enabled),
+            i_https_port: value.https_port as i32,
+        }
+    }
+}
+
+impl From<ReolinkAdvancedPortConfig> for reolink_proto::ReolinkNetAdvancedPort {
+    fn from(value: ReolinkAdvancedPortConfig) -> Self {
+        Self {
+            onvif_enabled: value.i_onvif_port_enable != 0,
+            onvif_port: value.i_onvif_port.max(0) as u32,
+            rtsp_enabled: value.i_rtsp_port_enable != 0,
+            rtsp_port: value.i_rtsp_port.max(0) as u32,
+            rtmp_enabled: value.i_rtmp_port_enable != 0,
+            rtmp_port: value.i_rtmp_port.max(0) as u32,
+        }
+    }
+}
+
+impl From<reolink_proto::ReolinkNetAdvancedPort> for ReolinkAdvancedPortConfig {
+    fn from(value: reolink_proto::ReolinkNetAdvancedPort) -> Self {
+        Self {
+            i_onvif_port_enable: i32::from(value.onvif_enabled),
+            i_onvif_port: value.onvif_port as i32,
+            i_rtsp_port_enable: i32::from(value.rtsp_enabled),
+            i_rtsp_port: value.rtsp_port as i32,
+            i_rtmp_port_enable: i32::from(value.rtmp_enabled),
+            i_rtmp_port: value.rtmp_port as i32,
+        }
+    }
+}
+
+impl From<ReolinkP2PConfig> for reolink_proto::ReolinkP2PCfg {
+    fn from(value: ReolinkP2PConfig) -> Self {
+        Self {
+            enabled: value.i_enable != 0,
+            port: value.i_port.max(0) as u32,
+            server_domain: value.server_domain_name,
+        }
+    }
+}
+
+impl From<reolink_proto::ReolinkP2PCfg> for ReolinkP2PConfig {
+    fn from(value: reolink_proto::ReolinkP2PCfg) -> Self {
+        Self {
+            i_enable: i32::from(value.enabled),
+            i_port: value.port as i32,
+            server_domain_name: value.server_domain,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkSetupRequest {
+    pub ip: String,
+    #[serde(default = "default_reolink_username")]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default)]
+    pub desired_password: String,
+    #[serde(default)]
+    pub generate_password: bool,
+    #[serde(default)]
+    pub normal: Option<ReolinkNormalPortConfig>,
+    #[serde(default)]
+    pub advanced: Option<ReolinkAdvancedPortConfig>,
+    #[serde(default)]
+    pub p2p: Option<ReolinkP2PConfig>,
+}
+
+impl ReolinkSetupRequest {
+    pub fn normalized(mut self) -> Result<Self> {
+        parse_ipv4(&self.ip).context("invalid ip")?;
+        if self.username.trim().is_empty() {
+            self.username = default_reolink_username();
+        }
+        if self.generate_password && self.desired_password.trim().is_empty() {
+            self.desired_password = generate_device_password();
+        }
+        if self.password.trim().is_empty() && self.desired_password.trim().is_empty() {
+            return Err(anyhow!(
+                "either password or desired_password (or generate_password) is required"
+            ));
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkConnectRequest {
+    pub ip: String,
+    #[serde(default = "default_reolink_username")]
+    pub username: String,
+    #[serde(default = "default_reolink_channel")]
+    pub channel: i32,
+    pub password: String,
+}
+
+impl ReolinkConnectRequest {
+    pub fn normalized(mut self) -> Result<Self> {
+        parse_ipv4(&self.ip).context("invalid ip")?;
+        if self.username.trim().is_empty() {
+            self.username = default_reolink_username();
+        }
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkStateSnapshot {
+    #[serde(default)]
+    pub normal: Value,
+    #[serde(default)]
+    pub advanced: Value,
+    #[serde(default)]
+    pub p2p: Value,
+    #[serde(default)]
+    pub auto_reboot: Value,
+    #[serde(default)]
+    pub ptz: Value,
+    #[serde(default)]
+    pub ptz_position: Value,
+    #[serde(default)]
+    pub presets: Value,
+    #[serde(default)]
+    pub cruises: Value,
+    #[serde(default)]
+    pub smart_track_task: Value,
+    #[serde(default)]
+    pub smart_track_limit: Value,
+    #[serde(default)]
+    pub signature_login: Value,
+    #[serde(default)]
+    pub user_config: Value,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkStateResult {
+    #[serde(default)]
+    pub state: ReolinkStateSnapshot,
+    #[serde(default)]
+    pub active_password: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkStateApplyRequest {
+    #[serde(flatten)]
+    pub connection: ReolinkConnectRequest,
+    #[serde(default)]
+    pub normal: Option<Value>,
+    #[serde(default)]
+    pub advanced: Option<Value>,
+    #[serde(default)]
+    pub p2p: Option<Value>,
+    #[serde(default)]
+    pub auto_reboot: Option<Value>,
+    #[serde(default)]
+    pub ptz: Option<Value>,
+    #[serde(default)]
+    pub ptz_position: Option<Value>,
+    #[serde(default)]
+    pub smart_track_task: Option<Value>,
+    #[serde(default)]
+    pub smart_track_limit: Option<Value>,
+    #[serde(default)]
+    pub signature_login: Option<Value>,
+    #[serde(default)]
+    pub user_config: Option<Value>,
+}
+
+impl ReolinkStateApplyRequest {
+    pub fn normalized(self) -> Result<Self> {
+        Ok(Self {
+            connection: self.connection.normalized()?,
+            normal: self.normal,
+            advanced: self.advanced,
+            p2p: self.p2p,
+            auto_reboot: self.auto_reboot,
+            ptz: self.ptz,
+            ptz_position: self.ptz_position,
+            smart_track_task: self.smart_track_task,
+            smart_track_limit: self.smart_track_limit,
+            signature_login: self.signature_login,
+            user_config: self.user_config,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkStateApplyResult {
+    #[serde(default)]
+    pub before: ReolinkStateSnapshot,
+    #[serde(default)]
+    pub after: ReolinkStateSnapshot,
+    #[serde(default)]
+    pub active_password: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkSetupBridgeResult {
+    pub ip: String,
+    pub username: String,
+    pub before_normal: ReolinkNormalPortConfig,
+    pub before_advanced: ReolinkAdvancedPortConfig,
+    pub before_p2p: ReolinkP2PConfig,
+    pub after_normal: ReolinkNormalPortConfig,
+    pub after_advanced: ReolinkAdvancedPortConfig,
+    pub after_p2p: ReolinkP2PConfig,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkSetupResult {
+    pub bridge: ReolinkSetupBridgeResult,
+    pub probe: ReolinkProbe,
+    #[serde(default)]
+    pub generated_password: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReolinkPasswordRecoveryNote {
+    ip: String,
+    username: String,
+    desired_password: String,
+    generated: bool,
+    note: &'static str,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkBootstrapRequest {
+    pub server_ip: String,
+    pub lease_ip: String,
+    #[serde(default)]
+    pub target_mac: String,
+    #[serde(default = "default_timeout_secs")]
+    pub timeout_secs: u64,
+    #[serde(default = "default_subnet_mask")]
+    pub subnet_mask: String,
+    #[serde(default)]
+    pub router_ip: String,
+    #[serde(default)]
+    pub dns_ip: String,
+}
+
+impl ReolinkBootstrapRequest {
+    pub fn normalized(mut self) -> Result<Self> {
+        parse_ipv4(&self.server_ip).context("invalid server_ip")?;
+        parse_ipv4(&self.lease_ip).context("invalid lease_ip")?;
+        parse_ipv4(&self.subnet_mask).context("invalid subnet_mask")?;
+
+        if self.router_ip.trim().is_empty() {
+            self.router_ip = self.server_ip.clone();
+        } else {
+            parse_ipv4(&self.router_ip).context("invalid router_ip")?;
+        }
+
+        if self.dns_ip.trim().is_empty() {
+            self.dns_ip = self.server_ip.clone();
+        } else {
+            parse_ipv4(&self.dns_ip).context("invalid dns_ip")?;
+        }
+
+        if self.timeout_secs == 0 {
+            self.timeout_secs = default_timeout_secs();
+        }
+
+        if !self.target_mac.trim().is_empty() {
+            normalize_mac(&self.target_mac).context("invalid target_mac")?;
+        }
+
+        Ok(self)
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReolinkBootstrapResult {
+    pub lease_acked: bool,
+    pub assigned_ip: String,
+    pub target_mac: String,
+    pub discovered: Vec<ReolinkDiscovery>,
+    pub probe: ReolinkProbe,
+}
+
+#[derive(Clone, Debug)]
+struct DhcpLeaseAck {
+    assigned_ip: String,
+    target_mac: String,
+}
+
+pub async fn discover(timeout_secs: u64) -> Result<Vec<ReolinkDiscovery>> {
+    discover_on_targets(
+        &[SocketAddrV4::new(Ipv4Addr::new(255, 255, 255, 255), 2000)],
+        timeout_secs,
+    )
+    .await
+}
+
+pub async fn discover_with_hint(hint_ip: &str, timeout_secs: u64) -> Result<Vec<ReolinkDiscovery>> {
+    let mut targets = vec![SocketAddrV4::new(Ipv4Addr::new(255, 255, 255, 255), 2000)];
+    let hinted = SocketAddrV4::new(broadcast_ip(hint_ip)?, 2000);
+    if !targets.contains(&hinted) {
+        targets.push(hinted);
+    }
+    discover_on_targets(&targets, timeout_secs).await
+}
+
+async fn discover_on_targets(
+    targets: &[SocketAddrV4],
+    timeout_secs: u64,
+) -> Result<Vec<ReolinkDiscovery>> {
+    let socket = UdpSocket::bind("0.0.0.0:3000")
+        .await
+        .context("failed binding Reolink discovery socket to udp/3000")?;
+    socket
+        .set_broadcast(true)
+        .context("failed enabling UDP broadcast on discovery socket")?;
+    for target in targets {
+        socket
+            .send_to(&DISCOVERY_PROBE, *target)
+            .await
+            .with_context(|| format!("failed sending Reolink discovery probe to {}", target))?;
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs.max(1));
+    let mut buf = vec![0u8; 4096];
+    let mut out = Vec::<ReolinkDiscovery>::new();
+
+    loop {
+        let remain = deadline.saturating_duration_since(Instant::now());
+        if remain.is_zero() {
+            break;
+        }
+
+        let recv = timeout(remain, socket.recv_from(&mut buf)).await;
+        let Ok(Ok((len, from))) = recv else {
+            break;
+        };
+
+        if len == 0 {
+            continue;
+        }
+
+        let device = parse_discovery_payload(&buf[..len], from.to_string());
+        if device.ip.is_empty() && device.mac.is_empty() && device.uid.is_empty() {
+            continue;
+        }
+
+        if !out
+            .iter()
+            .any(|existing| existing.ip == device.ip && existing.mac == device.mac)
+        {
+            out.push(device);
+        }
+    }
+
+    out.sort_by(|a, b| a.ip.cmp(&b.ip).then(a.mac.cmp(&b.mac)));
+    Ok(out)
+}
+
+pub async fn probe(ip: &str, timeout_secs: u64) -> Result<ReolinkProbe> {
+    let target = parse_ipv4(ip).context("invalid probe ip")?;
+    let timeout_secs = timeout_secs.max(1);
+    let proprietary_port_open = tcp_open(target, 9000, timeout_secs).await;
+    let rtsp_port_open = tcp_open(target, 554, timeout_secs).await;
+    let onvif_port_open = tcp_open(target, 8000, timeout_secs).await;
+
+    let onvif_xaddr = if onvif_port_open {
+        let expected = format!("http://{}:8000/onvif/device_service", target);
+        let discovered = camera::discover_onvif(timeout_secs.min(3))
+            .await
+            .unwrap_or_default();
+        discovered
+            .into_iter()
+            .find(|entry| entry.endpoint.contains(&target.to_string()))
+            .map(|entry| entry.endpoint)
+            .unwrap_or(expected)
+    } else {
+        String::new()
+    };
+
+    Ok(ReolinkProbe {
+        ip: target.to_string(),
+        proprietary_port_open,
+        rtsp_port_open,
+        onvif_port_open,
+        standards_ready: rtsp_port_open && onvif_port_open,
+        onvif_xaddr,
+    })
+}
+
+pub async fn setup(request: ReolinkSetupRequest) -> Result<ReolinkSetupResult> {
+    let request = request.normalized()?;
+    let generated_password = if request.generate_password {
+        request.desired_password.clone()
+    } else {
+        String::new()
+    };
+    let recovery_path = if should_persist_recovery_note(&request) {
+        Some(write_password_recovery_note(&request).await?)
+    } else {
+        None
+    };
+
+    let bridge_result = if sdk_bridge_available() {
+        setup_via_sdk_bridge(&request)
+            .await
+            .context("Reolink proprietary 9000 setup failed")
+    } else {
+        reolink_cgi::setup(&request).await
+    };
+
+    let bridge = match bridge_result {
+        Ok(bridge) => {
+            if let Some(path) = &recovery_path {
+                let _ = fs::remove_file(path).await;
+            }
+            bridge
+        }
+        Err(err) => {
+            if let Some(path) = &recovery_path {
+                return Err(err.context(format!(
+                    "camera password may already have changed; recovery note: {}; desired password: {}",
+                    path.display(), request.desired_password
+                )));
+            }
+            return Err(err);
+        }
+    };
+
+    let probe = probe(&request.ip, 3).await?;
+    Ok(ReolinkSetupResult {
+        bridge,
+        probe,
+        generated_password,
+    })
+}
+
+fn sdk_bridge_script_path() -> PathBuf {
+    if let Ok(raw) = env::var("CONSTITUTE_REOLINK_BRIDGE") {
+        let trimmed = raw.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace_root) = manifest_dir.ancestors().nth(2) {
+        return workspace_root
+            .join("reolink-rev-eng")
+            .join("reolink-sdk-bridge.cjs");
+    }
+
+    manifest_dir
+        .join("..")
+        .join("..")
+        .join("reolink-rev-eng")
+        .join("reolink-sdk-bridge.cjs")
+}
+
+fn should_persist_recovery_note(request: &ReolinkSetupRequest) -> bool {
+    !request.desired_password.trim().is_empty() && request.desired_password != request.password
+}
+
+fn password_recovery_note_path(ip: &str) -> PathBuf {
+    let safe_ip = ip
+        .chars()
+        .map(|ch| if ch.is_ascii_alphanumeric() { ch } else { '_' })
+        .collect::<String>();
+    env::temp_dir().join(format!("constitute-nvr-reolink-recovery-{safe_ip}.json"))
+}
+
+async fn write_password_recovery_note(request: &ReolinkSetupRequest) -> Result<PathBuf> {
+    let note = ReolinkPasswordRecoveryNote {
+        ip: request.ip.clone(),
+        username: request.username.clone(),
+        desired_password: request.desired_password.clone(),
+        generated: request.generate_password,
+        note: "Delete this file after you confirm the camera is reachable with the desired password.",
+    };
+    let path = password_recovery_note_path(&request.ip);
+    let bytes =
+        serde_json::to_vec_pretty(&note).context("failed encoding password recovery note")?;
+    fs::write(&path, bytes)
+        .await
+        .with_context(|| format!("failed writing {}", path.display()))?;
+    Ok(path)
+}
+
+fn sdk_bridge_available() -> bool {
+    cfg!(target_os = "windows") && sdk_bridge_script_path().exists()
+}
+
+pub async fn read_state(request: ReolinkConnectRequest) -> Result<ReolinkStateResult> {
+    let request = request.normalized()?;
+    if !sdk_bridge_available() {
+        return Err(anyhow!(format!(
+            "Reolink runtime settings require the external proprietary 9000 bridge until native cross-platform transport is finished (expected at {})",
+            sdk_bridge_script_path().display()
+        )));
+    }
+
+    let value = run_sdk_bridge_value(json!({
+        "action": "state",
+        "ip": request.ip,
+        "username": request.username,
+        "password": request.password,
+    }))
+    .await?;
+
+    serde_json::from_value(value).context("failed decoding Reolink runtime state")
+}
+
+pub async fn apply_state(request: ReolinkStateApplyRequest) -> Result<ReolinkStateApplyResult> {
+    let request = request.normalized()?;
+    if !sdk_bridge_available() {
+        return Err(anyhow!(format!(
+            "Reolink runtime settings require the external proprietary 9000 bridge until native cross-platform transport is finished (expected at {})",
+            sdk_bridge_script_path().display()
+        )));
+    }
+
+    let value = run_sdk_bridge_value(json!({
+        "action": "apply",
+        "ip": request.connection.ip,
+        "username": request.connection.username,
+        "channel": request.connection.channel,
+        "password": request.connection.password,
+        "normal": request.normal,
+        "advanced": request.advanced,
+        "p2p": request.p2p,
+        "autoReboot": request.auto_reboot,
+        "ptz": request.ptz,
+        "ptzPosition": request.ptz_position,
+        "smartTrackTask": request.smart_track_task,
+        "smartTrackLimit": request.smart_track_limit,
+        "signatureLogin": request.signature_login,
+        "userConfig": request.user_config,
+    }))
+    .await?;
+
+    serde_json::from_value(value).context("failed decoding Reolink runtime state update")
+}
+
+async fn setup_via_sdk_bridge(request: &ReolinkSetupRequest) -> Result<ReolinkSetupBridgeResult> {
+    let value = run_sdk_bridge_value(json!({
+        "action": "setup",
+        "ip": request.ip,
+        "username": request.username,
+        "password": request.password,
+        "desiredPassword": request.desired_password,
+        "normal": request.normal,
+        "advanced": request.advanced,
+        "p2p": request.p2p,
+    }))
+    .await?;
+
+    serde_json::from_value(value).context("failed decoding Reolink SDK bridge result")
+}
+
+async fn run_sdk_bridge_value(payload: Value) -> Result<Value> {
+    let script = sdk_bridge_script_path();
+    if !script.exists() {
+        return Err(anyhow!(
+            "Reolink SDK bridge script not found at {}",
+            script.display()
+        ));
+    }
+
+    let response_path = env::temp_dir().join(format!(
+        "constitute-nvr-reolink-bridge-{}.json",
+        rand::thread_rng().r#gen::<u64>()
+    ));
+
+    let mut child = Command::new("node")
+        .arg(&script)
+        .arg(&response_path)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .with_context(|| format!("failed spawning node for {}", script.display()))?;
+
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(
+                &serde_json::to_vec(&payload).context("failed encoding Reolink bridge request")?,
+            )
+            .await
+            .context("failed writing request to Reolink SDK bridge")?;
+    } else {
+        return Err(anyhow!("failed opening stdin for Reolink SDK bridge"));
+    }
+
+    let output = child
+        .wait_with_output()
+        .await
+        .context("failed waiting for Reolink SDK bridge")?;
+
+    let raw = fs::read(&response_path)
+        .await
+        .with_context(|| format!("failed reading {}", response_path.display()))?;
+    let _ = fs::remove_file(&response_path).await;
+
+    let value: Value =
+        serde_json::from_slice(&raw).context("failed parsing Reolink SDK bridge response")?;
+    let ok = value.get("ok").and_then(Value::as_bool).unwrap_or(false);
+    if !output.status.success() || !ok {
+        let bridge_error = value
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown Reolink SDK bridge error");
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        if stderr.is_empty() {
+            return Err(anyhow!(bridge_error.to_string()));
+        }
+        return Err(anyhow!(format!("{bridge_error}; {stderr}")));
+    }
+
+    Ok(value)
+}
+
+pub async fn bootstrap(request: ReolinkBootstrapRequest) -> Result<ReolinkBootstrapResult> {
+    let request = request.normalized()?;
+    let ack = run_dhcp_bootstrap(&request).await?;
+
+    sleep(Duration::from_millis(750)).await;
+
+    let discovered = discover_with_hint(&request.lease_ip, 3)
+        .await
+        .unwrap_or_default();
+    let probe = probe(&ack.assigned_ip, 3).await?;
+
+    Ok(ReolinkBootstrapResult {
+        lease_acked: true,
+        assigned_ip: ack.assigned_ip,
+        target_mac: ack.target_mac,
+        discovered,
+        probe,
+    })
+}
+
+async fn run_dhcp_bootstrap(request: &ReolinkBootstrapRequest) -> Result<DhcpLeaseAck> {
+    let bind = format!("{}:67", request.server_ip);
+    let socket = UdpSocket::bind(&bind)
+        .await
+        .with_context(|| format!("failed binding DHCP responder on {}", bind))?;
+    socket
+        .set_broadcast(true)
+        .context("failed enabling UDP broadcast on DHCP socket")?;
+
+    let mut buf = vec![0u8; 4096];
+    let deadline = Instant::now() + Duration::from_secs(request.timeout_secs.max(1));
+    let target_mac = if request.target_mac.trim().is_empty() {
+        None
+    } else {
+        Some(normalize_mac(&request.target_mac)?)
+    };
+    let lease_ip = parse_ipv4(&request.lease_ip)?;
+    let server_ip = parse_ipv4(&request.server_ip)?;
+    let subnet_mask = parse_ipv4(&request.subnet_mask)?;
+    let router_ip = parse_ipv4(&request.router_ip)?;
+    let dns_ip = parse_ipv4(&request.dns_ip)?;
+    let broadcast = SocketAddrV4::new(broadcast_ip(&request.lease_ip)?, 68);
+
+    loop {
+        let remain = deadline.saturating_duration_since(Instant::now());
+        if remain.is_zero() {
+            return Err(anyhow!("timed out waiting for DHCP request"));
+        }
+
+        let recv = timeout(remain, socket.recv_from(&mut buf)).await;
+        let Ok(Ok((len, _from))) = recv else {
+            return Err(anyhow!("timed out waiting for DHCP request"));
+        };
+        if len < 240 || buf[0] != 1 {
+            continue;
+        }
+        if buf[236..240] != DHCP_COOKIE {
+            continue;
+        }
+
+        let client_mac = buf[28..34].to_vec();
+        if let Some(expected) = &target_mac {
+            if &client_mac != expected {
+                continue;
+            }
+        }
+
+        match dhcp_message_type(&buf[..len]) {
+            Some(DHCP_DISCOVER) => {
+                let offer = build_dhcp_reply(
+                    &buf[..len],
+                    DHCP_OFFER,
+                    &client_mac,
+                    lease_ip,
+                    server_ip,
+                    subnet_mask,
+                    router_ip,
+                    dns_ip,
+                )?;
+                socket
+                    .send_to(&offer, broadcast)
+                    .await
+                    .context("failed sending DHCP offer")?;
+            }
+            Some(DHCP_REQUEST) => {
+                let ack = build_dhcp_reply(
+                    &buf[..len],
+                    DHCP_ACK,
+                    &client_mac,
+                    lease_ip,
+                    server_ip,
+                    subnet_mask,
+                    router_ip,
+                    dns_ip,
+                )?;
+                socket
+                    .send_to(&ack, broadcast)
+                    .await
+                    .context("failed sending DHCP ack")?;
+                return Ok(DhcpLeaseAck {
+                    assigned_ip: lease_ip.to_string(),
+                    target_mac: format_mac(&client_mac),
+                });
+            }
+            _ => {}
+        }
+    }
+}
+
+fn build_dhcp_reply(
+    request: &[u8],
+    message_type: u8,
+    client_mac: &[u8],
+    lease_ip: Ipv4Addr,
+    server_ip: Ipv4Addr,
+    subnet_mask: Ipv4Addr,
+    router_ip: Ipv4Addr,
+    dns_ip: Ipv4Addr,
+) -> Result<Vec<u8>> {
+    let mut packet = vec![0u8; 300];
+    packet[0] = 2;
+    packet[1] = 1;
+    packet[2] = 6;
+    packet[3] = 0;
+    packet[4..8].copy_from_slice(&request[4..8]);
+    packet[8..10].copy_from_slice(&request[8..10]);
+    packet[10..12].copy_from_slice(&request[10..12]);
+    packet[16..20].copy_from_slice(&lease_ip.octets());
+    packet[20..24].copy_from_slice(&server_ip.octets());
+    packet[28..34].copy_from_slice(client_mac);
+    packet[236..240].copy_from_slice(&DHCP_COOKIE);
+
+    let mut idx = 240;
+    idx = push_dhcp_option(&mut packet, idx, 53, &[message_type]);
+    idx = push_dhcp_option(&mut packet, idx, 54, &server_ip.octets());
+    idx = push_dhcp_option(&mut packet, idx, 51, &3600u32.to_be_bytes());
+    idx = push_dhcp_option(&mut packet, idx, 1, &subnet_mask.octets());
+    idx = push_dhcp_option(&mut packet, idx, 3, &router_ip.octets());
+    idx = push_dhcp_option(&mut packet, idx, 6, &dns_ip.octets());
+    if idx >= packet.len() {
+        return Err(anyhow!("DHCP packet overflow"));
+    }
+    packet[idx] = DHCP_END;
+    packet.truncate(idx + 1);
+    Ok(packet)
+}
+
+fn push_dhcp_option(packet: &mut Vec<u8>, idx: usize, code: u8, value: &[u8]) -> usize {
+    let end = idx + 2 + value.len();
+    if end > packet.len() {
+        packet.resize(end, 0);
+    }
+    packet[idx] = code;
+    packet[idx + 1] = value.len() as u8;
+    packet[idx + 2..end].copy_from_slice(value);
+    end
+}
+
+fn dhcp_message_type(packet: &[u8]) -> Option<u8> {
+    let mut idx = 240;
+    while idx < packet.len() {
+        let code = packet[idx];
+        idx += 1;
+        if code == DHCP_END {
+            return None;
+        }
+        if code == 0 {
+            continue;
+        }
+        if idx >= packet.len() {
+            return None;
+        }
+        let len = packet[idx] as usize;
+        idx += 1;
+        if idx + len > packet.len() {
+            return None;
+        }
+        if code == 53 && len == 1 {
+            return Some(packet[idx]);
+        }
+        idx += len;
+    }
+    None
+}
+
+fn parse_discovery_payload(payload: &[u8], from: String) -> ReolinkDiscovery {
+    let body = if payload.len() > 8 {
+        &payload[8..]
+    } else {
+        payload
+    };
+    let parts = body
+        .split(|byte| *byte == 0)
+        .filter_map(parse_printable_token)
+        .collect::<Vec<_>>();
+
+    let mut out = ReolinkDiscovery::default();
+    out.from = from;
+
+    let mut extras = Vec::new();
+    for value in parts {
+        if out.ip.is_empty() && parse_ipv4(&value).is_ok() {
+            out.ip = value;
+            continue;
+        }
+        if out.mac.is_empty() && looks_like_mac(&value) {
+            out.mac = value;
+            continue;
+        }
+        extras.push(value);
+    }
+
+    if let Some(model) = extras
+        .iter()
+        .find(|value| value.contains(' ') && value.chars().any(|ch| ch.is_ascii_alphabetic()))
+    {
+        out.model = model.clone();
+    }
+    if out.model.is_empty() {
+        if let Some(model) = extras
+            .iter()
+            .find(|value| value.chars().any(|ch| ch.is_ascii_alphabetic()))
+        {
+            out.model = model.clone();
+        }
+    }
+    if let Some(uid) = extras
+        .iter()
+        .find(|value| value != &&out.model && looks_like_uid(value))
+    {
+        out.uid = uid.clone();
+    }
+    if out.uid.is_empty() {
+        if let Some(uid) = extras.iter().find(|value| value != &&out.model) {
+            out.uid = uid.clone();
+        }
+    }
+
+    out
+}
+
+fn looks_like_mac(value: &str) -> bool {
+    value.len() == 17
+        && value.bytes().enumerate().all(|(idx, byte)| {
+            if [2, 5, 8, 11, 14].contains(&idx) {
+                byte == b':' || byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        })
+}
+
+fn looks_like_uid(value: &str) -> bool {
+    value.len() >= 8
+        && !value.contains(' ')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_')
+}
+
+fn parse_printable_token(chunk: &[u8]) -> Option<String> {
+    if chunk.is_empty() {
+        return None;
+    }
+    if chunk
+        .iter()
+        .any(|byte| !byte.is_ascii_graphic() && *byte != b' ')
+    {
+        return None;
+    }
+    let value = String::from_utf8_lossy(chunk).trim().to_string();
+    (!value.is_empty()).then_some(value)
+}
+
+fn default_reolink_username() -> String {
+    "admin".to_string()
+}
+
+fn default_reolink_channel() -> i32 {
+    0
+}
+
+fn default_timeout_secs() -> u64 {
+    20
+}
+
+fn default_subnet_mask() -> String {
+    "255.255.255.0".to_string()
+}
+
+fn parse_ipv4(input: &str) -> Result<Ipv4Addr> {
+    Ipv4Addr::from_str(input.trim()).with_context(|| format!("invalid IPv4 address: {input}"))
+}
+
+fn broadcast_ip(ip: &str) -> Result<Ipv4Addr> {
+    let mut octets = parse_ipv4(ip)?.octets();
+    octets[3] = 255;
+    Ok(Ipv4Addr::from(octets))
+}
+
+fn normalize_mac(input: &str) -> Result<Vec<u8>> {
+    let parts = input
+        .trim()
+        .replace('-', ":")
+        .split(':')
+        .filter(|part| !part.is_empty())
+        .map(|part| u8::from_str_radix(part, 16))
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .context("failed parsing MAC address")?;
+    if parts.len() != 6 {
+        return Err(anyhow!("MAC address must contain six octets"));
+    }
+    Ok(parts)
+}
+
+fn format_mac(bytes: &[u8]) -> String {
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02X}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+fn generate_device_password() -> String {
+    let mut rng = rand::thread_rng();
+    (0..GENERATED_DEVICE_PASSWORD_LEN)
+        .map(|_| {
+            let idx = rng.gen_range(0..DEVICE_PASSWORD_CHARSET.len());
+            DEVICE_PASSWORD_CHARSET[idx] as char
+        })
+        .collect()
+}
+
+async fn tcp_open(target: Ipv4Addr, port: u16, timeout_secs: u64) -> bool {
+    let addr = SocketAddrV4::new(target, port);
+    timeout(
+        Duration::from_secs(timeout_secs.max(1)),
+        TcpStream::connect(addr),
+    )
+    .await
+    .is_ok_and(|result| result.is_ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_reolink_discovery_payload() {
+        let payload = b"\x00\x00\x00\x00\xaa\xaa\x00\x00192.168.1.20\x00EC:71:DB:32:0A:8F\x00E1 Outdoor SE PoE\x009527000L3X9U13GR\x00";
+        let out = parse_discovery_payload(payload, "192.168.1.20:2000".to_string());
+        assert_eq!(out.ip, "192.168.1.20");
+        assert_eq!(out.mac, "EC:71:DB:32:0A:8F");
+        assert_eq!(out.model, "E1 Outdoor SE PoE");
+        assert_eq!(out.uid, "9527000L3X9U13GR");
+    }
+
+    #[test]
+    fn skips_binary_garbage_in_reolink_discovery_payload() {
+        let payload = b"\x00\x00\x00\x00\xaa\xaa\x00\x00\x01\x02garbage\x00192.168.1.20\x00EC:71:DB:32:0A:8F\x00E1 Outdoor SE PoE\x009527000L3X9U13GR\x00";
+        let out = parse_discovery_payload(payload, "192.168.1.20:2000".to_string());
+        assert_eq!(out.ip, "192.168.1.20");
+        assert_eq!(out.mac, "EC:71:DB:32:0A:8F");
+        assert_eq!(out.model, "E1 Outdoor SE PoE");
+        assert_eq!(out.uid, "9527000L3X9U13GR");
+    }
+
+    #[test]
+    fn parses_dhcp_message_type() {
+        let mut packet = vec![0u8; 244];
+        packet[236..240].copy_from_slice(&DHCP_COOKIE);
+        packet[240] = 53;
+        packet[241] = 1;
+        packet[242] = DHCP_DISCOVER;
+        packet[243] = DHCP_END;
+        assert_eq!(dhcp_message_type(&packet), Some(DHCP_DISCOVER));
+    }
+
+    #[test]
+    fn normalizes_mac() {
+        let out = normalize_mac("EC:71:DB:32:0A:8F").expect("mac");
+        assert_eq!(out, vec![0xEC, 0x71, 0xDB, 0x32, 0x0A, 0x8F]);
+    }
+
+    #[test]
+    fn setup_request_defaults_username() {
+        let request = ReolinkSetupRequest {
+            ip: "192.168.1.20".to_string(),
+            username: String::new(),
+            password: "secret".to_string(),
+            desired_password: String::new(),
+            generate_password: false,
+            normal: None,
+            advanced: None,
+            p2p: None,
+        }
+        .normalized()
+        .expect("normalized");
+        assert_eq!(request.username, "admin");
+    }
+
+    #[test]
+    fn converts_bridge_configs_to_core_models() {
+        let normal = ReolinkNormalPortConfig {
+            i_surv_port_enable: 1,
+            i_surv_port: 9000,
+            i_http_port_enable: 0,
+            i_http_port: 80,
+            i_https_port_enable: 1,
+            i_https_port: 443,
+        };
+        let advanced = ReolinkAdvancedPortConfig {
+            i_onvif_port_enable: 1,
+            i_onvif_port: 8000,
+            i_rtsp_port_enable: 1,
+            i_rtsp_port: 554,
+            i_rtmp_port_enable: 0,
+            i_rtmp_port: 1935,
+        };
+        let p2p = ReolinkP2PConfig {
+            i_enable: 0,
+            i_port: 0,
+            server_domain_name: "p2p.reolink.com".into(),
+        };
+
+        let normal_core: reolink_proto::ReolinkNetNormalPort = normal.clone().into();
+        let advanced_core: reolink_proto::ReolinkNetAdvancedPort = advanced.clone().into();
+        let p2p_core: reolink_proto::ReolinkP2PCfg = p2p.clone().into();
+
+        assert_eq!(ReolinkNormalPortConfig::from(normal_core), normal);
+        assert_eq!(ReolinkAdvancedPortConfig::from(advanced_core), advanced);
+        assert_eq!(ReolinkP2PConfig::from(p2p_core), p2p);
+    }
+
+    #[test]
+    fn generates_device_password_with_expected_shape() {
+        let out = generate_device_password();
+        assert_eq!(out.len(), GENERATED_DEVICE_PASSWORD_LEN);
+        assert!(
+            out.bytes()
+                .all(|byte| DEVICE_PASSWORD_CHARSET.contains(&byte))
+        );
+    }
+
+    #[test]
+    fn setup_request_generates_password_when_requested() {
+        let request = ReolinkSetupRequest {
+            ip: "192.168.1.20".to_string(),
+            username: "admin".to_string(),
+            password: String::new(),
+            desired_password: String::new(),
+            generate_password: true,
+            normal: None,
+            advanced: None,
+            p2p: None,
+        }
+        .normalized()
+        .expect("normalized");
+        assert_eq!(
+            request.desired_password.len(),
+            GENERATED_DEVICE_PASSWORD_LEN
+        );
+    }
+}

--- a/src/reolink.rs
+++ b/src/reolink.rs
@@ -602,53 +602,48 @@ fn sdk_bridge_available() -> bool {
 
 pub async fn read_state(request: ReolinkConnectRequest) -> Result<ReolinkStateResult> {
     let request = request.normalized()?;
-    if !sdk_bridge_available() {
-        return Err(anyhow!(format!(
-            "Reolink runtime settings require the external proprietary 9000 bridge until native cross-platform transport is finished (expected at {})",
-            sdk_bridge_script_path().display()
-        )));
+    if sdk_bridge_available() {
+        let value = run_sdk_bridge_value(json!({
+            "action": "state",
+            "ip": request.ip,
+            "username": request.username,
+            "password": request.password,
+        }))
+        .await?;
+
+        return serde_json::from_value(value).context("failed decoding Reolink runtime state");
     }
 
-    let value = run_sdk_bridge_value(json!({
-        "action": "state",
-        "ip": request.ip,
-        "username": request.username,
-        "password": request.password,
-    }))
-    .await?;
-
-    serde_json::from_value(value).context("failed decoding Reolink runtime state")
+    reolink_cgi::read_state(&request).await
 }
 
 pub async fn apply_state(request: ReolinkStateApplyRequest) -> Result<ReolinkStateApplyResult> {
     let request = request.normalized()?;
-    if !sdk_bridge_available() {
-        return Err(anyhow!(format!(
-            "Reolink runtime settings require the external proprietary 9000 bridge until native cross-platform transport is finished (expected at {})",
-            sdk_bridge_script_path().display()
-        )));
+    if sdk_bridge_available() {
+        let value = run_sdk_bridge_value(json!({
+            "action": "apply",
+            "ip": request.connection.ip,
+            "username": request.connection.username,
+            "channel": request.connection.channel,
+            "password": request.connection.password,
+            "normal": request.normal,
+            "advanced": request.advanced,
+            "p2p": request.p2p,
+            "autoReboot": request.auto_reboot,
+            "ptz": request.ptz,
+            "ptzPosition": request.ptz_position,
+            "smartTrackTask": request.smart_track_task,
+            "smartTrackLimit": request.smart_track_limit,
+            "signatureLogin": request.signature_login,
+            "userConfig": request.user_config,
+        }))
+        .await?;
+
+        return serde_json::from_value(value)
+            .context("failed decoding Reolink runtime state update");
     }
 
-    let value = run_sdk_bridge_value(json!({
-        "action": "apply",
-        "ip": request.connection.ip,
-        "username": request.connection.username,
-        "channel": request.connection.channel,
-        "password": request.connection.password,
-        "normal": request.normal,
-        "advanced": request.advanced,
-        "p2p": request.p2p,
-        "autoReboot": request.auto_reboot,
-        "ptz": request.ptz,
-        "ptzPosition": request.ptz_position,
-        "smartTrackTask": request.smart_track_task,
-        "smartTrackLimit": request.smart_track_limit,
-        "signatureLogin": request.signature_login,
-        "userConfig": request.user_config,
-    }))
-    .await?;
-
-    serde_json::from_value(value).context("failed decoding Reolink runtime state update")
+    reolink_cgi::apply_state(&request).await
 }
 
 async fn setup_via_sdk_bridge(request: &ReolinkSetupRequest) -> Result<ReolinkSetupBridgeResult> {

--- a/src/reolink.rs
+++ b/src/reolink.rs
@@ -9,10 +9,11 @@ use std::path::PathBuf;
 use std::process::Stdio;
 use std::str::FromStr;
 use tokio::fs;
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpStream, UdpSocket};
 use tokio::process::Command;
 use tokio::time::{Duration, Instant, sleep, timeout};
+use tracing::{info, warn};
 
 const DISCOVERY_PROBE: [u8; 4] = [0xaa, 0xaa, 0x00, 0x00];
 const DHCP_COOKIE: [u8; 4] = [0x63, 0x82, 0x53, 0x63];
@@ -24,6 +25,10 @@ const DHCP_END: u8 = 255;
 const GENERATED_DEVICE_PASSWORD_LEN: usize = 24;
 const DEVICE_PASSWORD_CHARSET: &[u8] =
     b"ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789-_";
+const REOLINK_PROPRIETARY_PORT: u16 = 9000;
+const REOLINK_NATIVE_CONNECT_TIMEOUT_SECS: u64 = 5;
+const REOLINK_NATIVE_IO_TIMEOUT_SECS: u64 = 5;
+const REOLINK_NATIVE_MAX_PAYLOAD_LEN: usize = 1 << 20;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -470,7 +475,7 @@ async fn discover_on_targets(
 pub async fn probe(ip: &str, timeout_secs: u64) -> Result<ReolinkProbe> {
     let target = parse_ipv4(ip).context("invalid probe ip")?;
     let timeout_secs = timeout_secs.max(1);
-    let proprietary_port_open = tcp_open(target, 9000, timeout_secs).await;
+    let proprietary_port_open = tcp_open(target, REOLINK_PROPRIETARY_PORT, timeout_secs).await;
     let rtsp_port_open = tcp_open(target, 554, timeout_secs).await;
     let onvif_port_open = tcp_open(target, 8000, timeout_secs).await;
 
@@ -511,10 +516,24 @@ pub async fn setup(request: ReolinkSetupRequest) -> Result<ReolinkSetupResult> {
         None
     };
 
-    let bridge_result = if sdk_bridge_available() {
-        setup_via_sdk_bridge(&request)
+    if native_preflight_enabled() {
+        match native_9000_preflight(&request).await {
+            Ok(()) => info!(ip = %request.ip, "native 9000 preflight ok"),
+            Err(err) => warn!(ip = %request.ip, error = %err, "native 9000 preflight failed"),
+        }
+    }
+
+    let bridge_result = if use_sdk_bridge_for_mvp() {
+        match setup_via_sdk_bridge(&request)
             .await
             .context("Reolink proprietary 9000 setup failed")
+        {
+            Ok(value) => Ok(value),
+            Err(err) => {
+                warn!(error = %err, "sdk bridge setup failed; falling back to CGI");
+                reolink_cgi::setup(&request).await
+            }
+        }
     } else {
         reolink_cgi::setup(&request).await
     };
@@ -543,6 +562,171 @@ pub async fn setup(request: ReolinkSetupRequest) -> Result<ReolinkSetupResult> {
         probe,
         generated_password,
     })
+}
+
+async fn native_9000_preflight(request: &ReolinkSetupRequest) -> Result<()> {
+    let target = parse_ipv4(&request.ip).context("invalid setup ip for native 9000 preflight")?;
+    let mut failures = Vec::new();
+
+    for password in native_password_candidates(request) {
+        match try_native_9000_login(target, &request.username, &password).await {
+            Ok(()) => return Ok(()),
+            Err(err) => {
+                let label = if password.is_empty() {
+                    "<empty>"
+                } else if password == request.password.trim() {
+                    "<request.password>"
+                } else if password == request.desired_password.trim() {
+                    "<request.desired_password>"
+                } else {
+                    "<candidate>"
+                };
+                failures.push(format!("{label}: {err:#}"));
+            }
+        }
+    }
+
+    Err(anyhow!(format!(
+        "native 9000 login failed for all credential candidates ({})",
+        failures.join("; ")
+    )))
+}
+
+fn native_password_candidates(request: &ReolinkSetupRequest) -> Vec<String> {
+    let mut out = vec![request.password.trim().to_string()];
+    let desired = request.desired_password.trim().to_string();
+    if !desired.is_empty() && !out.contains(&desired) {
+        out.push(desired);
+    }
+    out
+}
+
+async fn try_native_9000_login(target: Ipv4Addr, username: &str, password: &str) -> Result<()> {
+    let addr = SocketAddrV4::new(target, REOLINK_PROPRIETARY_PORT);
+    let mut stream = timeout(
+        Duration::from_secs(REOLINK_NATIVE_CONNECT_TIMEOUT_SECS),
+        TcpStream::connect(addr),
+    )
+    .await
+    .context("timed out connecting to Reolink proprietary port")?
+    .with_context(|| format!("failed connecting to {addr}"))?;
+
+    let _ = stream.set_nodelay(true);
+
+    let probe = reolink_proto::build_handshake_probe_frame();
+    timed_write_all(&mut stream, &probe, "native handshake probe").await?;
+
+    let handshake_frame = read_reolink_transport_frame(&mut stream).await?;
+    let handshake_body = reolink_proto::handshake_frame_body(&handshake_frame)
+        .ok_or_else(|| anyhow!("native handshake response missing handshake body"))?;
+    let nonce = reolink_proto::extract_nonce_from_handshake_body(handshake_body)
+        .ok_or_else(|| anyhow!("native handshake response missing nonce"))?;
+
+    let login_frame = reolink_proto::build_login_frame(username, password, &nonce);
+    timed_write_all(&mut stream, &login_frame, "native login frame").await?;
+
+    let login_response = read_reolink_transport_frame(&mut stream).await?;
+    let login_header = reolink_proto::parse_frame_header(&login_response)
+        .ok_or_else(|| anyhow!("native login response is not a valid Reolink frame"))?;
+    if reolink_proto::ReolinkTransportOp::from_u32(login_header.op()).is_none() {
+        return Err(anyhow!(format!(
+            "native login response used unknown op {}",
+            login_header.op()
+        )));
+    }
+
+    Ok(())
+}
+
+async fn timed_write_all(stream: &mut TcpStream, buf: &[u8], label: &str) -> Result<()> {
+    timeout(
+        Duration::from_secs(REOLINK_NATIVE_IO_TIMEOUT_SECS),
+        stream.write_all(buf),
+    )
+    .await
+    .with_context(|| format!("timed out writing {label}"))?
+    .with_context(|| format!("failed writing {label}"))
+}
+
+async fn timed_read_exact(stream: &mut TcpStream, buf: &mut [u8], label: &str) -> Result<()> {
+    let _ = timeout(
+        Duration::from_secs(REOLINK_NATIVE_IO_TIMEOUT_SECS),
+        stream.read_exact(buf),
+    )
+    .await
+    .with_context(|| format!("timed out reading {label}"))?
+    .with_context(|| format!("failed reading {label}"))?;
+    Ok(())
+}
+
+async fn read_reolink_transport_frame(stream: &mut TcpStream) -> Result<Vec<u8>> {
+    let mut header = [0u8; 20];
+    timed_read_exact(stream, &mut header, "Reolink frame header").await?;
+    if header[..4] != reolink_proto::MAGIC {
+        return Err(anyhow!("invalid Reolink frame magic"));
+    }
+
+    let op = u32::from_le_bytes(
+        header[4..8]
+            .try_into()
+            .map_err(|_| anyhow!("failed decoding Reolink op field"))?,
+    );
+    let payload_len = u32::from_le_bytes(
+        header[8..12]
+            .try_into()
+            .map_err(|_| anyhow!("failed decoding Reolink payload length"))?,
+    ) as usize;
+    if payload_len > REOLINK_NATIVE_MAX_PAYLOAD_LEN {
+        return Err(anyhow!(format!(
+            "Reolink frame payload too large: {payload_len}"
+        )));
+    }
+
+    let mut frame = header.to_vec();
+
+    if op == reolink_proto::ReolinkTransportOp::Handshake as u32 {
+        if payload_len == 0 {
+            return Ok(frame);
+        }
+
+        let mut maybe_tail = [0u8; 4];
+        timed_read_exact(stream, &mut maybe_tail, "Reolink handshake tail").await?;
+
+        let maybe_field_e = u32::from_le_bytes(maybe_tail);
+        let use_extended_header = maybe_field_e == 0;
+
+        if use_extended_header {
+            frame.extend_from_slice(&maybe_tail);
+            let mut body = vec![0u8; payload_len];
+            if payload_len > 0 {
+                timed_read_exact(stream, &mut body, "Reolink handshake payload").await?;
+            }
+            frame.extend_from_slice(&body);
+            return Ok(frame);
+        }
+
+        let first_payload_len = payload_len.min(4);
+        frame.extend_from_slice(&maybe_tail[..first_payload_len]);
+        let remaining_payload = payload_len.saturating_sub(first_payload_len);
+        if remaining_payload > 0 {
+            let mut body = vec![0u8; remaining_payload];
+            timed_read_exact(stream, &mut body, "Reolink short payload").await?;
+            frame.extend_from_slice(&body);
+        }
+        return Ok(frame);
+    }
+
+    let mut field_e = [0u8; 4];
+    timed_read_exact(stream, &mut field_e, "Reolink extended field_e").await?;
+    frame.extend_from_slice(&field_e);
+
+    let mut body = vec![0u8; payload_len];
+    if payload_len > 0 {
+        timed_read_exact(stream, &mut body, "Reolink extended payload").await?;
+    }
+    frame.extend_from_slice(&body);
+
+    Ok(frame)
 }
 
 fn sdk_bridge_script_path() -> PathBuf {
@@ -600,18 +784,42 @@ fn sdk_bridge_available() -> bool {
     cfg!(target_os = "windows") && sdk_bridge_script_path().exists()
 }
 
+fn env_truthy(name: &str) -> bool {
+    matches!(
+        env::var(name)
+            .ok()
+            .map(|raw| raw.trim().to_ascii_lowercase()),
+        Some(value) if value == "1" || value == "true" || value == "yes" || value == "on"
+    )
+}
+
+fn use_sdk_bridge_for_mvp() -> bool {
+    env_truthy("CONSTITUTE_NVR_USE_SDK_BRIDGE") && sdk_bridge_available()
+}
+
+fn native_preflight_enabled() -> bool {
+    env_truthy("CONSTITUTE_NVR_NATIVE_PREFLIGHT")
+}
+
 pub async fn read_state(request: ReolinkConnectRequest) -> Result<ReolinkStateResult> {
     let request = request.normalized()?;
-    if sdk_bridge_available() {
-        let value = run_sdk_bridge_value(json!({
+    if use_sdk_bridge_for_mvp() {
+        match run_sdk_bridge_value(json!({
             "action": "state",
             "ip": request.ip,
             "username": request.username,
             "password": request.password,
         }))
-        .await?;
-
-        return serde_json::from_value(value).context("failed decoding Reolink runtime state");
+        .await
+        {
+            Ok(value) => {
+                return serde_json::from_value(value)
+                    .context("failed decoding Reolink runtime state");
+            }
+            Err(err) => {
+                warn!(error = %err, "sdk bridge state read failed; falling back to CGI");
+            }
+        }
     }
 
     reolink_cgi::read_state(&request).await
@@ -619,8 +827,8 @@ pub async fn read_state(request: ReolinkConnectRequest) -> Result<ReolinkStateRe
 
 pub async fn apply_state(request: ReolinkStateApplyRequest) -> Result<ReolinkStateApplyResult> {
     let request = request.normalized()?;
-    if sdk_bridge_available() {
-        let value = run_sdk_bridge_value(json!({
+    if use_sdk_bridge_for_mvp() {
+        match run_sdk_bridge_value(json!({
             "action": "apply",
             "ip": request.connection.ip,
             "username": request.connection.username,
@@ -637,10 +845,16 @@ pub async fn apply_state(request: ReolinkStateApplyRequest) -> Result<ReolinkSta
             "signatureLogin": request.signature_login,
             "userConfig": request.user_config,
         }))
-        .await?;
-
-        return serde_json::from_value(value)
-            .context("failed decoding Reolink runtime state update");
+        .await
+        {
+            Ok(value) => {
+                return serde_json::from_value(value)
+                    .context("failed decoding Reolink runtime state update");
+            }
+            Err(err) => {
+                warn!(error = %err, "sdk bridge state apply failed; falling back to CGI");
+            }
+        }
     }
 
     reolink_cgi::apply_state(&request).await
@@ -1123,6 +1337,23 @@ mod tests {
         .normalized()
         .expect("normalized");
         assert_eq!(request.username, "admin");
+    }
+
+    #[test]
+    fn native_password_candidates_preserve_blank_first_for_factory_reset() {
+        let request = ReolinkSetupRequest {
+            ip: "192.168.1.20".to_string(),
+            username: "admin".to_string(),
+            password: String::new(),
+            desired_password: "Test1234".to_string(),
+            generate_password: false,
+            normal: None,
+            advanced: None,
+            p2p: None,
+        };
+
+        let out = native_password_candidates(&request);
+        assert_eq!(out, vec!["".to_string(), "Test1234".to_string()]);
     }
 
     #[test]

--- a/src/reolink_cgi.rs
+++ b/src/reolink_cgi.rs
@@ -1,6 +1,7 @@
 use crate::reolink::{
     ReolinkAdvancedPortConfig, ReolinkNormalPortConfig, ReolinkP2PConfig, ReolinkSetupBridgeResult,
-    ReolinkSetupRequest,
+    ReolinkSetupRequest, ReolinkStateApplyRequest, ReolinkStateApplyResult, ReolinkStateResult,
+    ReolinkStateSnapshot,
 };
 use aes::Aes128;
 use anyhow::{Context, Result, anyhow};
@@ -644,6 +645,110 @@ pub async fn setup(request: &ReolinkSetupRequest) -> Result<ReolinkSetupBridgeRe
         after_advanced: after_net.advanced(),
         after_p2p: after_p2p.config(),
     })
+}
+
+pub async fn read_state(
+    request: &crate::reolink::ReolinkConnectRequest,
+) -> Result<ReolinkStateResult> {
+    let mut session = login_existing_session(request).await?;
+    let net = session.get_net_port().await?;
+    let p2p = session.get_p2p().await?;
+    Ok(ReolinkStateResult {
+        state: ReolinkStateSnapshot {
+            normal: serde_json::to_value(net.normal())
+                .context("failed encoding CGI normal state")?,
+            advanced: serde_json::to_value(net.advanced())
+                .context("failed encoding CGI advanced state")?,
+            p2p: serde_json::to_value(p2p.config()).context("failed encoding CGI p2p state")?,
+            ..ReolinkStateSnapshot::default()
+        },
+        active_password: request.password.clone(),
+    })
+}
+
+pub async fn apply_state(request: &ReolinkStateApplyRequest) -> Result<ReolinkStateApplyResult> {
+    if request.auto_reboot.is_some()
+        || request.ptz.is_some()
+        || request.ptz_position.is_some()
+        || request.smart_track_task.is_some()
+        || request.smart_track_limit.is_some()
+        || request.signature_login.is_some()
+        || request.user_config.is_some()
+    {
+        return Err(anyhow!(
+            "Reolink CGI fallback only supports normal ports, advanced ports, and P2P state"
+        ));
+    }
+
+    let mut session = login_existing_session(&request.connection).await?;
+    let before_net = session.get_net_port().await?;
+    let before_p2p = session.get_p2p().await?;
+
+    let before_normal = before_net.normal();
+    let before_advanced = before_net.advanced();
+    let before_p2p_cfg = before_p2p.config();
+
+    let target_normal = match request.normal.as_ref() {
+        Some(value) => serde_json::from_value::<ReolinkNormalPortConfig>(value.clone())
+            .context("invalid CGI normal port state payload")?,
+        None => before_normal.clone(),
+    };
+    let target_advanced = match request.advanced.as_ref() {
+        Some(value) => serde_json::from_value::<ReolinkAdvancedPortConfig>(value.clone())
+            .context("invalid CGI advanced port state payload")?,
+        None => before_advanced.clone(),
+    };
+    let target_p2p_cfg = match request.p2p.as_ref() {
+        Some(value) => serde_json::from_value::<ReolinkP2PConfig>(value.clone())
+            .context("invalid CGI P2P state payload")?,
+        None => before_p2p_cfg.clone(),
+    };
+
+    let target_net = ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
+    if target_net != before_net {
+        session.set_net_port(&target_net).await?;
+    }
+
+    let target_p2p = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p_cfg);
+    if target_p2p != before_p2p {
+        session.set_p2p(&target_p2p).await?;
+    }
+
+    let after_net = session.get_net_port().await?;
+    let after_p2p = session.get_p2p().await?;
+
+    Ok(ReolinkStateApplyResult {
+        before: ReolinkStateSnapshot {
+            normal: serde_json::to_value(before_normal)
+                .context("failed encoding CGI pre-update normal state")?,
+            advanced: serde_json::to_value(before_advanced)
+                .context("failed encoding CGI pre-update advanced state")?,
+            p2p: serde_json::to_value(before_p2p_cfg)
+                .context("failed encoding CGI pre-update p2p state")?,
+            ..ReolinkStateSnapshot::default()
+        },
+        after: ReolinkStateSnapshot {
+            normal: serde_json::to_value(after_net.normal())
+                .context("failed encoding CGI post-update normal state")?,
+            advanced: serde_json::to_value(after_net.advanced())
+                .context("failed encoding CGI post-update advanced state")?,
+            p2p: serde_json::to_value(after_p2p.config())
+                .context("failed encoding CGI post-update p2p state")?,
+            ..ReolinkStateSnapshot::default()
+        },
+        active_password: request.connection.password.clone(),
+    })
+}
+
+async fn login_existing_session(
+    request: &crate::reolink::ReolinkConnectRequest,
+) -> Result<ReolinkHttpSession> {
+    match ReolinkHttpSession::login(&request.ip, &request.username, &request.password).await? {
+        ReolinkLoginOutcome::Session(session) => Ok(session),
+        ReolinkLoginOutcome::Uninitialized { .. } => Err(anyhow!(
+            "Reolink CGI fallback cannot initialize a factory-reset device; use the proprietary 9000 provisioning path first"
+        )),
+    }
 }
 
 async fn bootstrap_user(

--- a/src/reolink_cgi.rs
+++ b/src/reolink_cgi.rs
@@ -1,0 +1,966 @@
+use crate::reolink::{
+    ReolinkAdvancedPortConfig, ReolinkNormalPortConfig, ReolinkP2PConfig, ReolinkSetupBridgeResult,
+    ReolinkSetupRequest,
+};
+use aes::Aes128;
+use anyhow::{Context, Result, anyhow};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use cfb_mode::cipher::{AsyncStreamCipher, KeyIvInit};
+use md5::{Digest, Md5};
+use rand::Rng;
+use reqwest::{Client, header};
+use serde_json::{Value, json};
+use std::{error::Error, fmt};
+
+const HTTP_TIMEOUT_SECS: u64 = 10;
+const HTTP_ENDPOINTS: [(&str, u16); 2] = [("http", 80), ("https", 443)];
+const ZERO_BLOCK: usize = 16;
+
+type Aes128CfbEnc = cfb_mode::Encryptor<Aes128>;
+type Aes128CfbDec = cfb_mode::Decryptor<Aes128>;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct ReolinkCgiNetPort {
+    media_port: i32,
+    http_enable: i32,
+    http_port: i32,
+    https_enable: i32,
+    https_port: i32,
+    onvif_enable: i32,
+    onvif_port: i32,
+    rtsp_enable: i32,
+    rtsp_port: i32,
+    rtmp_enable: i32,
+    rtmp_port: i32,
+}
+
+impl ReolinkCgiNetPort {
+    fn from_value(value: &Value) -> Result<Self> {
+        Ok(Self {
+            media_port: int_field(value, "mediaPort"),
+            http_enable: int_field(value, "httpEnable"),
+            http_port: int_field(value, "httpPort"),
+            https_enable: int_field(value, "httpsEnable"),
+            https_port: int_field(value, "httpsPort"),
+            onvif_enable: int_field(value, "onvifEnable"),
+            onvif_port: int_field(value, "onvifPort"),
+            rtsp_enable: int_field(value, "rtspEnable"),
+            rtsp_port: int_field(value, "rtspPort"),
+            rtmp_enable: int_field(value, "rtmpEnable"),
+            rtmp_port: int_field(value, "rtmpPort"),
+        })
+    }
+
+    fn to_value(&self) -> Value {
+        json!({
+            "mediaPort": self.media_port,
+            "httpEnable": self.http_enable,
+            "httpPort": self.http_port,
+            "httpsEnable": self.https_enable,
+            "httpsPort": self.https_port,
+            "onvifEnable": self.onvif_enable,
+            "onvifPort": self.onvif_port,
+            "rtspEnable": self.rtsp_enable,
+            "rtspPort": self.rtsp_port,
+            "rtmpEnable": self.rtmp_enable,
+            "rtmpPort": self.rtmp_port,
+        })
+    }
+
+    fn normal(&self) -> ReolinkNormalPortConfig {
+        ReolinkNormalPortConfig {
+            i_surv_port_enable: 1,
+            i_surv_port: self.media_port,
+            i_http_port_enable: self.http_enable,
+            i_http_port: self.http_port,
+            i_https_port_enable: self.https_enable,
+            i_https_port: self.https_port,
+        }
+    }
+
+    fn advanced(&self) -> ReolinkAdvancedPortConfig {
+        ReolinkAdvancedPortConfig {
+            i_onvif_port_enable: self.onvif_enable,
+            i_onvif_port: self.onvif_port,
+            i_rtsp_port_enable: self.rtsp_enable,
+            i_rtsp_port: self.rtsp_port,
+            i_rtmp_port_enable: self.rtmp_enable,
+            i_rtmp_port: self.rtmp_port,
+        }
+    }
+
+    fn with_updates(
+        _current: &Self,
+        normal: &ReolinkNormalPortConfig,
+        advanced: &ReolinkAdvancedPortConfig,
+    ) -> Self {
+        Self {
+            media_port: normal.i_surv_port,
+            http_enable: normal.i_http_port_enable,
+            http_port: normal.i_http_port,
+            https_enable: normal.i_https_port_enable,
+            https_port: normal.i_https_port,
+            onvif_enable: advanced.i_onvif_port_enable,
+            onvif_port: advanced.i_onvif_port,
+            rtsp_enable: advanced.i_rtsp_port_enable,
+            rtsp_port: advanced.i_rtsp_port,
+            rtmp_enable: advanced.i_rtmp_port_enable,
+            rtmp_port: advanced.i_rtmp_port,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct ReolinkCgiP2P {
+    enable: i32,
+    uid: String,
+}
+
+impl ReolinkCgiP2P {
+    fn from_value(value: &Value) -> Self {
+        Self {
+            enable: int_field(value, "enable"),
+            uid: str_field(value, "uid"),
+        }
+    }
+
+    fn to_value(&self) -> Value {
+        json!({
+            "enable": self.enable,
+            "uid": self.uid,
+        })
+    }
+
+    fn config(&self) -> ReolinkP2PConfig {
+        ReolinkP2PConfig {
+            i_enable: self.enable,
+            i_port: 0,
+            server_domain_name: String::new(),
+        }
+    }
+
+    fn with_updates(current: &Self, p2p: &ReolinkP2PConfig) -> Self {
+        Self {
+            enable: p2p.i_enable,
+            uid: current.uid.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ReolinkHttpCounter {
+    id: u32,
+    value: u32,
+}
+
+#[derive(Clone, Debug)]
+struct ReolinkHttpCrypto {
+    key: [u8; 16],
+    iv: [u8; 16],
+}
+
+impl ReolinkHttpCrypto {
+    fn from_login(username: &str, password: &str, nonce: &str, cnonce: &str) -> Self {
+        let key = upper16(&md5_hex(&format!("{nonce}-{password}-{cnonce}")));
+        let iv = upper16(&md5_hex(&format!(
+            "webapp-{cnonce}-{password}-{nonce}-{username}"
+        )));
+        Self { key, iv }
+    }
+
+    fn encrypt_string(&self, plain: &str) -> String {
+        let mut buf = plain.as_bytes().to_vec();
+        let rem = buf.len() % ZERO_BLOCK;
+        if rem != 0 {
+            buf.extend(std::iter::repeat_n(0u8, ZERO_BLOCK - rem));
+        }
+        Aes128CfbEnc::new((&self.key).into(), (&self.iv).into()).encrypt(&mut buf);
+        BASE64.encode(buf)
+    }
+
+    fn decrypt_string(&self, encoded: &str) -> Result<String> {
+        let mut buf = BASE64
+            .decode(encoded.trim())
+            .with_context(|| "failed decoding Reolink CGI payload base64")?;
+        Aes128CfbDec::new((&self.key).into(), (&self.iv).into()).decrypt(&mut buf);
+        while matches!(buf.last(), Some(0)) {
+            buf.pop();
+        }
+        String::from_utf8(buf).context("failed decoding Reolink CGI payload as UTF-8")
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ReolinkHttpSession {
+    client: Client,
+    base_url: String,
+    token: String,
+    counters: Vec<ReolinkHttpCounter>,
+    crypto: ReolinkHttpCrypto,
+}
+
+#[derive(Clone, Debug)]
+enum LoginOnOutcome {
+    Session(ReolinkHttpSession),
+    Uninitialized,
+}
+
+#[derive(Clone, Debug)]
+enum ReolinkLoginOutcome {
+    Session(ReolinkHttpSession),
+    Uninitialized { client: Client, base_url: String },
+}
+
+#[derive(Clone, Debug)]
+struct ReolinkCgiCommandError {
+    cmd: String,
+    code: i64,
+    rsp_code: i64,
+    detail: String,
+}
+
+impl ReolinkCgiCommandError {
+    fn is_rsp_code(&self, value: i64) -> bool {
+        self.rsp_code == value
+    }
+}
+
+impl fmt::Display for ReolinkCgiCommandError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Reolink CGI command {} failed with code {} (rspCode {}): {}",
+            self.cmd, self.code, self.rsp_code, self.detail
+        )
+    }
+}
+
+impl Error for ReolinkCgiCommandError {}
+
+impl ReolinkHttpSession {
+    async fn login(ip: &str, username: &str, password: &str) -> Result<ReolinkLoginOutcome> {
+        let client = Client::builder()
+            .danger_accept_invalid_certs(true)
+            .timeout(std::time::Duration::from_secs(HTTP_TIMEOUT_SECS))
+            .build()
+            .context("failed building Reolink HTTP client")?;
+
+        let mut last_error = None;
+        for (scheme, port) in HTTP_ENDPOINTS {
+            let base_url = format!("{scheme}://{ip}:{port}");
+            match Self::login_on(&client, &base_url, username, password).await {
+                Ok(LoginOnOutcome::Session(session)) => {
+                    return Ok(ReolinkLoginOutcome::Session(session));
+                }
+                Ok(LoginOnOutcome::Uninitialized) => {
+                    return Ok(ReolinkLoginOutcome::Uninitialized {
+                        client: client.clone(),
+                        base_url,
+                    });
+                }
+                Err(err) => last_error = Some(err),
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| {
+            anyhow!("Reolink CGI endpoint not reachable on http/80 or https/443")
+        }))
+    }
+
+    async fn login_on(
+        client: &Client,
+        base_url: &str,
+        username: &str,
+        password: &str,
+    ) -> Result<LoginOnOutcome> {
+        let login_path = "cgi-bin/api.cgi?cmd=Login";
+        let url = format!("{base_url}/{login_path}");
+        let first = client
+            .post(&url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&vec![json!({
+                "cmd": "Login",
+                "action": 0,
+                "param": {"Version": 1},
+            })])?)
+            .send()
+            .await
+            .with_context(|| format!("failed reaching {url}"))?;
+
+        let challenge_header = first
+            .headers()
+            .get(header::WWW_AUTHENTICATE)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string);
+        let first_body = first
+            .text()
+            .await
+            .context("failed reading Reolink CGI login probe response")?;
+
+        if challenge_header.is_none() {
+            let entry = response_entry("Login", &first_body, None)?;
+            if let Some(error) = command_error("Login", &entry) {
+                if error.is_rsp_code(-505) {
+                    return Ok(LoginOnOutcome::Uninitialized);
+                }
+                return Err(error.into());
+            }
+            return Err(anyhow!(
+                "Reolink CGI login did not return a digest challenge"
+            ));
+        }
+
+        let challenge = parse_digest_header(challenge_header.as_deref().unwrap_or_default())?;
+        let cnonce = random_hex(48);
+        let response = md5_hex(&format!(
+            "{}:{}:{}:{}:{}:{}",
+            md5_hex(&format!("{username}:{}:{password}", challenge.realm)),
+            challenge.nonce,
+            challenge.nc,
+            cnonce,
+            challenge.qop,
+            md5_hex(&format!("POST:{login_path}")),
+        ));
+
+        let crypto = ReolinkHttpCrypto::from_login(username, password, &challenge.nonce, &cnonce);
+        let second = client
+            .post(&url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(serde_json::to_vec(&vec![json!({
+                "cmd": "Login",
+                "action": 0,
+                "param": {
+                    "Version": 1,
+                    "Digest": {
+                        "UserName": username,
+                        "Realm": challenge.realm,
+                        "Method": "POST",
+                        "Uri": login_path,
+                        "Nonce": challenge.nonce,
+                        "Nc": challenge.nc,
+                        "Cnonce": cnonce,
+                        "Qop": challenge.qop,
+                        "Response": response,
+                    }
+                },
+            })])?)
+            .send()
+            .await
+            .context("failed submitting Reolink CGI digest login")?;
+
+        if !second.status().is_success() {
+            return Err(anyhow!(
+                "Reolink CGI login failed with HTTP {}",
+                second.status()
+            ));
+        }
+
+        let body = second
+            .text()
+            .await
+            .context("failed reading Reolink CGI login response")?;
+        let entry = response_entry("Login", &body, Some(&crypto))?;
+        if let Some(error) = command_error("Login", &entry) {
+            if error.is_rsp_code(-505) {
+                return Ok(LoginOnOutcome::Uninitialized);
+            }
+            return Err(error.into());
+        }
+
+        let token = entry
+            .get("value")
+            .and_then(|value| value.get("Token"))
+            .ok_or_else(|| anyhow!("Reolink CGI login response missing Token"))?;
+
+        let token_name = token
+            .get("name")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+            .ok_or_else(|| anyhow!("Reolink CGI login response missing token name"))?
+            .to_string();
+        let check_basic = token
+            .get("checkBasic")
+            .and_then(Value::as_u64)
+            .unwrap_or_default() as u32;
+        let count_total = token
+            .get("countTotal")
+            .and_then(Value::as_u64)
+            .unwrap_or(1)
+            .max(1) as u32;
+        let counters = (0..count_total)
+            .map(|id| ReolinkHttpCounter {
+                id,
+                value: check_basic,
+            })
+            .collect();
+
+        Ok(LoginOnOutcome::Session(Self {
+            client: client.clone(),
+            base_url: base_url.to_string(),
+            token: token_name,
+            counters,
+            crypto,
+        }))
+    }
+
+    async fn get_net_port(&mut self) -> Result<ReolinkCgiNetPort> {
+        let entry = self.send_command("GetNetPort", json!({})).await?;
+        let value = entry
+            .get("value")
+            .and_then(|value| value.get("NetPort"))
+            .ok_or_else(|| anyhow!("Reolink CGI GetNetPort response missing NetPort"))?;
+        ReolinkCgiNetPort::from_value(value)
+    }
+
+    async fn set_net_port(&mut self, net_port: &ReolinkCgiNetPort) -> Result<()> {
+        self.send_command("SetNetPort", json!({ "NetPort": net_port.to_value() }))
+            .await?;
+        Ok(())
+    }
+
+    async fn get_p2p(&mut self) -> Result<ReolinkCgiP2P> {
+        let entry = self.send_command("GetP2p", json!({})).await?;
+        let value = entry
+            .get("value")
+            .and_then(|value| value.get("P2p"))
+            .ok_or_else(|| anyhow!("Reolink CGI GetP2p response missing P2p"))?;
+        Ok(ReolinkCgiP2P::from_value(value))
+    }
+
+    async fn set_p2p(&mut self, p2p: &ReolinkCgiP2P) -> Result<()> {
+        self.send_command("SetP2p", json!({ "P2p": p2p.to_value() }))
+            .await?;
+        Ok(())
+    }
+
+    async fn modify_user(
+        &mut self,
+        username: &str,
+        old_password: &str,
+        new_password: &str,
+    ) -> Result<()> {
+        self.send_command(
+            "ModifyUser",
+            json!({
+                "User": {
+                    "userName": username,
+                    "oldPassword": old_password,
+                    "newPassword": new_password,
+                }
+            }),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn send_command(&mut self, cmd: &str, param: Value) -> Result<Value> {
+        let first = self.send_command_entry(cmd, param).await?;
+        if let Some(error) = command_error(cmd, &first) {
+            return Err(error.into());
+        }
+        Ok(first)
+    }
+
+    async fn send_command_entry(&mut self, cmd: &str, param: Value) -> Result<Value> {
+        let encrypt_query = self.next_query(cmd)?;
+        let request_url = format!(
+            "{}/cgi-bin/api.cgi?token={}&encrypt={}",
+            self.base_url, self.token, encrypt_query
+        );
+
+        let body = serde_json::to_string(&vec![json!({
+            "cmd": cmd,
+            "action": 0,
+            "param": param,
+        })])
+        .context("failed serializing Reolink CGI request")?;
+        let encrypted_body = self.crypto.encrypt_string(&body);
+
+        let response = self
+            .client
+            .post(request_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(encrypted_body)
+            .send()
+            .await
+            .with_context(|| format!("failed sending Reolink CGI command {cmd}"))?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!(
+                "Reolink CGI command {cmd} failed with HTTP {}",
+                response.status()
+            ));
+        }
+
+        let body = response
+            .text()
+            .await
+            .with_context(|| format!("failed reading Reolink CGI response for {cmd}"))?;
+        response_entry(cmd, &body, Some(&self.crypto))
+    }
+
+    async fn send_command_without_token(
+        client: &Client,
+        base_url: &str,
+        cmd: &str,
+        param: Value,
+    ) -> Result<Value> {
+        let request_url = format!("{base_url}/cgi-bin/api.cgi?cmd={cmd}");
+        let body = serde_json::to_vec(&vec![json!({
+            "cmd": cmd,
+            "action": 0,
+            "param": param,
+        })])
+        .context("failed serializing Reolink CGI request")?;
+        let response = client
+            .post(&request_url)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(body)
+            .send()
+            .await
+            .with_context(|| format!("failed sending Reolink CGI command {cmd}"))?;
+
+        if !response.status().is_success() {
+            return Err(anyhow!(
+                "Reolink CGI command {cmd} failed with HTTP {}",
+                response.status()
+            ));
+        }
+
+        let body = response
+            .text()
+            .await
+            .with_context(|| format!("failed reading Reolink CGI response for {cmd}"))?;
+        response_entry(cmd, &body, None)
+    }
+
+    fn next_query(&mut self, cmd: &str) -> Result<String> {
+        if self.counters.is_empty() {
+            self.counters.push(ReolinkHttpCounter { id: 0, value: 0 });
+        }
+
+        let index = self
+            .counters
+            .iter()
+            .position(|counter| counter.id > 2)
+            .unwrap_or(0);
+        let counter = &mut self.counters[index];
+        counter.value = counter.value.saturating_add(1);
+        let plain = format!(
+            "countId={}&checkNum={}&cmd={cmd}",
+            counter.id, counter.value
+        );
+        Ok(self.crypto.encrypt_string(&plain))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct DigestChallenge {
+    realm: String,
+    qop: String,
+    nonce: String,
+    nc: String,
+}
+
+pub async fn setup(request: &ReolinkSetupRequest) -> Result<ReolinkSetupBridgeResult> {
+    let desired_password = request.desired_password.trim();
+    let mut login_password = request.password.trim().to_string();
+    let mut bootstrapped = false;
+
+    let mut session = match ReolinkHttpSession::login(
+        &request.ip,
+        &request.username,
+        &login_password,
+    )
+    .await?
+    {
+        ReolinkLoginOutcome::Session(session) => session,
+        ReolinkLoginOutcome::Uninitialized { client, base_url } => {
+            let bootstrap_password = if !desired_password.is_empty() {
+                desired_password.to_string()
+            } else if !login_password.is_empty() {
+                login_password.clone()
+            } else {
+                return Err(anyhow!(
+                    "Reolink device is uninitialized; provide desired_password or enable generate_password"
+                ));
+            };
+            bootstrap_user(&client, &base_url, &request.username, &bootstrap_password).await?;
+            bootstrapped = true;
+            login_password = bootstrap_password;
+            match ReolinkHttpSession::login_on(
+                &client,
+                &base_url,
+                &request.username,
+                &login_password,
+            )
+            .await?
+            {
+                LoginOnOutcome::Session(session) => session,
+                LoginOnOutcome::Uninitialized => {
+                    return Err(anyhow!(
+                        "Reolink device remained uninitialized after bootstrap user setup"
+                    ));
+                }
+            }
+        }
+    };
+
+    let before_net = session.get_net_port().await?;
+    let before_p2p = session.get_p2p().await?;
+    let before_normal = before_net.normal();
+    let before_advanced = before_net.advanced();
+
+    let target_normal = merge_normal(&before_normal, request.normal.as_ref());
+    let target_advanced = merge_advanced(&before_advanced, request.advanced.as_ref());
+    let target_p2p = merge_p2p(request.p2p.as_ref());
+
+    let target_net = ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
+    if target_net != before_net {
+        session.set_net_port(&target_net).await?;
+    }
+
+    let target_p2p_wire = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p);
+    if target_p2p_wire != before_p2p {
+        session.set_p2p(&target_p2p_wire).await?;
+    }
+
+    if !bootstrapped && !desired_password.is_empty() && desired_password != login_password {
+        session
+            .modify_user(&request.username, &login_password, desired_password)
+            .await?;
+    }
+
+    let after_net = session.get_net_port().await?;
+    let after_p2p = session.get_p2p().await?;
+
+    Ok(ReolinkSetupBridgeResult {
+        ip: request.ip.clone(),
+        username: request.username.clone(),
+        before_normal,
+        before_advanced,
+        before_p2p: before_p2p.config(),
+        after_normal: after_net.normal(),
+        after_advanced: after_net.advanced(),
+        after_p2p: after_p2p.config(),
+    })
+}
+
+async fn bootstrap_user(
+    client: &Client,
+    base_url: &str,
+    username: &str,
+    password: &str,
+) -> Result<()> {
+    let existing =
+        ReolinkHttpSession::send_command_without_token(client, base_url, "GetUser", json!({}))
+            .await
+            .ok();
+    let user_exists = existing
+        .as_ref()
+        .and_then(|entry| entry.get("value"))
+        .and_then(|value| value.get("User"))
+        .and_then(Value::as_array)
+        .map(|users| {
+            users.iter().any(|user| {
+                user.get("userName")
+                    .and_then(Value::as_str)
+                    .map(|value| value.eq_ignore_ascii_case(username))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+
+    if !user_exists {
+        match ReolinkHttpSession::send_command_without_token(
+            client,
+            base_url,
+            "AddUser",
+            json!({
+                "User": {
+                    "userName": username,
+                    "password": password,
+                    "level": "admin",
+                }
+            }),
+        )
+        .await
+        {
+            Ok(entry) => {
+                if let Some(error) = command_error("AddUser", &entry) {
+                    if !error.is_rsp_code(-28) {
+                        return Err(error.into());
+                    }
+                } else {
+                    return Ok(());
+                }
+            }
+            Err(err) => {
+                if err
+                    .downcast_ref::<ReolinkCgiCommandError>()
+                    .is_none_or(|error| !error.is_rsp_code(-28))
+                {
+                    return Err(err.context("failed creating bootstrap Reolink user"));
+                }
+            }
+        }
+    }
+
+    let entry = ReolinkHttpSession::send_command_without_token(
+        client,
+        base_url,
+        "ModifyUser",
+        json!({
+            "User": {
+                "userName": username,
+                "oldPassword": "",
+                "newPassword": password,
+            }
+        }),
+    )
+    .await
+    .context("failed updating bootstrap Reolink user password")?;
+    if let Some(error) = command_error("ModifyUser", &entry) {
+        return Err(error.into());
+    }
+    Ok(())
+}
+
+fn merge_normal(
+    current: &ReolinkNormalPortConfig,
+    requested: Option<&ReolinkNormalPortConfig>,
+) -> ReolinkNormalPortConfig {
+    requested
+        .cloned()
+        .unwrap_or_else(|| ReolinkNormalPortConfig {
+            i_surv_port_enable: current.i_surv_port_enable,
+            i_surv_port: current.i_surv_port,
+            i_http_port_enable: 0,
+            i_http_port: current.i_http_port,
+            i_https_port_enable: 0,
+            i_https_port: current.i_https_port,
+        })
+}
+
+fn merge_advanced(
+    current: &ReolinkAdvancedPortConfig,
+    requested: Option<&ReolinkAdvancedPortConfig>,
+) -> ReolinkAdvancedPortConfig {
+    let base = ReolinkAdvancedPortConfig {
+        i_onvif_port_enable: 1,
+        i_onvif_port: 8000,
+        i_rtsp_port_enable: 1,
+        i_rtsp_port: 554,
+        i_rtmp_port_enable: current.i_rtmp_port_enable,
+        i_rtmp_port: current.i_rtmp_port,
+    };
+    if let Some(requested) = requested {
+        ReolinkAdvancedPortConfig {
+            i_onvif_port_enable: requested.i_onvif_port_enable,
+            i_onvif_port: requested.i_onvif_port,
+            i_rtsp_port_enable: requested.i_rtsp_port_enable,
+            i_rtsp_port: requested.i_rtsp_port,
+            i_rtmp_port_enable: requested.i_rtmp_port_enable,
+            i_rtmp_port: requested.i_rtmp_port,
+        }
+    } else {
+        base
+    }
+}
+
+fn merge_p2p(requested: Option<&ReolinkP2PConfig>) -> ReolinkP2PConfig {
+    requested.cloned().unwrap_or_else(|| ReolinkP2PConfig {
+        i_enable: 0,
+        i_port: 0,
+        server_domain_name: String::new(),
+    })
+}
+
+fn response_entry(cmd: &str, body: &str, crypto: Option<&ReolinkHttpCrypto>) -> Result<Value> {
+    let parsed: Value = if let Some(crypto) = crypto {
+        if let Ok(decrypted) = crypto.decrypt_string(body) {
+            serde_json::from_str(&decrypted)
+                .with_context(|| format!("failed parsing decrypted Reolink CGI JSON for {cmd}"))?
+        } else {
+            serde_json::from_str(body)
+                .with_context(|| format!("failed parsing Reolink CGI JSON for {cmd}"))?
+        }
+    } else {
+        serde_json::from_str(body)
+            .with_context(|| format!("failed parsing Reolink CGI JSON for {cmd}"))?
+    };
+
+    let first = parsed
+        .as_array()
+        .and_then(|items| items.first())
+        .ok_or_else(|| anyhow!("Reolink CGI {cmd} returned an empty response"))?
+        .clone();
+    let actual_cmd = first.get("cmd").and_then(Value::as_str).unwrap_or_default();
+    if !actual_cmd.is_empty() && actual_cmd != cmd {
+        return Err(anyhow!(
+            "Reolink CGI response command mismatch: expected {cmd}, got {actual_cmd}"
+        ));
+    }
+    Ok(first)
+}
+
+fn command_error(cmd: &str, entry: &Value) -> Option<ReolinkCgiCommandError> {
+    let code = entry.get("code").and_then(Value::as_i64).unwrap_or(-1);
+    if code == 0 {
+        return None;
+    }
+
+    let detail = entry
+        .get("error")
+        .and_then(|error| error.get("detail"))
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string();
+    let rsp_code = entry
+        .get("error")
+        .and_then(|error| error.get("rspCode"))
+        .and_then(Value::as_i64)
+        .unwrap_or_default();
+    Some(ReolinkCgiCommandError {
+        cmd: cmd.to_string(),
+        code,
+        rsp_code,
+        detail,
+    })
+}
+
+fn parse_digest_header(header_value: &str) -> Result<DigestChallenge> {
+    let raw = header_value
+        .trim()
+        .strip_prefix("Digest")
+        .unwrap_or(header_value)
+        .trim();
+    let mut realm = String::new();
+    let mut qop = String::new();
+    let mut nonce = String::new();
+    let mut nc = String::new();
+
+    for part in raw.split(',') {
+        let mut pieces = part.trim().splitn(2, '=');
+        let key = pieces.next().unwrap_or_default().trim();
+        let value = pieces
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .trim_matches('"')
+            .to_string();
+        match key {
+            "realm" => realm = value,
+            "qop" => qop = value,
+            "nonce" => nonce = value,
+            "nc" => nc = value,
+            _ => {}
+        }
+    }
+
+    if realm.is_empty() || qop.is_empty() || nonce.is_empty() || nc.is_empty() {
+        return Err(anyhow!("Reolink CGI digest challenge was incomplete"));
+    }
+
+    Ok(DigestChallenge {
+        realm,
+        qop,
+        nonce,
+        nc,
+    })
+}
+
+fn int_field(value: &Value, key: &str) -> i32 {
+    value.get(key).and_then(Value::as_i64).unwrap_or_default() as i32
+}
+
+fn str_field(value: &Value, key: &str) -> String {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string()
+}
+
+fn md5_hex(input: &str) -> String {
+    let mut hasher = Md5::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    format!("{:032x}", digest)
+}
+
+fn upper16(value: &str) -> [u8; 16] {
+    let mut out = [0u8; 16];
+    let bytes = value.as_bytes();
+    for (idx, slot) in out.iter_mut().enumerate() {
+        *slot = bytes.get(idx).copied().unwrap_or(b'0').to_ascii_uppercase();
+    }
+    out
+}
+
+fn random_hex(len: usize) -> String {
+    const HEX: &[u8] = b"0123456789abcdef";
+    let mut rng = rand::thread_rng();
+    (0..len)
+        .map(|_| HEX[rng.gen_range(0..HEX.len())] as char)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_digest_challenge() {
+        let parsed = parse_digest_header(
+            "Digest realm=\"IPC\", qop=\"auth\", nonce=\"abc\", nc=\"00000001\"",
+        )
+        .expect("challenge");
+        assert_eq!(parsed.realm, "IPC");
+        assert_eq!(parsed.qop, "auth");
+        assert_eq!(parsed.nonce, "abc");
+        assert_eq!(parsed.nc, "00000001");
+    }
+
+    #[test]
+    fn reolink_http_crypto_roundtrips() {
+        let crypto =
+            ReolinkHttpCrypto::from_login("admin", "test1234", "nonce123", "abcdef0123456789");
+        let plain = r#"[{\"cmd\":\"GetNetPort\",\"action\":0,\"param\":{}}]"#;
+        let encoded = crypto.encrypt_string(plain);
+        let decoded = crypto.decrypt_string(&encoded).expect("decode");
+        assert_eq!(decoded, plain);
+    }
+
+    #[test]
+    fn cgi_net_port_maps_to_setup_configs() {
+        let port = ReolinkCgiNetPort {
+            media_port: 9000,
+            http_enable: 1,
+            http_port: 80,
+            https_enable: 0,
+            https_port: 443,
+            onvif_enable: 1,
+            onvif_port: 8000,
+            rtsp_enable: 1,
+            rtsp_port: 554,
+            rtmp_enable: 0,
+            rtmp_port: 1935,
+        };
+        assert_eq!(port.normal().i_http_port, 80);
+        assert_eq!(port.advanced().i_onvif_port, 8000);
+        assert_eq!(port.advanced().i_rtsp_port, 554);
+    }
+
+    #[test]
+    fn parses_login_uninitialized_error() {
+        let entry = response_entry(
+            "Login",
+            r#"[{"cmd":"Login","code":1,"error":{"rspCode":-505,"detail":"login not init"}}]"#,
+            None,
+        )
+        .expect("entry");
+        let error = command_error("Login", &entry).expect("error");
+        assert!(error.is_rsp_code(-505));
+    }
+}

--- a/src/reolink_proto.rs
+++ b/src/reolink_proto.rs
@@ -1,0 +1,2548 @@
+use aes::Aes128;
+use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReolinkFrameHeader {
+    Short {
+        op: u32,
+        payload_len: u32,
+        field_c: u32,
+        field_d: u32,
+        header_len: usize,
+        total_len: usize,
+    },
+    Extended {
+        op: u32,
+        payload_len: u32,
+        field_c: u32,
+        field_d: u32,
+        field_e: u32,
+        header_len: usize,
+        total_len: usize,
+    },
+}
+
+pub const MAGIC: [u8; 4] = [0xf0, 0xde, 0xbc, 0x0a];
+pub const OBSERVED_CLIENT_FIELD_D: u32 = 0x6414_0000;
+pub const OBSERVED_SERVER_OK: u32 = 200;
+pub const LOGIN_FRAME_LEN: usize = 316;
+pub const LOGIN_MESSAGE_STRUCT_LEN: usize = 0x60c;
+pub const LOGIN_MESSAGE_AUTH_MODE_OFFSET: usize = 0x00;
+pub const LOGIN_MESSAGE_PORT_OFFSET: usize = 0x04;
+pub const LOGIN_MESSAGE_UID_PORT_OFFSET: usize = 0x08;
+pub const LOGIN_MESSAGE_NAME_OFFSET: usize = 0x0c;
+pub const LOGIN_MESSAGE_NAME_FIELD_LEN: usize = 0x100;
+pub const LOGIN_MESSAGE_HOST_OFFSET: usize = 0x10c;
+pub const LOGIN_MESSAGE_HOST_FIELD_LEN: usize = 0x400;
+pub const LOGIN_MESSAGE_UID_OFFSET: usize = 0x50c;
+pub const LOGIN_MESSAGE_UID_FIELD_LEN: usize = 0x80;
+pub const LOGIN_MESSAGE_USERNAME_OFFSET: usize = 0x58c;
+pub const LOGIN_MESSAGE_USERNAME_FIELD_LEN: usize = 0x20;
+pub const LOGIN_MESSAGE_PASSWORD_OFFSET: usize = 0x5ac;
+pub const LOGIN_MESSAGE_PASSWORD_FIELD_LEN: usize = 0x20;
+pub const LOGIN_MESSAGE_AUTH_CODE_OFFSET: usize = 0x5cc;
+pub const LOGIN_MESSAGE_AUTH_CODE_FIELD_LEN: usize = 0x40;
+pub const AUTH_CODE_STRUCT_LEN: usize = 4;
+pub const AUTH_CODE_VALUE_OFFSET: usize = 0;
+pub const AUTH_INFO_STRUCT_LEN: usize = 152;
+pub const AUTH_INFO_NOTES_OFFSET: usize = 0;
+pub const AUTH_INFO_NOTES_FIELD_LEN: usize = 128;
+pub const AUTH_INFO_VALID_HOURS_OFFSET: usize = 128;
+pub const AUTH_INFO_USER_LEVEL_OFFSET: usize = 132;
+pub const AUTH_INFO_ABILITY_OFFSET: usize = 136;
+pub const AUTH_INFO_ABILITY_FIELD_LEN: usize = 4;
+pub const AUTH_INFO_CHANNEL_ABILITY_OFFSET: usize = 144;
+pub const BOOT_PWD_STATE_STRUCT_LEN: usize = 1;
+pub const BOOT_PWD_STATE_VALUE_OFFSET: usize = 0;
+pub const NET_NORMAL_PORT_STRUCT_LEN: usize = 24;
+pub const NET_NORMAL_PORT_SURV_ENABLE_OFFSET: usize = 0;
+pub const NET_NORMAL_PORT_SURV_OFFSET: usize = 4;
+pub const NET_NORMAL_PORT_HTTP_ENABLE_OFFSET: usize = 8;
+pub const NET_NORMAL_PORT_HTTP_OFFSET: usize = 12;
+pub const NET_NORMAL_PORT_HTTPS_ENABLE_OFFSET: usize = 16;
+pub const NET_NORMAL_PORT_HTTPS_OFFSET: usize = 20;
+pub const NET_ADVANCED_PORT_STRUCT_LEN: usize = 24;
+pub const NET_ADVANCED_PORT_ONVIF_ENABLE_OFFSET: usize = 0;
+pub const NET_ADVANCED_PORT_ONVIF_OFFSET: usize = 4;
+pub const NET_ADVANCED_PORT_RTSP_ENABLE_OFFSET: usize = 8;
+pub const NET_ADVANCED_PORT_RTSP_OFFSET: usize = 12;
+pub const NET_ADVANCED_PORT_RTMP_ENABLE_OFFSET: usize = 16;
+pub const NET_ADVANCED_PORT_RTMP_OFFSET: usize = 20;
+pub const P2P_CFG_STRUCT_LEN: usize = 40;
+pub const P2P_CFG_ENABLE_OFFSET: usize = 0;
+pub const P2P_CFG_PORT_OFFSET: usize = 4;
+pub const P2P_CFG_SERVER_DOMAIN_OFFSET: usize = 8;
+pub const P2P_CFG_SERVER_DOMAIN_FIELD_LEN: usize = 32;
+pub const FORCE_PASSWORD_STRUCT_LEN: usize = 96;
+pub const FORCE_PASSWORD_USERNAME_OFFSET: usize = 0;
+pub const FORCE_PASSWORD_USERNAME_FIELD_LEN: usize = 32;
+pub const FORCE_PASSWORD_PASSWORD_OFFSET: usize = 32;
+pub const FORCE_PASSWORD_PASSWORD_FIELD_LEN: usize = 32;
+pub const FORCE_PASSWORD_NICKNAME_OFFSET: usize = 64;
+pub const FORCE_PASSWORD_NICKNAME_FIELD_LEN: usize = 32;
+pub const PTZ_DECODER_STRUCT_LEN: usize = 800;
+pub const PTZ_DECODER_DATABIT_OFFSET: usize = 0;
+pub const PTZ_DECODER_STOPBIT_OFFSET: usize = 4;
+pub const PTZ_DECODER_ADDRESS_OFFSET: usize = 8;
+pub const PTZ_DECODER_BAUDRATE_OFFSET: usize = 12;
+pub const PTZ_DECODER_PARITY_OFFSET: usize = 16;
+pub const PTZ_DECODER_FLOWCONTROL_OFFSET: usize = 20;
+pub const PTZ_DECODER_TYPE_OFFSET: usize = 24;
+pub const PTZ_DECODER_SUPPORT_PELCO_C_OFFSET: usize = 28;
+pub const PTZ_DECODER_PRESET_OFFSET: usize = 32;
+pub const PTZ_DECODER_PRESET_FIELD_LEN: usize = 256;
+pub const PTZ_DECODER_CRUISE_OFFSET: usize = 288;
+pub const PTZ_DECODER_CRUISE_FIELD_LEN: usize = 256;
+pub const PTZ_DECODER_TRACK_OFFSET: usize = 544;
+pub const PTZ_DECODER_TRACK_FIELD_LEN: usize = 256;
+pub const PTZ_POSITION_STRUCT_LEN: usize = 12;
+pub const PTZ_POSITION_P_OFFSET: usize = 0;
+pub const PTZ_POSITION_T_OFFSET: usize = 4;
+pub const PTZ_POSITION_Z_OFFSET: usize = 8;
+pub const PTZ_3D_LOCATION_STRUCT_LEN: usize = 24;
+pub const PTZ_3D_LOCATION_TOP_LEFT_X_OFFSET: usize = 0;
+pub const PTZ_3D_LOCATION_TOP_LEFT_Y_OFFSET: usize = 4;
+pub const PTZ_3D_LOCATION_WIDTH_OFFSET: usize = 8;
+pub const PTZ_3D_LOCATION_HEIGHT_OFFSET: usize = 12;
+pub const PTZ_3D_LOCATION_STREAM_TYPE_OFFSET: usize = 16;
+pub const PTZ_3D_LOCATION_SPEED_OFFSET: usize = 20;
+pub const SMART_TRACK_TASK_STRUCT_LEN: usize = 672;
+pub const SMART_TRACK_TASK_TIMETABLE_LEN: usize = 168;
+pub const SMART_TRACK_LIMIT_POINT_STRUCT_LEN: usize = 36;
+pub const SMART_TRACK_LIMIT_POINT_LIMIT_OFFSET: usize = 0;
+pub const SMART_TRACK_LIMIT_POINT_IMAGE_NAME_OFFSET: usize = 4;
+pub const SMART_TRACK_LIMIT_POINT_IMAGE_NAME_FIELD_LEN: usize = 32;
+pub const SMART_TRACK_LIMIT_STRUCT_LEN: usize = 72;
+pub const SMART_TRACK_LIMIT_LEFT_OFFSET: usize = 0;
+pub const SMART_TRACK_LIMIT_RIGHT_OFFSET: usize = 36;
+pub const USER_RECORD_STRUCT_LEN: usize = 336;
+pub const USER_RECORD_USERNAME_OFFSET: usize = 0;
+pub const USER_RECORD_USERNAME_FIELD_LEN: usize = 32;
+pub const USER_RECORD_NICKNAME_OFFSET: usize = 32;
+pub const USER_RECORD_NICKNAME_FIELD_LEN: usize = 32;
+pub const USER_RECORD_PASSWORD_OFFSET: usize = 64;
+pub const USER_RECORD_PASSWORD_FIELD_LEN: usize = 32;
+pub const USER_RECORD_LOCAL_RIGHT_OFFSET: usize = 96;
+pub const USER_RECORD_LOCAL_RIGHT_FIELD_LEN: usize = 32;
+pub const USER_RECORD_OLD_IPC_RIGHT_OFFSET: usize = 128;
+pub const USER_RECORD_OLD_IPC_RIGHT_FIELD_LEN: usize = 32;
+pub const USER_RECORD_MAGIC_NUM_OFFSET: usize = 160;
+pub const USER_RECORD_USER_IP_OFFSET: usize = 164;
+pub const USER_RECORD_USER_IP_FIELD_LEN: usize = 128;
+pub const USER_RECORD_MAC_OFFSET: usize = 292;
+pub const USER_RECORD_MAC_FIELD_LEN: usize = 8;
+pub const USER_RECORD_LEVEL_OFFSET: usize = 300;
+pub const USER_RECORD_LOGIN_STATE_OFFSET: usize = 304;
+pub const USER_RECORD_VALID_PASSWORD_OFFSET: usize = 308;
+pub const USER_RECORD_USER_SET_STATE_OFFSET: usize = 312;
+pub const USER_RECORD_BOOT_PASSWORD_OFFSET: usize = 316;
+pub const USER_RECORD_VALID_HOURS_OFFSET: usize = 320;
+pub const USER_RECORD_CHANNEL_ABILITY_OFFSET: usize = 328;
+pub const USER_CFG_STRUCT_LEN: usize = 10792;
+pub const USER_CFG_CURRENT_USERNAME_OFFSET: usize = 0;
+pub const USER_CFG_CURRENT_USERNAME_FIELD_LEN: usize = 32;
+pub const USER_CFG_USERNUM_OFFSET: usize = 32;
+pub const USER_CFG_USERS_OFFSET: usize = 40;
+pub const USER_CFG_USERS_MAX: usize = 32;
+pub const SIGNATURE_LOGIN_CFG_STRUCT_LEN: usize = 20;
+pub const SIGNATURE_LOGIN_CFG_IS_OPENED_OFFSET: usize = 0;
+pub const SIGNATURE_LOGIN_CFG_VERSION_OFFSET: usize = 4;
+pub const SIGNATURE_LOGIN_CFG_V1_OFFSET: usize = 8;
+pub const SIGNATURE_LOGIN_CFG_V2_OFFSET: usize = 12;
+pub const SIGNATURE_LOGIN_CFG_V3_OFFSET: usize = 16;
+pub const LOGIN_LEADING_ZERO_LEN: usize = 4;
+pub const LOGIN_REFLECTED_SERVER_PREFIX_LEN: usize = 48;
+pub const LOGIN_REFLECTED_SERVER_PREFIX_WINDOW: std::ops::Range<usize> =
+    24..(24 + LOGIN_REFLECTED_SERVER_PREFIX_LEN);
+pub const SERVER_HANDSHAKE_CREDENTIAL_SALT_INDICES: [usize; 21] = [
+    105, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
+    125, 126,
+];
+pub const LOGIN_CREDENTIAL_WINDOW: std::ops::Range<usize> = 107..191;
+pub const LOGIN_USERNAME_WINDOW: std::ops::Range<usize> = 107..138;
+pub const LOGIN_MIDDLE_WINDOW: std::ops::Range<usize> = 138..160;
+pub const LOGIN_PASSWORD_WINDOW: std::ops::Range<usize> = 160..191;
+pub const BAICHUAN_KEY: [u8; 16] = *b"!shenzhenbaichua";
+pub const BAICHUAN_IV: [u8; 16] = *b"0123456789abcdef";
+
+pub const LOGIN_STATIC_MIDDLE: [u8; 22] = [
+    0x00, 0x64, 0x2f, 0x1a, 0x1d, 0x8d, 0x51, 0x4c, 0x51, 0x2e, 0x64, 0x63, 0x44, 0x8f, 0x7e, 0x5e,
+    0x4f, 0x3c, 0x35, 0x1b, 0x1c, 0xc1,
+];
+
+pub const SDK_CMD_GET_NORMAL_PORT: u32 = 2041;
+pub const SDK_CMD_SET_NORMAL_PORT: u32 = 2042;
+pub const SDK_CMD_GET_PTZCFG: u32 = 2057;
+pub const SDK_CMD_SET_PTZCFG: u32 = 2058;
+pub const SDK_CMD_GET_AUTOREBOOT_CFG: u32 = 2061;
+pub const SDK_CMD_SET_AUTOREBOOT_CFG: u32 = 2062;
+pub const SDK_CMD_GET_USERCFG: u32 = 2068;
+pub const SDK_CMD_SET_USERCFG: u32 = 2069;
+pub const SDK_CMD_GET_BOOTPWD_STATE: u32 = 2079;
+pub const SDK_CMD_SET_BOOTPWD_STATE: u32 = 2080;
+pub const SDK_CMD_LOGIN: u32 = 2087;
+pub const SDK_CMD_REBOOT: u32 = 2101;
+pub const SDK_CMD_PTZ_CONTROL: u32 = 2108;
+pub const SDK_CMD_GET_ADVANCED_PORTS: u32 = 2120;
+pub const SDK_CMD_GET_PRESET: u32 = 2126;
+pub const SDK_CMD_SET_PRESET: u32 = 2127;
+pub const SDK_CMD_GET_CRUISE: u32 = 2128;
+pub const SDK_CMD_SET_CRUISE: u32 = 2129;
+pub const SDK_CMD_SET_ADVANCED_PORTS: u32 = 2121;
+pub const SDK_CMD_FORCE_PASSWORD: u32 = 2124;
+pub const SDK_CMD_GET_PTOP_CFG: u32 = 2153;
+pub const SDK_CMD_SET_PTOP_CFG: u32 = 2154;
+pub const SDK_CMD_GET_SIGNATURE_LOGIN_CFG: u32 = 2227;
+pub const SDK_CMD_SET_SIGNATURE_LOGIN_CFG: u32 = 2228;
+pub const SDK_CMD_GET_SMART_TRACK_LIMIT_CFG: u32 = 2364;
+pub const SDK_CMD_SET_SMART_TRACK_LIMIT_CFG: u32 = 2365;
+pub const SDK_CMD_GET_PTZ_CUR_POS: u32 = 2367;
+pub const SDK_CMD_GET_SMART_TRACK_TASK_CFG: u32 = 2368;
+pub const SDK_CMD_SET_SMART_TRACK_TASK_CFG: u32 = 2369;
+pub const SDK_CMD_PTZ_3DLOCATION: u32 = 2374;
+pub const SDK_CMD_GET_LOGIN_AUTH_CODE: u32 = 2432;
+pub const SDK_CMD_SET_PTZ_POS: u32 = 2453;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReolinkRemoteCommand {
+    GetNetAdvancedPort,
+    SetNetAdvancedPort,
+    GetNetNormalPort,
+    SetNetNormalPort,
+    GetP2PCfg,
+    SetP2PCfg,
+    GetBootPwdState,
+    SetBootPwdState,
+    ForceUserPassword,
+    GetLoginAuthCode,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReolinkDispatchKind {
+    HeaderOnly,
+    Payload,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkObservedDispatch {
+    pub kind: ReolinkDispatchKind,
+    pub request_id: u32,
+    pub payload_len: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkObservedTransportRequest {
+    pub op: ReolinkTransportOp,
+    pub payload_len: u32,
+}
+
+impl ReolinkRemoteCommand {
+    pub fn request_id(self) -> u32 {
+        match self {
+            Self::GetNetAdvancedPort => 0x848,
+            Self::SetNetAdvancedPort => 0x849,
+            Self::GetNetNormalPort => 0x7f9,
+            Self::SetNetNormalPort => 0x7fa,
+            Self::GetP2PCfg | Self::SetP2PCfg => 0x869,
+            Self::GetBootPwdState => 0x81f,
+            Self::SetBootPwdState => 0x820,
+            Self::ForceUserPassword => 0x84c,
+            Self::GetLoginAuthCode => 0x980,
+        }
+    }
+
+    pub fn payload_len(self) -> u32 {
+        match self {
+            Self::GetNetAdvancedPort
+            | Self::GetNetNormalPort
+            | Self::GetP2PCfg
+            | Self::GetBootPwdState => 0,
+            Self::SetBootPwdState => 0x01,
+            Self::SetNetAdvancedPort | Self::SetNetNormalPort => 0x18,
+            Self::SetP2PCfg => 0x28,
+            Self::ForceUserPassword => 0x60,
+            Self::GetLoginAuthCode => 0x98,
+        }
+    }
+
+    pub fn observed_dispatch(self) -> Option<ReolinkObservedDispatch> {
+        Some(match self {
+            Self::GetNetAdvancedPort => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::HeaderOnly,
+                request_id: 0x848,
+                payload_len: 0,
+            },
+            Self::SetNetAdvancedPort => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x849,
+                payload_len: 0x18,
+            },
+            Self::GetP2PCfg => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::HeaderOnly,
+                request_id: 0x8a4,
+                payload_len: 0,
+            },
+            Self::SetP2PCfg => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x86a,
+                payload_len: 0x28,
+            },
+            Self::GetBootPwdState => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::HeaderOnly,
+                request_id: 0x81f,
+                payload_len: 0,
+            },
+            Self::SetBootPwdState => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x820,
+                payload_len: 0x01,
+            },
+            Self::GetLoginAuthCode => ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x980,
+                payload_len: 0x98,
+            },
+            // These still fan out through multiple helper IDs in the native wrapper.
+            Self::GetNetNormalPort | Self::SetNetNormalPort | Self::ForceUserPassword => {
+                return None;
+            }
+        })
+    }
+
+    pub fn observed_primary_transport(self) -> Option<ReolinkObservedTransportRequest> {
+        Some(match self {
+            Self::GetNetAdvancedPort => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadPortBundle,
+                payload_len: 0,
+            },
+            Self::SetNetAdvancedPort => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WritePortBundle,
+                payload_len: 304,
+            },
+            Self::GetNetNormalPort => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadPortBundle,
+                payload_len: 0,
+            },
+            Self::SetNetNormalPort => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WritePortBundle,
+                payload_len: 310,
+            },
+            Self::GetP2PCfg => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadP2P,
+                payload_len: 0,
+            },
+            Self::SetP2PCfg => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WriteP2P,
+                payload_len: 144,
+            },
+            Self::GetBootPwdState => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadBootPwdState,
+                payload_len: 0,
+            },
+            Self::SetBootPwdState => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WriteBootPwdState,
+                payload_len: 123,
+            },
+            Self::ForceUserPassword => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ForceUserPassword,
+                payload_len: 328,
+            },
+            Self::GetLoginAuthCode => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadLoginAuthCode,
+                payload_len: 218,
+            },
+        })
+    }
+
+    pub fn observed_apply_transport(self) -> Option<ReolinkObservedTransportRequest> {
+        None
+    }
+
+    pub fn observed_transport_ops(self) -> Option<&'static [ReolinkTransportOp]> {
+        Some(match self {
+            Self::GetNetAdvancedPort => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ReadPortBundle,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::SetNetAdvancedPort => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::WritePortBundle,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::GetNetNormalPort => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ReadPortBundle,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::SetNetNormalPort => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::WritePortBundle,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::ForceUserPassword => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ForceUserPassword,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::GetP2PCfg => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ReadP2P,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::GetBootPwdState => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ReadBootPwdState,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::SetBootPwdState => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::WriteBootPwdState,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::SetP2PCfg => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::WriteP2P,
+                ReolinkTransportOp::Telemetry,
+            ],
+            Self::GetLoginAuthCode => &[
+                ReolinkTransportOp::CommonReadA,
+                ReolinkTransportOp::CommonReadB,
+                ReolinkTransportOp::CommonReadC,
+                ReolinkTransportOp::ReadLoginAuthCode,
+                ReolinkTransportOp::Telemetry,
+            ],
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn observed_verify_transport_ops(self) -> Option<&'static [ReolinkTransportOp]> {
+        Some(match self {
+            Self::SetNetNormalPort => &[ReolinkTransportOp::ReadPortBundle],
+            Self::SetP2PCfg => &[ReolinkTransportOp::ReadP2P],
+            _ => return None,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReolinkTransportOp {
+    Handshake = 0x01,
+    AsyncStatus = 0x02,
+    Login = 0x97,
+    ReadLoginAuthCode = 0x1fd,
+    SessionBind = 0x3a,
+    ChannelReady = 0x92,
+    CommonAck = 0xc0,
+    CommonReadA = 0x66,
+    CommonReadB = 0x50,
+    CommonReadC = 0x72,
+    ReadPortBundle = 0x25,
+    ReadP2P = 0xd2,
+    ReadBootPwdState = 0x76,
+    WriteBootPwdState = 0x77,
+    WritePortBundle = 0x24,
+    WriteP2P = 0xd3,
+    ForceUserPassword = 0x3b,
+    ApplyConfig = 0x0a,
+    Telemetry = 0xc7,
+}
+
+impl ReolinkTransportOp {
+    pub fn from_u32(value: u32) -> Option<Self> {
+        Some(match value {
+            0x01 => Self::Handshake,
+            0x02 => Self::AsyncStatus,
+            0x97 => Self::Login,
+            0x1fd => Self::ReadLoginAuthCode,
+            0x3a => Self::SessionBind,
+            0x92 => Self::ChannelReady,
+            0xc0 => Self::CommonAck,
+            0x66 => Self::CommonReadA,
+            0x50 => Self::CommonReadB,
+            0x72 => Self::CommonReadC,
+            0x25 => Self::ReadPortBundle,
+            0xd2 => Self::ReadP2P,
+            0x76 => Self::ReadBootPwdState,
+            0x77 => Self::WriteBootPwdState,
+            0x24 => Self::WritePortBundle,
+            0xd3 => Self::WriteP2P,
+            0x3b => Self::ForceUserPassword,
+            0x0a => Self::ApplyConfig,
+            0xc7 => Self::Telemetry,
+            _ => return None,
+        })
+    }
+}
+
+impl ReolinkFrameHeader {
+    pub fn op(&self) -> u32 {
+        match self {
+            Self::Short { op, .. } | Self::Extended { op, .. } => *op,
+        }
+    }
+
+    pub fn header_len(&self) -> usize {
+        match self {
+            Self::Short { header_len, .. } | Self::Extended { header_len, .. } => *header_len,
+        }
+    }
+
+    pub fn total_len(&self) -> usize {
+        match self {
+            Self::Short { total_len, .. } | Self::Extended { total_len, .. } => *total_len,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ReolinkSegment<'a> {
+    Frame {
+        header: ReolinkFrameHeader,
+        body: &'a [u8],
+    },
+    Opaque(&'a [u8]),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkAuthCode {
+    pub auth_code: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkBootPwdState {
+    pub has_boot_password: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkAuthInfo {
+    pub notes: Vec<u8>,
+    pub valid_hours: i32,
+    pub user_level: i32,
+    pub ability: u32,
+    pub channel_ability: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkNetNormalPort {
+    pub surv_enabled: bool,
+    pub surv_port: u32,
+    pub http_enabled: bool,
+    pub http_port: u32,
+    pub https_enabled: bool,
+    pub https_port: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkNetAdvancedPort {
+    pub onvif_enabled: bool,
+    pub onvif_port: u32,
+    pub rtsp_enabled: bool,
+    pub rtsp_port: u32,
+    pub rtmp_enabled: bool,
+    pub rtmp_port: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkP2PCfg {
+    pub enabled: bool,
+    pub port: u32,
+    pub server_domain: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkForcePassword {
+    pub username: String,
+    pub password: String,
+    pub nickname: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkPtzDecoder {
+    pub data_bit: i32,
+    pub stop_bit: i32,
+    pub decoder_address: i32,
+    pub baud_rate: i32,
+    pub parity: i32,
+    pub flow_control: i32,
+    pub decoder_type: i32,
+    pub support_pelco_c: i32,
+    pub preset: Vec<u8>,
+    pub cruise: Vec<u8>,
+    pub track: Vec<u8>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ReolinkPtzPosition {
+    pub pan: i32,
+    pub tilt: i32,
+    pub zoom: i32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ReolinkPtz3DLocation {
+    pub top_left_x: f32,
+    pub top_left_y: f32,
+    pub width: f32,
+    pub height: f32,
+    pub stream_type: i32,
+    pub speed: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkSmartTrackTask {
+    pub timetable: [i32; SMART_TRACK_TASK_TIMETABLE_LEN],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkSmartTrackLimitPoint {
+    pub limit: i32,
+    pub image_name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkSmartTrackLimit {
+    pub left: ReolinkSmartTrackLimitPoint,
+    pub right: ReolinkSmartTrackLimitPoint,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkUserRecord {
+    pub username: String,
+    pub nickname: String,
+    pub password: String,
+    pub local_right: String,
+    pub old_ipc_right: String,
+    pub magic_num: i32,
+    pub user_ip: String,
+    pub mac_address: Vec<u8>,
+    pub user_level: i32,
+    pub login_state: i32,
+    pub valid_password: i32,
+    pub user_set_state: i32,
+    pub boot_password: i32,
+    pub valid_hours: i32,
+    pub channel_ability: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkUserConfig {
+    pub current_username: String,
+    pub user_count: i32,
+    pub users: Vec<ReolinkUserRecord>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ReolinkSignatureLoginCfg {
+    pub is_opened: i32,
+    pub version: i32,
+    pub supported_versions: [i32; 3],
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReolinkLoginMessage {
+    pub auth_mode: u32,
+    pub port: u32,
+    pub uid_port: u32,
+    pub name: String,
+    pub host: String,
+    pub uid: String,
+    pub username: String,
+    pub password: String,
+    pub auth_code: String,
+}
+
+pub fn parse_frame_header(buf: &[u8]) -> Option<ReolinkFrameHeader> {
+    if buf.len() < 20 || buf[..4] != MAGIC {
+        return None;
+    }
+
+    let op = u32::from_le_bytes(buf[4..8].try_into().ok()?);
+    let payload_len = u32::from_le_bytes(buf[8..12].try_into().ok()?);
+    let field_c = u32::from_le_bytes(buf[12..16].try_into().ok()?);
+    let field_d = u32::from_le_bytes(buf[16..20].try_into().ok()?);
+
+    if op == ReolinkTransportOp::Handshake as u32 {
+        let short_total = 20usize.saturating_add(payload_len as usize);
+        if buf.len() >= short_total && (buf.len() == short_total || buf.len() < short_total + 4) {
+            return Some(ReolinkFrameHeader::Short {
+                op,
+                payload_len,
+                field_c,
+                field_d,
+                header_len: 20,
+                total_len: short_total,
+            });
+        }
+    }
+
+    if buf.len() < 24 {
+        return None;
+    }
+
+    let field_e = u32::from_le_bytes(buf[20..24].try_into().ok()?);
+    let total_len = 24usize.saturating_add(payload_len as usize);
+    if buf.len() < total_len {
+        return None;
+    }
+
+    Some(ReolinkFrameHeader::Extended {
+        op,
+        payload_len,
+        field_c,
+        field_d,
+        field_e,
+        header_len: 24,
+        total_len,
+    })
+}
+
+pub fn split_segments(mut buf: &[u8]) -> Vec<ReolinkSegment<'_>> {
+    let mut out = Vec::new();
+    while !buf.is_empty() {
+        if buf.len() < 4 {
+            out.push(ReolinkSegment::Opaque(buf));
+            break;
+        }
+        if buf[..4] != MAGIC {
+            if let Some(next) = buf.windows(4).position(|window| window == MAGIC) {
+                if next > 0 {
+                    out.push(ReolinkSegment::Opaque(&buf[..next]));
+                    buf = &buf[next..];
+                    continue;
+                }
+            }
+            out.push(ReolinkSegment::Opaque(buf));
+            break;
+        }
+
+        if let Some(header) = parse_frame_header(buf) {
+            let header_len = header.header_len();
+            let total_len = header.total_len();
+            let body = &buf[header_len..total_len];
+            out.push(ReolinkSegment::Frame { header, body });
+            buf = &buf[total_len..];
+            continue;
+        }
+
+        out.push(ReolinkSegment::Opaque(buf));
+        break;
+    }
+    out
+}
+
+fn trim_trailing_nul(buf: &[u8]) -> Vec<u8> {
+    let used = buf
+        .iter()
+        .rposition(|byte| *byte != 0)
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    buf[..used].to_vec()
+}
+
+fn read_fixed_c_string(buf: &[u8], offset: usize, field_len: usize) -> Option<String> {
+    let field = buf.get(offset..offset.checked_add(field_len)?)?;
+    let used = field
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(field.len());
+    Some(String::from_utf8_lossy(&field[..used]).to_string())
+}
+
+fn write_fixed_c_string(
+    out: &mut [u8],
+    offset: usize,
+    field_len: usize,
+    value: &str,
+) -> Option<()> {
+    let field = out.get_mut(offset..offset.checked_add(field_len)?)?;
+    field.fill(0);
+    let bytes = value.as_bytes();
+    if bytes.len() >= field_len {
+        return None;
+    }
+    field[..bytes.len()].copy_from_slice(bytes);
+    Some(())
+}
+
+pub fn parse_login_message(buf: &[u8]) -> Option<ReolinkLoginMessage> {
+    if buf.len() < LOGIN_MESSAGE_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkLoginMessage {
+        auth_mode: u32::from_le_bytes(
+            buf.get(LOGIN_MESSAGE_AUTH_MODE_OFFSET..LOGIN_MESSAGE_AUTH_MODE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        port: u32::from_le_bytes(
+            buf.get(LOGIN_MESSAGE_PORT_OFFSET..LOGIN_MESSAGE_PORT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        uid_port: u32::from_le_bytes(
+            buf.get(LOGIN_MESSAGE_UID_PORT_OFFSET..LOGIN_MESSAGE_UID_PORT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        name: read_fixed_c_string(buf, LOGIN_MESSAGE_NAME_OFFSET, LOGIN_MESSAGE_NAME_FIELD_LEN)?,
+        host: read_fixed_c_string(buf, LOGIN_MESSAGE_HOST_OFFSET, LOGIN_MESSAGE_HOST_FIELD_LEN)?,
+        uid: read_fixed_c_string(buf, LOGIN_MESSAGE_UID_OFFSET, LOGIN_MESSAGE_UID_FIELD_LEN)?,
+        username: read_fixed_c_string(
+            buf,
+            LOGIN_MESSAGE_USERNAME_OFFSET,
+            LOGIN_MESSAGE_USERNAME_FIELD_LEN,
+        )?,
+        password: read_fixed_c_string(
+            buf,
+            LOGIN_MESSAGE_PASSWORD_OFFSET,
+            LOGIN_MESSAGE_PASSWORD_FIELD_LEN,
+        )?,
+        auth_code: read_fixed_c_string(
+            buf,
+            LOGIN_MESSAGE_AUTH_CODE_OFFSET,
+            LOGIN_MESSAGE_AUTH_CODE_FIELD_LEN,
+        )?,
+    })
+}
+
+pub fn parse_auth_code(buf: &[u8]) -> Option<ReolinkAuthCode> {
+    if buf.len() < AUTH_CODE_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkAuthCode {
+        auth_code: i32::from_le_bytes(
+            buf.get(AUTH_CODE_VALUE_OFFSET..AUTH_CODE_VALUE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_auth_code(value: ReolinkAuthCode) -> Vec<u8> {
+    value.auth_code.to_le_bytes().to_vec()
+}
+
+pub fn parse_boot_pwd_state(buf: &[u8]) -> Option<ReolinkBootPwdState> {
+    let value = *buf.get(BOOT_PWD_STATE_VALUE_OFFSET)?;
+    Some(ReolinkBootPwdState {
+        has_boot_password: value != 0,
+    })
+}
+
+pub fn build_boot_pwd_state(value: ReolinkBootPwdState) -> Vec<u8> {
+    vec![u8::from(value.has_boot_password)]
+}
+
+pub fn parse_auth_info(buf: &[u8]) -> Option<ReolinkAuthInfo> {
+    if buf.len() < AUTH_INFO_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkAuthInfo {
+        notes: trim_trailing_nul(
+            &buf[AUTH_INFO_NOTES_OFFSET..AUTH_INFO_NOTES_OFFSET + AUTH_INFO_NOTES_FIELD_LEN],
+        ),
+        valid_hours: i32::from_le_bytes(
+            buf.get(AUTH_INFO_VALID_HOURS_OFFSET..AUTH_INFO_VALID_HOURS_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        user_level: i32::from_le_bytes(
+            buf.get(AUTH_INFO_USER_LEVEL_OFFSET..AUTH_INFO_USER_LEVEL_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        ability: u32::from_le_bytes(
+            buf.get(
+                AUTH_INFO_ABILITY_OFFSET..AUTH_INFO_ABILITY_OFFSET + AUTH_INFO_ABILITY_FIELD_LEN,
+            )?
+            .try_into()
+            .ok()?,
+        ),
+        channel_ability: u64::from_le_bytes(
+            buf.get(AUTH_INFO_CHANNEL_ABILITY_OFFSET..AUTH_INFO_CHANNEL_ABILITY_OFFSET + 8)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_auth_info(info: &ReolinkAuthInfo) -> Vec<u8> {
+    let mut out = vec![0u8; AUTH_INFO_STRUCT_LEN];
+    let notes_len = info.notes.len().min(AUTH_INFO_NOTES_FIELD_LEN);
+    out[AUTH_INFO_NOTES_OFFSET..AUTH_INFO_NOTES_OFFSET + notes_len]
+        .copy_from_slice(&info.notes[..notes_len]);
+    out[AUTH_INFO_VALID_HOURS_OFFSET..AUTH_INFO_VALID_HOURS_OFFSET + 4]
+        .copy_from_slice(&info.valid_hours.to_le_bytes());
+    out[AUTH_INFO_USER_LEVEL_OFFSET..AUTH_INFO_USER_LEVEL_OFFSET + 4]
+        .copy_from_slice(&info.user_level.to_le_bytes());
+    out[AUTH_INFO_ABILITY_OFFSET..AUTH_INFO_ABILITY_OFFSET + AUTH_INFO_ABILITY_FIELD_LEN]
+        .copy_from_slice(&info.ability.to_le_bytes());
+    out[AUTH_INFO_CHANNEL_ABILITY_OFFSET..AUTH_INFO_CHANNEL_ABILITY_OFFSET + 8]
+        .copy_from_slice(&info.channel_ability.to_le_bytes());
+    out
+}
+
+pub fn parse_net_normal_port(buf: &[u8]) -> Option<ReolinkNetNormalPort> {
+    if buf.len() < NET_NORMAL_PORT_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkNetNormalPort {
+        surv_enabled: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_SURV_ENABLE_OFFSET..NET_NORMAL_PORT_SURV_ENABLE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ) != 0,
+        surv_port: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_SURV_OFFSET..NET_NORMAL_PORT_SURV_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        http_enabled: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_HTTP_ENABLE_OFFSET..NET_NORMAL_PORT_HTTP_ENABLE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ) != 0,
+        http_port: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_HTTP_OFFSET..NET_NORMAL_PORT_HTTP_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        https_enabled: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_HTTPS_ENABLE_OFFSET..NET_NORMAL_PORT_HTTPS_ENABLE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ) != 0,
+        https_port: u32::from_le_bytes(
+            buf.get(NET_NORMAL_PORT_HTTPS_OFFSET..NET_NORMAL_PORT_HTTPS_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_net_normal_port(value: ReolinkNetNormalPort) -> Vec<u8> {
+    let mut out = vec![0u8; NET_NORMAL_PORT_STRUCT_LEN];
+    out[NET_NORMAL_PORT_SURV_ENABLE_OFFSET..NET_NORMAL_PORT_SURV_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.surv_enabled)).to_le_bytes());
+    out[NET_NORMAL_PORT_SURV_OFFSET..NET_NORMAL_PORT_SURV_OFFSET + 4]
+        .copy_from_slice(&value.surv_port.to_le_bytes());
+    out[NET_NORMAL_PORT_HTTP_ENABLE_OFFSET..NET_NORMAL_PORT_HTTP_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.http_enabled)).to_le_bytes());
+    out[NET_NORMAL_PORT_HTTP_OFFSET..NET_NORMAL_PORT_HTTP_OFFSET + 4]
+        .copy_from_slice(&value.http_port.to_le_bytes());
+    out[NET_NORMAL_PORT_HTTPS_ENABLE_OFFSET..NET_NORMAL_PORT_HTTPS_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.https_enabled)).to_le_bytes());
+    out[NET_NORMAL_PORT_HTTPS_OFFSET..NET_NORMAL_PORT_HTTPS_OFFSET + 4]
+        .copy_from_slice(&value.https_port.to_le_bytes());
+    out
+}
+
+pub fn parse_net_advanced_port(buf: &[u8]) -> Option<ReolinkNetAdvancedPort> {
+    if buf.len() < NET_ADVANCED_PORT_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkNetAdvancedPort {
+        onvif_enabled: u32::from_le_bytes(
+            buf.get(
+                NET_ADVANCED_PORT_ONVIF_ENABLE_OFFSET..NET_ADVANCED_PORT_ONVIF_ENABLE_OFFSET + 4,
+            )?
+            .try_into()
+            .ok()?,
+        ) != 0,
+        onvif_port: u32::from_le_bytes(
+            buf.get(NET_ADVANCED_PORT_ONVIF_OFFSET..NET_ADVANCED_PORT_ONVIF_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        rtsp_enabled: u32::from_le_bytes(
+            buf.get(
+                NET_ADVANCED_PORT_RTSP_ENABLE_OFFSET..NET_ADVANCED_PORT_RTSP_ENABLE_OFFSET + 4,
+            )?
+            .try_into()
+            .ok()?,
+        ) != 0,
+        rtsp_port: u32::from_le_bytes(
+            buf.get(NET_ADVANCED_PORT_RTSP_OFFSET..NET_ADVANCED_PORT_RTSP_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        rtmp_enabled: u32::from_le_bytes(
+            buf.get(
+                NET_ADVANCED_PORT_RTMP_ENABLE_OFFSET..NET_ADVANCED_PORT_RTMP_ENABLE_OFFSET + 4,
+            )?
+            .try_into()
+            .ok()?,
+        ) != 0,
+        rtmp_port: u32::from_le_bytes(
+            buf.get(NET_ADVANCED_PORT_RTMP_OFFSET..NET_ADVANCED_PORT_RTMP_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_net_advanced_port(value: ReolinkNetAdvancedPort) -> Vec<u8> {
+    let mut out = vec![0u8; NET_ADVANCED_PORT_STRUCT_LEN];
+    out[NET_ADVANCED_PORT_ONVIF_ENABLE_OFFSET..NET_ADVANCED_PORT_ONVIF_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.onvif_enabled)).to_le_bytes());
+    out[NET_ADVANCED_PORT_ONVIF_OFFSET..NET_ADVANCED_PORT_ONVIF_OFFSET + 4]
+        .copy_from_slice(&value.onvif_port.to_le_bytes());
+    out[NET_ADVANCED_PORT_RTSP_ENABLE_OFFSET..NET_ADVANCED_PORT_RTSP_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.rtsp_enabled)).to_le_bytes());
+    out[NET_ADVANCED_PORT_RTSP_OFFSET..NET_ADVANCED_PORT_RTSP_OFFSET + 4]
+        .copy_from_slice(&value.rtsp_port.to_le_bytes());
+    out[NET_ADVANCED_PORT_RTMP_ENABLE_OFFSET..NET_ADVANCED_PORT_RTMP_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.rtmp_enabled)).to_le_bytes());
+    out[NET_ADVANCED_PORT_RTMP_OFFSET..NET_ADVANCED_PORT_RTMP_OFFSET + 4]
+        .copy_from_slice(&value.rtmp_port.to_le_bytes());
+    out
+}
+
+pub fn parse_p2p_cfg(buf: &[u8]) -> Option<ReolinkP2PCfg> {
+    if buf.len() < P2P_CFG_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkP2PCfg {
+        enabled: u32::from_le_bytes(
+            buf.get(P2P_CFG_ENABLE_OFFSET..P2P_CFG_ENABLE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ) != 0,
+        port: u32::from_le_bytes(
+            buf.get(P2P_CFG_PORT_OFFSET..P2P_CFG_PORT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        server_domain: read_fixed_c_string(
+            buf,
+            P2P_CFG_SERVER_DOMAIN_OFFSET,
+            P2P_CFG_SERVER_DOMAIN_FIELD_LEN,
+        )?,
+    })
+}
+
+pub fn build_p2p_cfg(value: &ReolinkP2PCfg) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; P2P_CFG_STRUCT_LEN];
+    out[P2P_CFG_ENABLE_OFFSET..P2P_CFG_ENABLE_OFFSET + 4]
+        .copy_from_slice(&(u32::from(value.enabled)).to_le_bytes());
+    out[P2P_CFG_PORT_OFFSET..P2P_CFG_PORT_OFFSET + 4].copy_from_slice(&value.port.to_le_bytes());
+    write_fixed_c_string(
+        &mut out,
+        P2P_CFG_SERVER_DOMAIN_OFFSET,
+        P2P_CFG_SERVER_DOMAIN_FIELD_LEN,
+        &value.server_domain,
+    )?;
+    Some(out)
+}
+
+pub fn parse_force_password(buf: &[u8]) -> Option<ReolinkForcePassword> {
+    if buf.len() < FORCE_PASSWORD_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkForcePassword {
+        username: read_fixed_c_string(
+            buf,
+            FORCE_PASSWORD_USERNAME_OFFSET,
+            FORCE_PASSWORD_USERNAME_FIELD_LEN,
+        )?,
+        password: read_fixed_c_string(
+            buf,
+            FORCE_PASSWORD_PASSWORD_OFFSET,
+            FORCE_PASSWORD_PASSWORD_FIELD_LEN,
+        )?,
+        nickname: read_fixed_c_string(
+            buf,
+            FORCE_PASSWORD_NICKNAME_OFFSET,
+            FORCE_PASSWORD_NICKNAME_FIELD_LEN,
+        )?,
+    })
+}
+
+pub fn build_force_password(value: &ReolinkForcePassword) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; FORCE_PASSWORD_STRUCT_LEN];
+    write_fixed_c_string(
+        &mut out,
+        FORCE_PASSWORD_USERNAME_OFFSET,
+        FORCE_PASSWORD_USERNAME_FIELD_LEN,
+        &value.username,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        FORCE_PASSWORD_PASSWORD_OFFSET,
+        FORCE_PASSWORD_PASSWORD_FIELD_LEN,
+        &value.password,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        FORCE_PASSWORD_NICKNAME_OFFSET,
+        FORCE_PASSWORD_NICKNAME_FIELD_LEN,
+        &value.nickname,
+    )?;
+    Some(out)
+}
+
+pub fn parse_ptz_decoder(buf: &[u8]) -> Option<ReolinkPtzDecoder> {
+    if buf.len() < PTZ_DECODER_STRUCT_LEN {
+        return None;
+    }
+
+    Some(ReolinkPtzDecoder {
+        data_bit: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_DATABIT_OFFSET..PTZ_DECODER_DATABIT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        stop_bit: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_STOPBIT_OFFSET..PTZ_DECODER_STOPBIT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        decoder_address: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_ADDRESS_OFFSET..PTZ_DECODER_ADDRESS_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        baud_rate: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_BAUDRATE_OFFSET..PTZ_DECODER_BAUDRATE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        parity: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_PARITY_OFFSET..PTZ_DECODER_PARITY_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        flow_control: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_FLOWCONTROL_OFFSET..PTZ_DECODER_FLOWCONTROL_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        decoder_type: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_TYPE_OFFSET..PTZ_DECODER_TYPE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        support_pelco_c: i32::from_le_bytes(
+            buf.get(PTZ_DECODER_SUPPORT_PELCO_C_OFFSET..PTZ_DECODER_SUPPORT_PELCO_C_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        preset: trim_trailing_nul(buf.get(
+            PTZ_DECODER_PRESET_OFFSET..PTZ_DECODER_PRESET_OFFSET + PTZ_DECODER_PRESET_FIELD_LEN,
+        )?),
+        cruise: trim_trailing_nul(buf.get(
+            PTZ_DECODER_CRUISE_OFFSET..PTZ_DECODER_CRUISE_OFFSET + PTZ_DECODER_CRUISE_FIELD_LEN,
+        )?),
+        track: trim_trailing_nul(buf.get(
+            PTZ_DECODER_TRACK_OFFSET..PTZ_DECODER_TRACK_OFFSET + PTZ_DECODER_TRACK_FIELD_LEN,
+        )?),
+    })
+}
+
+pub fn build_ptz_decoder(value: &ReolinkPtzDecoder) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; PTZ_DECODER_STRUCT_LEN];
+    out[PTZ_DECODER_DATABIT_OFFSET..PTZ_DECODER_DATABIT_OFFSET + 4]
+        .copy_from_slice(&value.data_bit.to_le_bytes());
+    out[PTZ_DECODER_STOPBIT_OFFSET..PTZ_DECODER_STOPBIT_OFFSET + 4]
+        .copy_from_slice(&value.stop_bit.to_le_bytes());
+    out[PTZ_DECODER_ADDRESS_OFFSET..PTZ_DECODER_ADDRESS_OFFSET + 4]
+        .copy_from_slice(&value.decoder_address.to_le_bytes());
+    out[PTZ_DECODER_BAUDRATE_OFFSET..PTZ_DECODER_BAUDRATE_OFFSET + 4]
+        .copy_from_slice(&value.baud_rate.to_le_bytes());
+    out[PTZ_DECODER_PARITY_OFFSET..PTZ_DECODER_PARITY_OFFSET + 4]
+        .copy_from_slice(&value.parity.to_le_bytes());
+    out[PTZ_DECODER_FLOWCONTROL_OFFSET..PTZ_DECODER_FLOWCONTROL_OFFSET + 4]
+        .copy_from_slice(&value.flow_control.to_le_bytes());
+    out[PTZ_DECODER_TYPE_OFFSET..PTZ_DECODER_TYPE_OFFSET + 4]
+        .copy_from_slice(&value.decoder_type.to_le_bytes());
+    out[PTZ_DECODER_SUPPORT_PELCO_C_OFFSET..PTZ_DECODER_SUPPORT_PELCO_C_OFFSET + 4]
+        .copy_from_slice(&value.support_pelco_c.to_le_bytes());
+    if value.preset.len() > PTZ_DECODER_PRESET_FIELD_LEN
+        || value.cruise.len() > PTZ_DECODER_CRUISE_FIELD_LEN
+        || value.track.len() > PTZ_DECODER_TRACK_FIELD_LEN
+    {
+        return None;
+    }
+    out[PTZ_DECODER_PRESET_OFFSET..PTZ_DECODER_PRESET_OFFSET + value.preset.len()]
+        .copy_from_slice(&value.preset);
+    out[PTZ_DECODER_CRUISE_OFFSET..PTZ_DECODER_CRUISE_OFFSET + value.cruise.len()]
+        .copy_from_slice(&value.cruise);
+    out[PTZ_DECODER_TRACK_OFFSET..PTZ_DECODER_TRACK_OFFSET + value.track.len()]
+        .copy_from_slice(&value.track);
+    Some(out)
+}
+
+pub fn parse_ptz_position(buf: &[u8]) -> Option<ReolinkPtzPosition> {
+    if buf.len() < PTZ_POSITION_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkPtzPosition {
+        pan: i32::from_le_bytes(
+            buf.get(PTZ_POSITION_P_OFFSET..PTZ_POSITION_P_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        tilt: i32::from_le_bytes(
+            buf.get(PTZ_POSITION_T_OFFSET..PTZ_POSITION_T_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        zoom: i32::from_le_bytes(
+            buf.get(PTZ_POSITION_Z_OFFSET..PTZ_POSITION_Z_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_ptz_position(value: &ReolinkPtzPosition) -> Vec<u8> {
+    let mut out = vec![0u8; PTZ_POSITION_STRUCT_LEN];
+    out[PTZ_POSITION_P_OFFSET..PTZ_POSITION_P_OFFSET + 4].copy_from_slice(&value.pan.to_le_bytes());
+    out[PTZ_POSITION_T_OFFSET..PTZ_POSITION_T_OFFSET + 4]
+        .copy_from_slice(&value.tilt.to_le_bytes());
+    out[PTZ_POSITION_Z_OFFSET..PTZ_POSITION_Z_OFFSET + 4]
+        .copy_from_slice(&value.zoom.to_le_bytes());
+    out
+}
+
+pub fn parse_ptz_3d_location(buf: &[u8]) -> Option<ReolinkPtz3DLocation> {
+    if buf.len() < PTZ_3D_LOCATION_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkPtz3DLocation {
+        top_left_x: f32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_TOP_LEFT_X_OFFSET..PTZ_3D_LOCATION_TOP_LEFT_X_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        top_left_y: f32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_TOP_LEFT_Y_OFFSET..PTZ_3D_LOCATION_TOP_LEFT_Y_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        width: f32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_WIDTH_OFFSET..PTZ_3D_LOCATION_WIDTH_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        height: f32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_HEIGHT_OFFSET..PTZ_3D_LOCATION_HEIGHT_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        stream_type: i32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_STREAM_TYPE_OFFSET..PTZ_3D_LOCATION_STREAM_TYPE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        speed: i32::from_le_bytes(
+            buf.get(PTZ_3D_LOCATION_SPEED_OFFSET..PTZ_3D_LOCATION_SPEED_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+pub fn build_ptz_3d_location(value: &ReolinkPtz3DLocation) -> Vec<u8> {
+    let mut out = vec![0u8; PTZ_3D_LOCATION_STRUCT_LEN];
+    out[PTZ_3D_LOCATION_TOP_LEFT_X_OFFSET..PTZ_3D_LOCATION_TOP_LEFT_X_OFFSET + 4]
+        .copy_from_slice(&value.top_left_x.to_le_bytes());
+    out[PTZ_3D_LOCATION_TOP_LEFT_Y_OFFSET..PTZ_3D_LOCATION_TOP_LEFT_Y_OFFSET + 4]
+        .copy_from_slice(&value.top_left_y.to_le_bytes());
+    out[PTZ_3D_LOCATION_WIDTH_OFFSET..PTZ_3D_LOCATION_WIDTH_OFFSET + 4]
+        .copy_from_slice(&value.width.to_le_bytes());
+    out[PTZ_3D_LOCATION_HEIGHT_OFFSET..PTZ_3D_LOCATION_HEIGHT_OFFSET + 4]
+        .copy_from_slice(&value.height.to_le_bytes());
+    out[PTZ_3D_LOCATION_STREAM_TYPE_OFFSET..PTZ_3D_LOCATION_STREAM_TYPE_OFFSET + 4]
+        .copy_from_slice(&value.stream_type.to_le_bytes());
+    out[PTZ_3D_LOCATION_SPEED_OFFSET..PTZ_3D_LOCATION_SPEED_OFFSET + 4]
+        .copy_from_slice(&value.speed.to_le_bytes());
+    out
+}
+
+pub fn parse_smart_track_task(buf: &[u8]) -> Option<ReolinkSmartTrackTask> {
+    if buf.len() < SMART_TRACK_TASK_STRUCT_LEN {
+        return None;
+    }
+    let mut timetable = [0i32; SMART_TRACK_TASK_TIMETABLE_LEN];
+    for (index, slot) in timetable.iter_mut().enumerate() {
+        let offset = index * 4;
+        *slot = i32::from_le_bytes(buf.get(offset..offset + 4)?.try_into().ok()?);
+    }
+    Some(ReolinkSmartTrackTask { timetable })
+}
+
+pub fn build_smart_track_task(value: &ReolinkSmartTrackTask) -> Vec<u8> {
+    let mut out = vec![0u8; SMART_TRACK_TASK_STRUCT_LEN];
+    for (index, item) in value.timetable.iter().enumerate() {
+        let offset = index * 4;
+        out[offset..offset + 4].copy_from_slice(&item.to_le_bytes());
+    }
+    out
+}
+
+fn parse_smart_track_limit_point(buf: &[u8]) -> Option<ReolinkSmartTrackLimitPoint> {
+    if buf.len() < SMART_TRACK_LIMIT_POINT_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkSmartTrackLimitPoint {
+        limit: i32::from_le_bytes(
+            buf.get(
+                SMART_TRACK_LIMIT_POINT_LIMIT_OFFSET..SMART_TRACK_LIMIT_POINT_LIMIT_OFFSET + 4,
+            )?
+            .try_into()
+            .ok()?,
+        ),
+        image_name: read_fixed_c_string(
+            buf,
+            SMART_TRACK_LIMIT_POINT_IMAGE_NAME_OFFSET,
+            SMART_TRACK_LIMIT_POINT_IMAGE_NAME_FIELD_LEN,
+        )?,
+    })
+}
+
+fn build_smart_track_limit_point(value: &ReolinkSmartTrackLimitPoint) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; SMART_TRACK_LIMIT_POINT_STRUCT_LEN];
+    out[SMART_TRACK_LIMIT_POINT_LIMIT_OFFSET..SMART_TRACK_LIMIT_POINT_LIMIT_OFFSET + 4]
+        .copy_from_slice(&value.limit.to_le_bytes());
+    write_fixed_c_string(
+        &mut out,
+        SMART_TRACK_LIMIT_POINT_IMAGE_NAME_OFFSET,
+        SMART_TRACK_LIMIT_POINT_IMAGE_NAME_FIELD_LEN,
+        &value.image_name,
+    )?;
+    Some(out)
+}
+
+pub fn parse_smart_track_limit(buf: &[u8]) -> Option<ReolinkSmartTrackLimit> {
+    if buf.len() < SMART_TRACK_LIMIT_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkSmartTrackLimit {
+        left: parse_smart_track_limit_point(buf.get(
+            SMART_TRACK_LIMIT_LEFT_OFFSET
+                ..SMART_TRACK_LIMIT_LEFT_OFFSET + SMART_TRACK_LIMIT_POINT_STRUCT_LEN,
+        )?)?,
+        right: parse_smart_track_limit_point(buf.get(
+            SMART_TRACK_LIMIT_RIGHT_OFFSET
+                ..SMART_TRACK_LIMIT_RIGHT_OFFSET + SMART_TRACK_LIMIT_POINT_STRUCT_LEN,
+        )?)?,
+    })
+}
+
+pub fn build_smart_track_limit(value: &ReolinkSmartTrackLimit) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; SMART_TRACK_LIMIT_STRUCT_LEN];
+    let left = build_smart_track_limit_point(&value.left)?;
+    let right = build_smart_track_limit_point(&value.right)?;
+    out[SMART_TRACK_LIMIT_LEFT_OFFSET
+        ..SMART_TRACK_LIMIT_LEFT_OFFSET + SMART_TRACK_LIMIT_POINT_STRUCT_LEN]
+        .copy_from_slice(&left);
+    out[SMART_TRACK_LIMIT_RIGHT_OFFSET
+        ..SMART_TRACK_LIMIT_RIGHT_OFFSET + SMART_TRACK_LIMIT_POINT_STRUCT_LEN]
+        .copy_from_slice(&right);
+    Some(out)
+}
+
+fn parse_user_record(buf: &[u8]) -> Option<ReolinkUserRecord> {
+    if buf.len() < USER_RECORD_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkUserRecord {
+        username: read_fixed_c_string(
+            buf,
+            USER_RECORD_USERNAME_OFFSET,
+            USER_RECORD_USERNAME_FIELD_LEN,
+        )?,
+        nickname: read_fixed_c_string(
+            buf,
+            USER_RECORD_NICKNAME_OFFSET,
+            USER_RECORD_NICKNAME_FIELD_LEN,
+        )?,
+        password: read_fixed_c_string(
+            buf,
+            USER_RECORD_PASSWORD_OFFSET,
+            USER_RECORD_PASSWORD_FIELD_LEN,
+        )?,
+        local_right: read_fixed_c_string(
+            buf,
+            USER_RECORD_LOCAL_RIGHT_OFFSET,
+            USER_RECORD_LOCAL_RIGHT_FIELD_LEN,
+        )?,
+        old_ipc_right: read_fixed_c_string(
+            buf,
+            USER_RECORD_OLD_IPC_RIGHT_OFFSET,
+            USER_RECORD_OLD_IPC_RIGHT_FIELD_LEN,
+        )?,
+        magic_num: i32::from_le_bytes(
+            buf.get(USER_RECORD_MAGIC_NUM_OFFSET..USER_RECORD_MAGIC_NUM_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        user_ip: read_fixed_c_string(
+            buf,
+            USER_RECORD_USER_IP_OFFSET,
+            USER_RECORD_USER_IP_FIELD_LEN,
+        )?,
+        mac_address: buf
+            .get(USER_RECORD_MAC_OFFSET..USER_RECORD_MAC_OFFSET + USER_RECORD_MAC_FIELD_LEN)?
+            .to_vec(),
+        user_level: i32::from_le_bytes(
+            buf.get(USER_RECORD_LEVEL_OFFSET..USER_RECORD_LEVEL_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        login_state: i32::from_le_bytes(
+            buf.get(USER_RECORD_LOGIN_STATE_OFFSET..USER_RECORD_LOGIN_STATE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        valid_password: i32::from_le_bytes(
+            buf.get(USER_RECORD_VALID_PASSWORD_OFFSET..USER_RECORD_VALID_PASSWORD_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        user_set_state: i32::from_le_bytes(
+            buf.get(USER_RECORD_USER_SET_STATE_OFFSET..USER_RECORD_USER_SET_STATE_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        boot_password: i32::from_le_bytes(
+            buf.get(USER_RECORD_BOOT_PASSWORD_OFFSET..USER_RECORD_BOOT_PASSWORD_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        valid_hours: i32::from_le_bytes(
+            buf.get(USER_RECORD_VALID_HOURS_OFFSET..USER_RECORD_VALID_HOURS_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        channel_ability: u64::from_le_bytes(
+            buf.get(USER_RECORD_CHANNEL_ABILITY_OFFSET..USER_RECORD_CHANNEL_ABILITY_OFFSET + 8)?
+                .try_into()
+                .ok()?,
+        ),
+    })
+}
+
+fn build_user_record(value: &ReolinkUserRecord) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; USER_RECORD_STRUCT_LEN];
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_USERNAME_OFFSET,
+        USER_RECORD_USERNAME_FIELD_LEN,
+        &value.username,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_NICKNAME_OFFSET,
+        USER_RECORD_NICKNAME_FIELD_LEN,
+        &value.nickname,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_PASSWORD_OFFSET,
+        USER_RECORD_PASSWORD_FIELD_LEN,
+        &value.password,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_LOCAL_RIGHT_OFFSET,
+        USER_RECORD_LOCAL_RIGHT_FIELD_LEN,
+        &value.local_right,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_OLD_IPC_RIGHT_OFFSET,
+        USER_RECORD_OLD_IPC_RIGHT_FIELD_LEN,
+        &value.old_ipc_right,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        USER_RECORD_USER_IP_OFFSET,
+        USER_RECORD_USER_IP_FIELD_LEN,
+        &value.user_ip,
+    )?;
+    if value.mac_address.len() > USER_RECORD_MAC_FIELD_LEN {
+        return None;
+    }
+    out[USER_RECORD_MAGIC_NUM_OFFSET..USER_RECORD_MAGIC_NUM_OFFSET + 4]
+        .copy_from_slice(&value.magic_num.to_le_bytes());
+    out[USER_RECORD_MAC_OFFSET..USER_RECORD_MAC_OFFSET + value.mac_address.len()]
+        .copy_from_slice(&value.mac_address);
+    out[USER_RECORD_LEVEL_OFFSET..USER_RECORD_LEVEL_OFFSET + 4]
+        .copy_from_slice(&value.user_level.to_le_bytes());
+    out[USER_RECORD_LOGIN_STATE_OFFSET..USER_RECORD_LOGIN_STATE_OFFSET + 4]
+        .copy_from_slice(&value.login_state.to_le_bytes());
+    out[USER_RECORD_VALID_PASSWORD_OFFSET..USER_RECORD_VALID_PASSWORD_OFFSET + 4]
+        .copy_from_slice(&value.valid_password.to_le_bytes());
+    out[USER_RECORD_USER_SET_STATE_OFFSET..USER_RECORD_USER_SET_STATE_OFFSET + 4]
+        .copy_from_slice(&value.user_set_state.to_le_bytes());
+    out[USER_RECORD_BOOT_PASSWORD_OFFSET..USER_RECORD_BOOT_PASSWORD_OFFSET + 4]
+        .copy_from_slice(&value.boot_password.to_le_bytes());
+    out[USER_RECORD_VALID_HOURS_OFFSET..USER_RECORD_VALID_HOURS_OFFSET + 4]
+        .copy_from_slice(&value.valid_hours.to_le_bytes());
+    out[USER_RECORD_CHANNEL_ABILITY_OFFSET..USER_RECORD_CHANNEL_ABILITY_OFFSET + 8]
+        .copy_from_slice(&value.channel_ability.to_le_bytes());
+    Some(out)
+}
+
+pub fn parse_user_config(buf: &[u8]) -> Option<ReolinkUserConfig> {
+    if buf.len() < USER_CFG_STRUCT_LEN {
+        return None;
+    }
+    let user_count = i32::from_le_bytes(
+        buf.get(USER_CFG_USERNUM_OFFSET..USER_CFG_USERNUM_OFFSET + 4)?
+            .try_into()
+            .ok()?,
+    );
+    let clamped_count = user_count.clamp(0, USER_CFG_USERS_MAX as i32) as usize;
+    let mut users = Vec::with_capacity(clamped_count);
+    for index in 0..clamped_count {
+        let offset = USER_CFG_USERS_OFFSET + index * USER_RECORD_STRUCT_LEN;
+        users.push(parse_user_record(
+            buf.get(offset..offset + USER_RECORD_STRUCT_LEN)?,
+        )?);
+    }
+    Some(ReolinkUserConfig {
+        current_username: read_fixed_c_string(
+            buf,
+            USER_CFG_CURRENT_USERNAME_OFFSET,
+            USER_CFG_CURRENT_USERNAME_FIELD_LEN,
+        )?,
+        user_count,
+        users,
+    })
+}
+
+pub fn build_user_config(value: &ReolinkUserConfig) -> Option<Vec<u8>> {
+    if value.users.len() > USER_CFG_USERS_MAX {
+        return None;
+    }
+    let mut out = vec![0u8; USER_CFG_STRUCT_LEN];
+    write_fixed_c_string(
+        &mut out,
+        USER_CFG_CURRENT_USERNAME_OFFSET,
+        USER_CFG_CURRENT_USERNAME_FIELD_LEN,
+        &value.current_username,
+    )?;
+    out[USER_CFG_USERNUM_OFFSET..USER_CFG_USERNUM_OFFSET + 4]
+        .copy_from_slice(&value.user_count.to_le_bytes());
+    for (index, user) in value.users.iter().enumerate() {
+        let offset = USER_CFG_USERS_OFFSET + index * USER_RECORD_STRUCT_LEN;
+        let encoded = build_user_record(user)?;
+        out[offset..offset + USER_RECORD_STRUCT_LEN].copy_from_slice(&encoded);
+    }
+    Some(out)
+}
+
+pub fn parse_signature_login_cfg(buf: &[u8]) -> Option<ReolinkSignatureLoginCfg> {
+    if buf.len() < SIGNATURE_LOGIN_CFG_STRUCT_LEN {
+        return None;
+    }
+    Some(ReolinkSignatureLoginCfg {
+        is_opened: i32::from_le_bytes(
+            buf.get(
+                SIGNATURE_LOGIN_CFG_IS_OPENED_OFFSET..SIGNATURE_LOGIN_CFG_IS_OPENED_OFFSET + 4,
+            )?
+            .try_into()
+            .ok()?,
+        ),
+        version: i32::from_le_bytes(
+            buf.get(SIGNATURE_LOGIN_CFG_VERSION_OFFSET..SIGNATURE_LOGIN_CFG_VERSION_OFFSET + 4)?
+                .try_into()
+                .ok()?,
+        ),
+        supported_versions: [
+            i32::from_le_bytes(
+                buf.get(SIGNATURE_LOGIN_CFG_V1_OFFSET..SIGNATURE_LOGIN_CFG_V1_OFFSET + 4)?
+                    .try_into()
+                    .ok()?,
+            ),
+            i32::from_le_bytes(
+                buf.get(SIGNATURE_LOGIN_CFG_V2_OFFSET..SIGNATURE_LOGIN_CFG_V2_OFFSET + 4)?
+                    .try_into()
+                    .ok()?,
+            ),
+            i32::from_le_bytes(
+                buf.get(SIGNATURE_LOGIN_CFG_V3_OFFSET..SIGNATURE_LOGIN_CFG_V3_OFFSET + 4)?
+                    .try_into()
+                    .ok()?,
+            ),
+        ],
+    })
+}
+
+pub fn build_signature_login_cfg(value: &ReolinkSignatureLoginCfg) -> Vec<u8> {
+    let mut out = vec![0u8; SIGNATURE_LOGIN_CFG_STRUCT_LEN];
+    out[SIGNATURE_LOGIN_CFG_IS_OPENED_OFFSET..SIGNATURE_LOGIN_CFG_IS_OPENED_OFFSET + 4]
+        .copy_from_slice(&value.is_opened.to_le_bytes());
+    out[SIGNATURE_LOGIN_CFG_VERSION_OFFSET..SIGNATURE_LOGIN_CFG_VERSION_OFFSET + 4]
+        .copy_from_slice(&value.version.to_le_bytes());
+    out[SIGNATURE_LOGIN_CFG_V1_OFFSET..SIGNATURE_LOGIN_CFG_V1_OFFSET + 4]
+        .copy_from_slice(&value.supported_versions[0].to_le_bytes());
+    out[SIGNATURE_LOGIN_CFG_V2_OFFSET..SIGNATURE_LOGIN_CFG_V2_OFFSET + 4]
+        .copy_from_slice(&value.supported_versions[1].to_le_bytes());
+    out[SIGNATURE_LOGIN_CFG_V3_OFFSET..SIGNATURE_LOGIN_CFG_V3_OFFSET + 4]
+        .copy_from_slice(&value.supported_versions[2].to_le_bytes());
+    out
+}
+
+pub fn build_login_message(msg: &ReolinkLoginMessage) -> Option<Vec<u8>> {
+    let mut out = vec![0u8; LOGIN_MESSAGE_STRUCT_LEN];
+    out[LOGIN_MESSAGE_AUTH_MODE_OFFSET..LOGIN_MESSAGE_AUTH_MODE_OFFSET + 4]
+        .copy_from_slice(&msg.auth_mode.to_le_bytes());
+    out[LOGIN_MESSAGE_PORT_OFFSET..LOGIN_MESSAGE_PORT_OFFSET + 4]
+        .copy_from_slice(&msg.port.to_le_bytes());
+    out[LOGIN_MESSAGE_UID_PORT_OFFSET..LOGIN_MESSAGE_UID_PORT_OFFSET + 4]
+        .copy_from_slice(&msg.uid_port.to_le_bytes());
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_NAME_OFFSET,
+        LOGIN_MESSAGE_NAME_FIELD_LEN,
+        &msg.name,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_HOST_OFFSET,
+        LOGIN_MESSAGE_HOST_FIELD_LEN,
+        &msg.host,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_UID_OFFSET,
+        LOGIN_MESSAGE_UID_FIELD_LEN,
+        &msg.uid,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_USERNAME_OFFSET,
+        LOGIN_MESSAGE_USERNAME_FIELD_LEN,
+        &msg.username,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_PASSWORD_OFFSET,
+        LOGIN_MESSAGE_PASSWORD_FIELD_LEN,
+        &msg.password,
+    )?;
+    write_fixed_c_string(
+        &mut out,
+        LOGIN_MESSAGE_AUTH_CODE_OFFSET,
+        LOGIN_MESSAGE_AUTH_CODE_FIELD_LEN,
+        &msg.auth_code,
+    )?;
+    Some(out)
+}
+
+pub fn build_short_frame(op: u32, field_c: u32, field_d: u32, payload: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(20 + payload.len());
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&op.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(&field_c.to_le_bytes());
+    out.extend_from_slice(&field_d.to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+pub fn build_extended_frame(
+    op: u32,
+    field_c: u32,
+    field_d: u32,
+    field_e: u32,
+    payload: &[u8],
+) -> Vec<u8> {
+    let mut out = Vec::with_capacity(24 + payload.len());
+    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&op.to_le_bytes());
+    out.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+    out.extend_from_slice(&field_c.to_le_bytes());
+    out.extend_from_slice(&field_d.to_le_bytes());
+    out.extend_from_slice(&field_e.to_le_bytes());
+    out.extend_from_slice(payload);
+    out
+}
+
+pub fn login_credential_window(frame: &[u8]) -> Option<&[u8]> {
+    if frame.len() < LOGIN_FRAME_LEN {
+        return None;
+    }
+    let header = parse_frame_header(frame)?;
+    match header {
+        ReolinkFrameHeader::Short { op, .. } if op == ReolinkTransportOp::Handshake as u32 => {
+            Some(&frame[LOGIN_CREDENTIAL_WINDOW.clone()])
+        }
+        _ => None,
+    }
+}
+
+pub fn handshake_frame_body(frame: &[u8]) -> Option<&[u8]> {
+    let header = parse_frame_header(frame)?;
+    match header {
+        ReolinkFrameHeader::Short { op, .. } if op == ReolinkTransportOp::Handshake as u32 => {
+            Some(&frame[header.header_len()..header.total_len()])
+        }
+        _ => None,
+    }
+}
+
+pub fn login_reflected_server_prefix(frame: &[u8]) -> Option<&[u8]> {
+    let _ = login_credential_window(frame)?;
+    Some(&frame[LOGIN_REFLECTED_SERVER_PREFIX_WINDOW.clone()])
+}
+
+pub fn handshake_reflected_prefix(frame: &[u8]) -> Option<&[u8]> {
+    let body = handshake_frame_body(frame)?;
+    body.get(..LOGIN_REFLECTED_SERVER_PREFIX_LEN)
+}
+
+pub fn handshake_observed_credential_salt(frame: &[u8]) -> Option<[u8; 21]> {
+    let body = handshake_frame_body(frame)?;
+    let mut out = [0u8; SERVER_HANDSHAKE_CREDENTIAL_SALT_INDICES.len()];
+    for (slot, index) in out
+        .iter_mut()
+        .zip(SERVER_HANDSHAKE_CREDENTIAL_SALT_INDICES.iter().copied())
+    {
+        *slot = *body.get(index)?;
+    }
+    Some(out)
+}
+
+pub fn login_has_expected_zero_lead(frame: &[u8]) -> bool {
+    matches!(login_credential_window(frame), Some(_)
+        if frame[20..(20 + LOGIN_LEADING_ZERO_LEN)].iter().all(|byte| *byte == 0))
+}
+
+pub fn login_matches_server_prefix(login_frame: &[u8], server_handshake_frame: &[u8]) -> bool {
+    let reflected = match login_reflected_server_prefix(login_frame) {
+        Some(value) => value,
+        None => return false,
+    };
+    let server_prefix = match handshake_reflected_prefix(server_handshake_frame) {
+        Some(value) => value,
+        None => return false,
+    };
+    server_prefix == reflected
+}
+
+pub fn login_username_block(frame: &[u8]) -> Option<&[u8]> {
+    let _ = login_credential_window(frame)?;
+    Some(&frame[LOGIN_USERNAME_WINDOW.clone()])
+}
+
+pub fn login_middle_block(frame: &[u8]) -> Option<&[u8]> {
+    let _ = login_credential_window(frame)?;
+    Some(&frame[LOGIN_MIDDLE_WINDOW.clone()])
+}
+
+pub fn login_password_block(frame: &[u8]) -> Option<&[u8]> {
+    let _ = login_credential_window(frame)?;
+    Some(&frame[LOGIN_PASSWORD_WINDOW.clone()])
+}
+
+pub fn login_has_observed_static_middle(frame: &[u8]) -> bool {
+    matches!(login_middle_block(frame), Some(block) if block == LOGIN_STATIC_MIDDLE)
+}
+
+pub fn login_frames_differ_only_in_credential_blocks(left: &[u8], right: &[u8]) -> bool {
+    if login_credential_window(left).is_none() || login_credential_window(right).is_none() {
+        return false;
+    }
+    if left.len() != right.len() {
+        return false;
+    }
+
+    left.iter()
+        .zip(right.iter())
+        .enumerate()
+        .all(|(index, (lhs, rhs))| {
+            lhs == rhs
+                || LOGIN_USERNAME_WINDOW.contains(&index)
+                || LOGIN_PASSWORD_WINDOW.contains(&index)
+        })
+}
+
+pub fn replace_login_blocks(
+    frame: &[u8],
+    username_block: &[u8],
+    password_block: &[u8],
+) -> Option<Vec<u8>> {
+    if username_block.len() != LOGIN_USERNAME_WINDOW.len()
+        || password_block.len() != LOGIN_PASSWORD_WINDOW.len()
+    {
+        return None;
+    }
+    let _ = login_credential_window(frame)?;
+    let mut out = frame.to_vec();
+    out[LOGIN_USERNAME_WINDOW.clone()].copy_from_slice(username_block);
+    out[LOGIN_MIDDLE_WINDOW.clone()].copy_from_slice(&LOGIN_STATIC_MIDDLE);
+    out[LOGIN_PASSWORD_WINDOW.clone()].copy_from_slice(password_block);
+    Some(out)
+}
+
+pub fn encode_password_secret(secret: &[u8]) -> Option<String> {
+    if secret.len() > 0x3ff {
+        return None;
+    }
+
+    let padded_len = (secret.len() + 1).next_multiple_of(16);
+    let mut buffer = vec![0u8; padded_len];
+    buffer[0] = secret.len() as u8;
+    buffer[1..=secret.len()].copy_from_slice(secret);
+
+    let cipher = Aes128::new_from_slice(&BAICHUAN_KEY).ok()?;
+    let mut previous = BAICHUAN_IV;
+    for chunk in buffer.chunks_exact_mut(16) {
+        for (slot, iv) in chunk.iter_mut().zip(previous) {
+            *slot ^= iv;
+        }
+        let block = GenericArray::from_mut_slice(chunk);
+        cipher.encrypt_block(block);
+        previous.copy_from_slice(chunk);
+    }
+
+    Some(BASE64_STANDARD.encode(buffer))
+}
+
+pub fn decode_password_secret(secret: &str) -> Option<Vec<u8>> {
+    let mut buffer = BASE64_STANDARD.decode(secret).ok()?;
+    if buffer.is_empty() || buffer.len() % 16 != 0 {
+        return None;
+    }
+
+    let cipher = Aes128::new_from_slice(&BAICHUAN_KEY).ok()?;
+    let mut previous = BAICHUAN_IV;
+    for chunk in buffer.chunks_exact_mut(16) {
+        let current = <[u8; 16]>::try_from(&*chunk).ok()?;
+        let block = GenericArray::from_mut_slice(chunk);
+        cipher.decrypt_block(block);
+        for (slot, iv) in chunk.iter_mut().zip(previous) {
+            *slot ^= iv;
+        }
+        previous = current;
+    }
+
+    let declared_len = buffer[0] as usize;
+    let end = 1usize.checked_add(declared_len)?;
+    if end > buffer.len() {
+        return None;
+    }
+    Some(buffer[1..end].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OBSERVED_USERNAME_BLOCK: [u8; 31] = [
+        0x79, 0x62, 0x50, 0x3a, 0xb9, 0x2a, 0x1e, 0x0e, 0x7a, 0x6f, 0x5b, 0x4c, 0xbb, 0x5c, 0x1c,
+        0x7a, 0x79, 0x1f, 0x5a, 0x3d, 0xbc, 0x5d, 0x15, 0x7a, 0x08, 0x6d, 0x58, 0x3e, 0xcc, 0x2c,
+        0x18,
+    ];
+
+    const OBSERVED_PASSWORD_BLOCK: [u8; 31] = [
+        0x29, 0x1f, 0x0d, 0x73, 0x1b, 0x2d, 0x4e, 0xbb, 0x59, 0x1e, 0x7d, 0x72, 0x1e, 0x2c, 0x3a,
+        0xce, 0x2b, 0x18, 0x7a, 0x0d, 0x6e, 0x5c, 0x48, 0xc9, 0x2f, 0x14, 0x04, 0x09, 0x69, 0x2d,
+        0x39,
+    ];
+    const OBSERVED_SERVER_HANDSHAKE_BODY: [u8; 273] = [
+        0x23, 0x12, 0x44, 0x26, 0x36, 0x49, 0x0e, 0x9a, 0x6d, 0x5e, 0x55, 0x24, 0x34, 0x54, 0x5a,
+        0xce, 0x31, 0x1d, 0x1e, 0x6b, 0x3f, 0x07, 0x1b, 0x90, 0x7b, 0x44, 0x52, 0x2c, 0x67, 0x4b,
+        0x2d, 0xab, 0x59, 0x00, 0x04, 0x69, 0x7a, 0x56, 0x46, 0xf5, 0x23, 0x4f, 0x53, 0x2f, 0x23,
+        0x57, 0x72, 0xc3, 0x5a, 0x43, 0x5f, 0x39, 0x23, 0x19, 0x0c, 0x96, 0x70, 0x43, 0x1c, 0x3d,
+        0x3f, 0x1b, 0x0b, 0x96, 0x70, 0x43, 0x01, 0x69, 0x6b, 0x47, 0x49, 0xdd, 0x21, 0x27, 0x00,
+        0x3f, 0x23, 0x19, 0x1d, 0xc1, 0x72, 0x49, 0x09, 0x77, 0x75, 0x1d, 0x01, 0x8f, 0x7a, 0x13,
+        0x36, 0x77, 0x34, 0x06, 0x16, 0x9c, 0x7a, 0x13, 0x0a, 0x72, 0x3b, 0x5f, 0x4d, 0x99, 0x79,
+        0x1d, 0x11, 0x2a, 0x23, 0x0c, 0x3b, 0x9c, 0x50, 0x7c, 0x7e, 0x2e, 0x17, 0x59, 0x2e, 0xb5,
+        0x6d, 0x43, 0x72, 0x7d, 0x30, 0x3c, 0x4b, 0xc3, 0x30, 0x43, 0x53, 0x25, 0x39, 0x0c, 0x46,
+        0xf5, 0x23, 0x4c, 0x49, 0x3f, 0x32, 0x3d, 0x01, 0x8f, 0x7a, 0x61, 0x55, 0x38, 0x2e, 0x57,
+        0x72, 0xc3, 0x7e, 0x58, 0x48, 0x23, 0x0e, 0x10, 0x08, 0x9a, 0x21, 0x5d, 0x5d, 0x38, 0x29,
+        0x1e, 0x17, 0x8d, 0x7b, 0x11, 0x13, 0x2a, 0x2f, 0x1d, 0x10, 0xab, 0x66, 0x5d, 0x59, 0x75,
+        0x50, 0x55, 0x19, 0x8a, 0x6b, 0x45, 0x68, 0x32, 0x2a, 0x0c, 0x46, 0x8c, 0x76, 0x4a, 0x6a,
+        0x7a, 0x66, 0x46, 0x19, 0x8a, 0x6b, 0x45, 0x68, 0x32, 0x2a, 0x0c, 0x46, 0xf5, 0x23, 0x4c,
+        0x49, 0x3f, 0x32, 0x3d, 0x01, 0x8f, 0x7a, 0x13, 0x4f, 0x22, 0x3d, 0x3f, 0x4b, 0xc3, 0x30,
+        0x4c, 0x49, 0x3f, 0x32, 0x3d, 0x01, 0x8f, 0x7a, 0x13, 0x36, 0x77, 0x75, 0x08, 0x0d, 0x8b,
+        0x77, 0x79, 0x45, 0x3b, 0x3f, 0x25, 0x11, 0x8c, 0x6b, 0x13, 0x36, 0x77, 0x75, 0x2c, 0x16,
+        0x9c, 0x6d, 0x54, 0x4c, 0x3f, 0x33, 0x06, 0x16, 0xc1, 0x15, 0x11, 0x13, 0x29, 0x35, 0x0d,
+        0x01, 0xc1, 0x15,
+    ];
+
+    fn observed_server_handshake_frame() -> Vec<u8> {
+        let mut frame = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x11, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x12, 0xdd, 0x14, 0x66,
+        ];
+        frame.extend_from_slice(&OBSERVED_SERVER_HANDSHAKE_BODY);
+        frame
+    }
+
+    fn observed_login_frame() -> Vec<u8> {
+        let mut frame = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x28, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x12, 0xdc, 0x14, 0x65,
+        ];
+        frame.extend(std::iter::repeat_n(0u8, 296));
+        frame[LOGIN_REFLECTED_SERVER_PREFIX_WINDOW.clone()]
+            .copy_from_slice(&OBSERVED_SERVER_HANDSHAKE_BODY[..LOGIN_REFLECTED_SERVER_PREFIX_LEN]);
+        frame[LOGIN_USERNAME_WINDOW.clone()].copy_from_slice(&OBSERVED_USERNAME_BLOCK);
+        frame[LOGIN_MIDDLE_WINDOW.clone()].copy_from_slice(&LOGIN_STATIC_MIDDLE);
+        frame[LOGIN_PASSWORD_WINDOW.clone()].copy_from_slice(&OBSERVED_PASSWORD_BLOCK);
+        frame
+    }
+
+    #[test]
+    fn parses_login_message_layout() {
+        let mut buf = vec![0u8; LOGIN_MESSAGE_STRUCT_LEN];
+        buf[LOGIN_MESSAGE_AUTH_MODE_OFFSET..LOGIN_MESSAGE_AUTH_MODE_OFFSET + 4]
+            .copy_from_slice(&3u32.to_le_bytes());
+        buf[LOGIN_MESSAGE_PORT_OFFSET..LOGIN_MESSAGE_PORT_OFFSET + 4]
+            .copy_from_slice(&9000u32.to_le_bytes());
+        buf[LOGIN_MESSAGE_UID_PORT_OFFSET..LOGIN_MESSAGE_UID_PORT_OFFSET + 4]
+            .copy_from_slice(&1234u32.to_le_bytes());
+        write_fixed_c_string(
+            &mut buf,
+            LOGIN_MESSAGE_HOST_OFFSET,
+            LOGIN_MESSAGE_HOST_FIELD_LEN,
+            "192.168.1.20",
+        )
+        .expect("host");
+        write_fixed_c_string(
+            &mut buf,
+            LOGIN_MESSAGE_UID_OFFSET,
+            LOGIN_MESSAGE_UID_FIELD_LEN,
+            "UIDTEST123",
+        )
+        .expect("uid");
+        write_fixed_c_string(
+            &mut buf,
+            LOGIN_MESSAGE_USERNAME_OFFSET,
+            LOGIN_MESSAGE_USERNAME_FIELD_LEN,
+            "admin",
+        )
+        .expect("username");
+        write_fixed_c_string(
+            &mut buf,
+            LOGIN_MESSAGE_PASSWORD_OFFSET,
+            LOGIN_MESSAGE_PASSWORD_FIELD_LEN,
+            "test1234",
+        )
+        .expect("password");
+        write_fixed_c_string(
+            &mut buf,
+            LOGIN_MESSAGE_AUTH_CODE_OFFSET,
+            LOGIN_MESSAGE_AUTH_CODE_FIELD_LEN,
+            "AUTH-CODE-XYZ",
+        )
+        .expect("auth code");
+
+        let parsed = parse_login_message(&buf).expect("parsed");
+        assert_eq!(
+            parsed,
+            ReolinkLoginMessage {
+                auth_mode: 3,
+                port: 9000,
+                uid_port: 1234,
+                host: "192.168.1.20".into(),
+                name: String::new(),
+                uid: "UIDTEST123".into(),
+                username: "admin".into(),
+                password: "test1234".into(),
+                auth_code: "AUTH-CODE-XYZ".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_and_builds_auth_code_layout() {
+        let expected = ReolinkAuthCode { auth_code: 7 };
+        let raw = build_auth_code(expected);
+        assert_eq!(raw.len(), AUTH_CODE_STRUCT_LEN);
+        assert_eq!(parse_auth_code(&raw), Some(expected));
+    }
+
+    #[test]
+    fn parses_and_builds_boot_pwd_state_layout() {
+        let expected = ReolinkBootPwdState {
+            has_boot_password: true,
+        };
+        let raw = build_boot_pwd_state(expected);
+        assert_eq!(raw.len(), BOOT_PWD_STATE_STRUCT_LEN);
+        assert_eq!(parse_boot_pwd_state(&raw), Some(expected));
+    }
+
+    #[test]
+    fn parses_and_builds_auth_info_layout() {
+        let expected = ReolinkAuthInfo {
+            notes: b"alpha-note".to_vec(),
+            valid_hours: 72,
+            user_level: 3,
+            ability: 0x1122_3344,
+            channel_ability: 0x8877_6655_4433_2211,
+        };
+        let raw = build_auth_info(&expected);
+        assert_eq!(raw.len(), AUTH_INFO_STRUCT_LEN);
+        assert_eq!(parse_auth_info(&raw), Some(expected));
+    }
+
+    #[test]
+    fn builds_login_message_layout_roundtrip() {
+        let msg = ReolinkLoginMessage {
+            auth_mode: 0,
+            port: 9000,
+            uid_port: 0,
+            host: "192.168.1.20".into(),
+            name: "lab-e1".into(),
+            uid: String::new(),
+            username: "admin".into(),
+            password: "test1234".into(),
+            auth_code: String::new(),
+        };
+
+        let bytes = build_login_message(&msg).expect("bytes");
+        assert_eq!(bytes.len(), LOGIN_MESSAGE_STRUCT_LEN);
+        assert_eq!(parse_login_message(&bytes), Some(msg));
+    }
+
+    #[test]
+    fn parses_and_builds_net_normal_port_layout() {
+        let expected = ReolinkNetNormalPort {
+            surv_enabled: true,
+            surv_port: 9000,
+            http_enabled: false,
+            http_port: 80,
+            https_enabled: true,
+            https_port: 443,
+        };
+        let raw = build_net_normal_port(expected);
+        assert_eq!(raw.len(), NET_NORMAL_PORT_STRUCT_LEN);
+        assert_eq!(parse_net_normal_port(&raw), Some(expected));
+    }
+
+    #[test]
+    fn parses_and_builds_net_advanced_port_layout() {
+        let expected = ReolinkNetAdvancedPort {
+            onvif_enabled: true,
+            onvif_port: 8000,
+            rtsp_enabled: true,
+            rtsp_port: 554,
+            rtmp_enabled: false,
+            rtmp_port: 1935,
+        };
+        let raw = build_net_advanced_port(expected);
+        assert_eq!(raw.len(), NET_ADVANCED_PORT_STRUCT_LEN);
+        assert_eq!(parse_net_advanced_port(&raw), Some(expected));
+    }
+
+    #[test]
+    fn parses_and_builds_p2p_cfg_layout() {
+        let expected = ReolinkP2PCfg {
+            enabled: false,
+            port: 0,
+            server_domain: "p2p.reolink.com".into(),
+        };
+        let raw = build_p2p_cfg(&expected).expect("raw");
+        assert_eq!(raw.len(), P2P_CFG_STRUCT_LEN);
+        assert_eq!(parse_p2p_cfg(&raw), Some(expected));
+    }
+
+    #[test]
+    fn parses_and_builds_force_password_layout() {
+        let expected = ReolinkForcePassword {
+            username: "admin".into(),
+            password: "test1234".into(),
+            nickname: "Camera A".into(),
+        };
+        let raw = build_force_password(&expected).expect("raw");
+        assert_eq!(raw.len(), FORCE_PASSWORD_STRUCT_LEN);
+        assert_eq!(parse_force_password(&raw), Some(expected));
+    }
+
+    #[test]
+    fn exposes_public_wrapper_metadata() {
+        assert_eq!(ReolinkRemoteCommand::SetNetAdvancedPort.request_id(), 0x849);
+        assert_eq!(ReolinkRemoteCommand::SetNetAdvancedPort.payload_len(), 0x18);
+        assert_eq!(ReolinkRemoteCommand::SetP2PCfg.request_id(), 0x869);
+        assert_eq!(ReolinkRemoteCommand::SetP2PCfg.payload_len(), 0x28);
+        assert_eq!(ReolinkRemoteCommand::ForceUserPassword.payload_len(), 0x60);
+    }
+
+    #[test]
+    fn parses_short_handshake_header() {
+        let buf = [
+            0xf0, 0xde, 0xbc, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x12, 0xdc, 0x14, 0x65,
+        ];
+        let header = parse_frame_header(&buf).expect("header");
+        assert_eq!(
+            header,
+            ReolinkFrameHeader::Short {
+                op: 1,
+                payload_len: 0,
+                field_c: 0,
+                field_d: 0x6514dc12,
+                header_len: 20,
+                total_len: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_extended_request_header() {
+        let mut buf = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x97, 0x00, 0x00, 0x00, 0xa6, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x14, 0x64, 0xa6, 0x00, 0x00, 0x00,
+        ];
+        buf.extend(std::iter::repeat_n(0u8, 0xa6));
+        let header = parse_frame_header(&buf).expect("header");
+        assert_eq!(
+            header,
+            ReolinkFrameHeader::Extended {
+                op: 0x97,
+                payload_len: 0xa6,
+                field_c: 1,
+                field_d: 0x6414_0000,
+                field_e: 0xa6,
+                header_len: 24,
+                total_len: 190,
+            }
+        );
+    }
+
+    #[test]
+    fn splits_multiple_extended_frames() {
+        let mut first = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x97, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x01, 0x00,
+            0x00, 0x00, 0xc8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb, 0xcc,
+        ];
+        let mut second = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x92, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x03, 0x00,
+            0x00, 0x00, 0xc8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xdd, 0xee,
+        ];
+        first.append(&mut second);
+        let segments = split_segments(&first);
+        assert_eq!(segments.len(), 2);
+        match &segments[0] {
+            ReolinkSegment::Frame { header, body } => {
+                assert_eq!(header.op(), 0x97);
+                assert_eq!(*body, [0xaa, 0xbb, 0xcc]);
+            }
+            _ => panic!("expected frame"),
+        }
+        match &segments[1] {
+            ReolinkSegment::Frame { header, body } => {
+                assert_eq!(header.op(), 0x92);
+                assert_eq!(*body, [0xdd, 0xee]);
+            }
+            _ => panic!("expected frame"),
+        }
+    }
+
+    #[test]
+    fn observes_server_ok_code() {
+        assert_eq!(OBSERVED_SERVER_OK, 200);
+    }
+
+    #[test]
+    fn identifies_known_transport_ops() {
+        assert_eq!(
+            ReolinkTransportOp::from_u32(0x3b),
+            Some(ReolinkTransportOp::ForceUserPassword)
+        );
+        assert_eq!(
+            ReolinkTransportOp::from_u32(0x76),
+            Some(ReolinkTransportOp::ReadBootPwdState)
+        );
+        assert_eq!(ReolinkTransportOp::from_u32(0xffff), None);
+    }
+
+    #[test]
+    fn builds_short_frame_roundtrip() {
+        let frame = build_short_frame(0x01, 0, 0x6514_dc12, &[]);
+        let header = parse_frame_header(&frame).expect("header");
+        assert_eq!(
+            header,
+            ReolinkFrameHeader::Short {
+                op: 0x01,
+                payload_len: 0,
+                field_c: 0,
+                field_d: 0x6514_dc12,
+                header_len: 20,
+                total_len: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn builds_extended_frame_roundtrip() {
+        let frame = build_extended_frame(0x24, 8, OBSERVED_CLIENT_FIELD_D, 0, &[0xaa, 0xbb]);
+        let header = parse_frame_header(&frame).expect("header");
+        assert_eq!(
+            header,
+            ReolinkFrameHeader::Extended {
+                op: 0x24,
+                payload_len: 2,
+                field_c: 8,
+                field_d: OBSERVED_CLIENT_FIELD_D,
+                field_e: 0,
+                header_len: 24,
+                total_len: 26,
+            }
+        );
+    }
+
+    #[test]
+    fn extracts_login_credential_window() {
+        let mut frame = vec![
+            0xf0, 0xde, 0xbc, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x2c, 0x01, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x12, 0xdc, 0x14, 0x65,
+        ];
+        frame.extend(std::iter::repeat_n(0u8, 300));
+        frame[LOGIN_CREDENTIAL_WINDOW.start] = 0xaa;
+        frame[LOGIN_CREDENTIAL_WINDOW.end - 1] = 0xbb;
+        let window = login_credential_window(&frame).expect("window");
+        assert_eq!(window.len(), LOGIN_CREDENTIAL_WINDOW.len());
+        assert_eq!(window[0], 0xaa);
+        assert_eq!(window[window.len() - 1], 0xbb);
+    }
+
+    #[test]
+    fn observed_login_frame_matches_declared_length() {
+        let frame = observed_login_frame();
+        let header = parse_frame_header(&frame).expect("header");
+        assert_eq!(header.total_len(), LOGIN_FRAME_LEN);
+        assert_eq!(frame.len(), LOGIN_FRAME_LEN);
+    }
+
+    #[test]
+    fn splits_observed_login_blocks() {
+        let frame = observed_login_frame();
+        assert!(login_has_expected_zero_lead(&frame));
+        assert_eq!(
+            login_reflected_server_prefix(&frame).expect("prefix"),
+            &OBSERVED_SERVER_HANDSHAKE_BODY[..LOGIN_REFLECTED_SERVER_PREFIX_LEN]
+        );
+        assert_eq!(
+            login_username_block(&frame).expect("username"),
+            OBSERVED_USERNAME_BLOCK
+        );
+        assert_eq!(
+            login_middle_block(&frame).expect("middle"),
+            LOGIN_STATIC_MIDDLE
+        );
+        assert_eq!(
+            login_password_block(&frame).expect("password"),
+            OBSERVED_PASSWORD_BLOCK
+        );
+        assert!(login_has_observed_static_middle(&frame));
+    }
+
+    #[test]
+    fn extracts_server_handshake_body() {
+        let frame = observed_server_handshake_frame();
+        let body = handshake_frame_body(&frame).expect("body");
+        assert_eq!(body, OBSERVED_SERVER_HANDSHAKE_BODY);
+    }
+
+    #[test]
+    fn login_matches_observed_server_prefix() {
+        let login = observed_login_frame();
+        let server = observed_server_handshake_frame();
+        assert!(login_matches_server_prefix(&login, &server));
+    }
+
+    #[test]
+    fn extracts_observed_handshake_windows() {
+        let payload: Vec<u8> = (0..OBSERVED_SERVER_HANDSHAKE_BODY.len())
+            .map(|index| index as u8)
+            .collect();
+        let frame = build_short_frame(
+            ReolinkTransportOp::Handshake as u32,
+            0,
+            0x6514_dc12,
+            &payload,
+        );
+
+        assert_eq!(
+            handshake_reflected_prefix(&frame).expect("prefix"),
+            &payload[..LOGIN_REFLECTED_SERVER_PREFIX_LEN]
+        );
+        assert_eq!(
+            handshake_observed_credential_salt(&frame).expect("salt"),
+            SERVER_HANDSHAKE_CREDENTIAL_SALT_INDICES.map(|index| payload[index])
+        );
+    }
+
+    #[test]
+    fn detects_diffs_confined_to_credential_blocks() {
+        let left = observed_login_frame();
+        let mut right = left.clone();
+        right[LOGIN_USERNAME_WINDOW.start] ^= 0xff;
+        right[LOGIN_PASSWORD_WINDOW.end - 1] ^= 0xff;
+        assert!(login_frames_differ_only_in_credential_blocks(&left, &right));
+
+        right[LOGIN_MIDDLE_WINDOW.start] ^= 0xff;
+        assert!(!login_frames_differ_only_in_credential_blocks(
+            &left, &right
+        ));
+    }
+
+    #[test]
+    fn encodes_observed_password_secret() {
+        assert_eq!(
+            encode_password_secret(b"test1234").as_deref(),
+            Some("sYvw14rJMSHhNsRJlaApLA==")
+        );
+    }
+
+    #[test]
+    fn decodes_observed_password_secret() {
+        assert_eq!(
+            decode_password_secret("sYvw14rJMSHhNsRJlaApLA==").as_deref(),
+            Some(b"test1234".as_slice())
+        );
+    }
+
+    #[test]
+    fn maps_confirmed_observed_dispatches() {
+        assert_eq!(
+            ReolinkRemoteCommand::GetNetAdvancedPort.observed_dispatch(),
+            Some(ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::HeaderOnly,
+                request_id: 0x848,
+                payload_len: 0,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetNetAdvancedPort.observed_dispatch(),
+            Some(ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x849,
+                payload_len: 0x18,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetP2PCfg.observed_dispatch(),
+            Some(ReolinkObservedDispatch {
+                kind: ReolinkDispatchKind::Payload,
+                request_id: 0x86a,
+                payload_len: 0x28,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetNetNormalPort.observed_dispatch(),
+            None
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::ForceUserPassword.observed_dispatch(),
+            None
+        );
+    }
+
+    #[test]
+    fn maps_confirmed_observed_primary_transport() {
+        assert_eq!(
+            ReolinkRemoteCommand::GetNetAdvancedPort.observed_primary_transport(),
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadPortBundle,
+                payload_len: 0,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetNetAdvancedPort.observed_primary_transport(),
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WritePortBundle,
+                payload_len: 304,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetNetNormalPort.observed_primary_transport(),
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WritePortBundle,
+                payload_len: 310,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetP2PCfg.observed_primary_transport(),
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::WriteP2P,
+                payload_len: 144,
+            })
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetP2PCfg.observed_apply_transport(),
+            None
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetLoginAuthCode.observed_primary_transport(),
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ReadLoginAuthCode,
+                payload_len: 218,
+            })
+        );
+    }
+
+    #[test]
+    fn maps_confirmed_observed_transport_ops() {
+        assert_eq!(
+            ReolinkRemoteCommand::GetNetAdvancedPort.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ReadPortBundle,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetNetAdvancedPort.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::WritePortBundle,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetNetNormalPort.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ReadPortBundle,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetNetNormalPort.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::WritePortBundle,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::ForceUserPassword.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ForceUserPassword,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetP2PCfg.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ReadP2P,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetBootPwdState.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ReadBootPwdState,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetBootPwdState.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::WriteBootPwdState,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::SetP2PCfg.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::WriteP2P,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+        assert_eq!(
+            ReolinkRemoteCommand::GetLoginAuthCode.observed_transport_ops(),
+            Some(
+                &[
+                    ReolinkTransportOp::CommonReadA,
+                    ReolinkTransportOp::CommonReadB,
+                    ReolinkTransportOp::CommonReadC,
+                    ReolinkTransportOp::ReadLoginAuthCode,
+                    ReolinkTransportOp::Telemetry,
+                ][..]
+            )
+        );
+    }
+
+    #[test]
+    fn replaces_login_blocks_and_preserves_observed_middle() {
+        let frame = observed_login_frame();
+        let username = [0x11; 31];
+        let password = [0x22; 31];
+        let replaced = replace_login_blocks(&frame, &username, &password).expect("replaced");
+        assert_eq!(login_username_block(&replaced).expect("username"), username);
+        assert_eq!(
+            login_middle_block(&replaced).expect("middle"),
+            LOGIN_STATIC_MIDDLE
+        );
+        assert_eq!(login_password_block(&replaced).expect("password"), password);
+    }
+}

--- a/src/reolink_proto.rs
+++ b/src/reolink_proto.rs
@@ -1,6 +1,7 @@
 use aes::Aes128;
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit, generic_array::GenericArray};
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64_STANDARD};
+use md5::{Digest, Md5};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ReolinkFrameHeader {
@@ -24,6 +25,9 @@ pub enum ReolinkFrameHeader {
 }
 
 pub const MAGIC: [u8; 4] = [0xf0, 0xde, 0xbc, 0x0a];
+pub const BC_XML_KEY: [u8; 8] = [0x1F, 0x2D, 0x3C, 0x4B, 0x5A, 0x69, 0x78, 0xFF];
+pub const OBSERVED_HANDSHAKE_REQUEST_FIELD_D: u32 = 0x6514_dc12;
+pub const OBSERVED_HANDSHAKE_RESPONSE_FIELD_D: u32 = 0x6614_dd12;
 pub const OBSERVED_CLIENT_FIELD_D: u32 = 0x6414_0000;
 pub const OBSERVED_SERVER_OK: u32 = 200;
 pub const LOGIN_FRAME_LEN: usize = 316;
@@ -1741,6 +1745,87 @@ pub fn build_short_frame(op: u32, field_c: u32, field_d: u32, payload: &[u8]) ->
     out
 }
 
+pub fn bcencrypt(offset: u8, payload: &[u8]) -> Vec<u8> {
+    payload
+        .iter()
+        .enumerate()
+        .map(|(index, byte)| {
+            let key = BC_XML_KEY[(index + (offset as usize)) % BC_XML_KEY.len()];
+            byte ^ key ^ offset
+        })
+        .collect()
+}
+
+pub fn bcdecrypt(offset: u8, payload: &[u8]) -> Vec<u8> {
+    // BCEncrypt is a XOR stream, so decrypt == encrypt.
+    bcencrypt(offset, payload)
+}
+
+pub fn build_handshake_probe_frame() -> Vec<u8> {
+    build_short_frame(
+        ReolinkTransportOp::Handshake as u32,
+        0,
+        OBSERVED_HANDSHAKE_REQUEST_FIELD_D,
+        &[],
+    )
+}
+
+fn parse_nonce_from_xml(xml: &str) -> Option<String> {
+    let start = xml.find("<nonce>")?;
+    let value_start = start + "<nonce>".len();
+    let end = xml[value_start..].find("</nonce>")?;
+    Some(xml[value_start..(value_start + end)].to_string())
+}
+
+pub fn decrypt_handshake_xml(body: &[u8]) -> Option<String> {
+    let plaintext = bcdecrypt(0, body);
+    String::from_utf8(plaintext).ok()
+}
+
+pub fn extract_nonce_from_handshake_body(body: &[u8]) -> Option<String> {
+    let xml = decrypt_handshake_xml(body)?;
+    parse_nonce_from_xml(&xml)
+}
+
+pub fn md5_upper_31(input: &str) -> String {
+    let mut hasher = Md5::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    let upper = hex::encode_upper(digest);
+    upper[..31].to_string()
+}
+
+pub fn build_login_xml(username: &str, password: &str, nonce: &str) -> String {
+    let username_md5 = md5_upper_31(&format!("{username}{nonce}"));
+    let password_md5 = md5_upper_31(&format!("{password}{nonce}"));
+    format!(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n\
+<body>\n\
+<LoginUser version=\"1.1\">\n\
+<userName>{username_md5}</userName>\n\
+<password>{password_md5}</password>\n\
+<userVer>1</userVer>\n\
+</LoginUser>\n\
+<LoginNet version=\"1.1\">\n\
+<type>LAN</type>\n\
+<udpPort>0</udpPort>\n\
+</LoginNet>\n\
+</body>\n"
+    )
+}
+
+pub fn build_login_frame(username: &str, password: &str, nonce: &str) -> Vec<u8> {
+    let xml = build_login_xml(username, password, nonce);
+    let encrypted = bcencrypt(0, xml.as_bytes());
+    build_extended_frame(
+        ReolinkTransportOp::Handshake as u32,
+        0,
+        OBSERVED_CLIENT_FIELD_D,
+        0,
+        &encrypted,
+    )
+}
+
 pub fn build_extended_frame(
     op: u32,
     field_c: u32,
@@ -2676,5 +2761,73 @@ mod tests {
             LOGIN_STATIC_MIDDLE
         );
         assert_eq!(login_password_block(&replaced).expect("password"), password);
+    }
+
+    #[test]
+    fn bcencrypt_roundtrip() {
+        let payload = b"constitute-reolink-bcencrypt";
+        let encrypted = bcencrypt(0, payload);
+        assert_ne!(encrypted, payload);
+        let decrypted = bcdecrypt(0, &encrypted);
+        assert_eq!(decrypted, payload);
+    }
+
+    #[test]
+    fn decrypts_observed_handshake_and_extracts_nonce() {
+        let frame = observed_server_handshake_frame();
+        let body = handshake_frame_body(&frame).expect("handshake body");
+        let xml = decrypt_handshake_xml(body).expect("handshake xml");
+        assert!(xml.contains("<Encryption version=\"1.1\">"));
+        assert!(xml.contains("<nonce>"));
+        let nonce = extract_nonce_from_handshake_body(body).expect("nonce");
+        assert!(!nonce.is_empty());
+    }
+
+    #[test]
+    fn computes_expected_modern_login_hashes() {
+        let nonce = "69a886e7-e6zQYHd61yUQBte6rV0F";
+        assert_eq!(
+            md5_upper_31(&format!("{}{}", "admin", nonce)),
+            "ED31EBDF0CB67A665AE471BF2A75BA7"
+        );
+        assert_eq!(
+            md5_upper_31(&format!("{}{}", "Test1234", nonce)),
+            "E400F51521344AC76EFCBF85C5A869C"
+        );
+    }
+
+    #[test]
+    fn builds_expected_login_xml_and_frame_shape() {
+        let nonce = "69a886e7-e6zQYHd61yUQBte6rV0F";
+        let xml = build_login_xml("admin", "Test1234", nonce);
+        assert!(xml.contains("<userName>ED31EBDF0CB67A665AE471BF2A75BA7</userName>"));
+        assert!(xml.contains("<password>E400F51521344AC76EFCBF85C5A869C</password>"));
+
+        let frame = build_login_frame("admin", "Test1234", nonce);
+        let header = parse_frame_header(&frame).expect("frame header");
+        assert_eq!(header.op(), ReolinkTransportOp::Handshake as u32);
+        assert_eq!(frame.len(), 24 + xml.len());
+
+        let encrypted = match header {
+            ReolinkFrameHeader::Extended { .. } => &frame[24..],
+            ReolinkFrameHeader::Short { .. } => panic!("expected extended login frame"),
+        };
+        let decrypted = String::from_utf8(bcdecrypt(0, encrypted)).expect("login xml utf8");
+        assert_eq!(decrypted, xml);
+    }
+
+    #[test]
+    fn builds_expected_handshake_probe_frame() {
+        let frame = build_handshake_probe_frame();
+        assert_eq!(
+            frame,
+            vec![
+                0xf0, 0xde, 0xbc, 0x0a, // magic
+                0x01, 0x00, 0x00, 0x00, // op
+                0x00, 0x00, 0x00, 0x00, // payload len
+                0x00, 0x00, 0x00, 0x00, // field c
+                0x12, 0xdc, 0x14, 0x65, // field d
+            ]
+        );
     }
 }

--- a/src/reolink_proto.rs
+++ b/src/reolink_proto.rs
@@ -318,7 +318,7 @@ impl ReolinkRemoteCommand {
             },
             Self::SetNetAdvancedPort => ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::WritePortBundle,
-                payload_len: 304,
+                payload_len: 222,
             },
             Self::GetNetNormalPort => ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::ReadPortBundle,
@@ -326,7 +326,7 @@ impl ReolinkRemoteCommand {
             },
             Self::SetNetNormalPort => ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::WritePortBundle,
-                payload_len: 310,
+                payload_len: 307,
             },
             Self::GetP2PCfg => ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::ReadP2P,
@@ -356,59 +356,120 @@ impl ReolinkRemoteCommand {
     }
 
     pub fn observed_apply_transport(self) -> Option<ReolinkObservedTransportRequest> {
-        None
+        Some(match self {
+            Self::SetNetAdvancedPort
+            | Self::SetNetNormalPort
+            | Self::SetP2PCfg
+            | Self::ForceUserPassword => ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ApplyConfig,
+                payload_len: 125,
+            },
+            _ => return None,
+        })
     }
 
     pub fn observed_transport_ops(self) -> Option<&'static [ReolinkTransportOp]> {
         Some(match self {
             Self::GetNetAdvancedPort => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::ReadPortBundle,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadPortBundle,
             ],
             Self::SetNetAdvancedPort => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::WritePortBundle,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadPortBundle,
+                ReolinkTransportOp::WritePortBundle,
             ],
             Self::GetNetNormalPort => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::ReadPortBundle,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadPortBundle,
             ],
             Self::SetNetNormalPort => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::WritePortBundle,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadPortBundle,
+                ReolinkTransportOp::WritePortBundle,
             ],
             Self::ForceUserPassword => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::ForceUserPassword,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ForceUserPassword,
             ],
             Self::GetP2PCfg => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::ReadP2P,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadP2P,
             ],
             Self::GetBootPwdState => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::ReadBootPwdState,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadBootPwdState,
+                ReolinkTransportOp::AsyncStatus,
             ],
             Self::SetBootPwdState => &[
                 ReolinkTransportOp::CommonReadA,
@@ -418,11 +479,19 @@ impl ReolinkRemoteCommand {
                 ReolinkTransportOp::Telemetry,
             ],
             Self::SetP2PCfg => &[
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Handshake,
+                ReolinkTransportOp::Login,
+                ReolinkTransportOp::SessionBind,
+                ReolinkTransportOp::ChannelReady,
+                ReolinkTransportOp::CommonAck,
                 ReolinkTransportOp::CommonReadA,
                 ReolinkTransportOp::CommonReadB,
                 ReolinkTransportOp::CommonReadC,
-                ReolinkTransportOp::WriteP2P,
                 ReolinkTransportOp::Telemetry,
+                ReolinkTransportOp::ApplyConfig,
+                ReolinkTransportOp::ReadP2P,
+                ReolinkTransportOp::WriteP2P,
             ],
             Self::GetLoginAuthCode => &[
                 ReolinkTransportOp::CommonReadA,
@@ -2378,14 +2447,14 @@ mod tests {
             ReolinkRemoteCommand::SetNetAdvancedPort.observed_primary_transport(),
             Some(ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::WritePortBundle,
-                payload_len: 304,
+                payload_len: 222,
             })
         );
         assert_eq!(
             ReolinkRemoteCommand::SetNetNormalPort.observed_primary_transport(),
             Some(ReolinkObservedTransportRequest {
                 op: ReolinkTransportOp::WritePortBundle,
-                payload_len: 310,
+                payload_len: 307,
             })
         );
         assert_eq!(
@@ -2397,7 +2466,10 @@ mod tests {
         );
         assert_eq!(
             ReolinkRemoteCommand::SetP2PCfg.observed_apply_transport(),
-            None
+            Some(ReolinkObservedTransportRequest {
+                op: ReolinkTransportOp::ApplyConfig,
+                payload_len: 125,
+            })
         );
         assert_eq!(
             ReolinkRemoteCommand::GetLoginAuthCode.observed_primary_transport(),
@@ -2414,11 +2486,18 @@ mod tests {
             ReolinkRemoteCommand::GetNetAdvancedPort.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::ReadPortBundle,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadPortBundle,
                 ][..]
             )
         );
@@ -2426,11 +2505,19 @@ mod tests {
             ReolinkRemoteCommand::SetNetAdvancedPort.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::WritePortBundle,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadPortBundle,
+                    ReolinkTransportOp::WritePortBundle,
                 ][..]
             )
         );
@@ -2438,11 +2525,18 @@ mod tests {
             ReolinkRemoteCommand::GetNetNormalPort.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::ReadPortBundle,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadPortBundle,
                 ][..]
             )
         );
@@ -2450,11 +2544,19 @@ mod tests {
             ReolinkRemoteCommand::SetNetNormalPort.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::WritePortBundle,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadPortBundle,
+                    ReolinkTransportOp::WritePortBundle,
                 ][..]
             )
         );
@@ -2462,11 +2564,18 @@ mod tests {
             ReolinkRemoteCommand::ForceUserPassword.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::ForceUserPassword,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ForceUserPassword,
                 ][..]
             )
         );
@@ -2474,11 +2583,18 @@ mod tests {
             ReolinkRemoteCommand::GetP2PCfg.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::ReadP2P,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadP2P,
                 ][..]
             )
         );
@@ -2486,11 +2602,19 @@ mod tests {
             ReolinkRemoteCommand::GetBootPwdState.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::ReadBootPwdState,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadBootPwdState,
+                    ReolinkTransportOp::AsyncStatus,
                 ][..]
             )
         );
@@ -2510,11 +2634,19 @@ mod tests {
             ReolinkRemoteCommand::SetP2PCfg.observed_transport_ops(),
             Some(
                 &[
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Handshake,
+                    ReolinkTransportOp::Login,
+                    ReolinkTransportOp::SessionBind,
+                    ReolinkTransportOp::ChannelReady,
+                    ReolinkTransportOp::CommonAck,
                     ReolinkTransportOp::CommonReadA,
                     ReolinkTransportOp::CommonReadB,
                     ReolinkTransportOp::CommonReadC,
-                    ReolinkTransportOp::WriteP2P,
                     ReolinkTransportOp::Telemetry,
+                    ReolinkTransportOp::ApplyConfig,
+                    ReolinkTransportOp::ReadP2P,
+                    ReolinkTransportOp::WriteP2P,
                 ][..]
             )
         );

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -68,6 +68,8 @@ struct DeviceRecordPayload {
     ui_entry: String,
     #[serde(skip_serializing_if = "String::is_empty")]
     session_ws_url: String,
+    #[serde(default)]
+    allow_unsigned_hello_mvp: bool,
     metrics: DeviceMetricsPayload,
 }
 
@@ -370,6 +372,7 @@ fn build_device_record(cfg: &Config, metrics: &DeviceMetricsPayload) -> Result<N
         ui_manifest_url: cfg.ui.manifest_url.clone(),
         ui_entry: cfg.ui.entry.clone(),
         session_ws_url: cfg.api.public_ws_url.clone(),
+        allow_unsigned_hello_mvp: cfg.api.allow_unsigned_hello_mvp,
         metrics: metrics.clone(),
     };
     let content = serde_json::to_string(&payload)?;
@@ -379,6 +382,14 @@ fn build_device_record(cfg: &Config, metrics: &DeviceMetricsPayload) -> Result<N
         vec!["role".to_string(), cfg.node_role.clone()],
         vec!["service".to_string(), "nvr".to_string()],
         vec!["cap".to_string(), "camera".to_string()],
+        vec![
+            "hello".to_string(),
+            if cfg.api.allow_unsigned_hello_mvp {
+                "unsigned-mvp".to_string()
+            } else {
+                "signed".to_string()
+            },
+        ],
     ];
     let unsigned = nostr::build_unsigned_event(
         &cfg.nostr_pubkey,

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::nostr::{self, NostrEvent};
 use crate::util;
 use anyhow::{Context, Result};
+use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::net::SocketAddr;
@@ -177,6 +178,28 @@ async fn announce_loop(
         .map(|z| z.key.clone())
         .collect::<Vec<_>>();
 
+    let pair_identity_label = cfg.pair_identity_label.trim().to_string();
+    let pair_code = cfg.pair_code.trim().to_string();
+    let pair_code_hash = if !cfg.pair_code_hash.trim().is_empty() {
+        cfg.pair_code_hash.trim().to_string()
+    } else if !pair_identity_label.is_empty() && !pair_code.is_empty() {
+        util::sha256_b64url(&format!("{}|{}", pair_identity_label, pair_code))
+    } else {
+        String::new()
+    };
+
+    if !pair_identity_label.is_empty() && pair_code_hash.is_empty() {
+        warn!("pair_identity_label configured but no pair_code/pair_code_hash available; enrollment publish disabled");
+    }
+
+    let pair_enabled = !pair_identity_label.is_empty() && !pair_code_hash.is_empty();
+    let mut pair_tick = interval(Duration::from_secs(cfg.pair_request_interval_secs.max(5)));
+    let mut pair_attempts_remaining = if pair_enabled {
+        cfg.pair_request_attempts.max(1)
+    } else {
+        0
+    };
+
     loop {
         tokio::select! {
             _ = hello_tick.tick() => {
@@ -224,6 +247,30 @@ async fn announce_loop(
                         broadcast_json(&socket, &peers, &msg).await;
                     }
                 }
+            }
+            _ = pair_tick.tick(), if pair_enabled && pair_attempts_remaining > 0 => {
+                for zone in &zones {
+                    match build_pair_request_event(&cfg, zone, &pair_identity_label, &pair_code, &pair_code_hash) {
+                        Ok(ev) => {
+                            let msg = UdpMessage::Record {
+                                v: PROTOCOL_VERSION,
+                                zone: zone.clone(),
+                                record_type: "signal".to_string(),
+                                event: ev,
+                                ts: util::now_ms(),
+                            };
+                            broadcast_json(&socket, &peers, &msg).await;
+                        }
+                        Err(err) => {
+                            warn!(error = %err, zone = %zone, "failed building pair_request enrollment signal");
+                        }
+                    }
+                }
+
+                if pair_attempts_remaining > 0 {
+                    pair_attempts_remaining -= 1;
+                }
+                info!(remaining = pair_attempts_remaining, identity = %pair_identity_label, "published nvr pair_request enrollment");
             }
         }
     }
@@ -428,4 +475,74 @@ fn build_zone_presence(cfg: &Config, zone: &str) -> Result<NostrEvent> {
         util::now_unix_seconds(),
     );
     nostr::sign_event(&unsigned, &cfg.nostr_sk_hex)
+}
+
+
+fn build_pair_request_event(
+    cfg: &Config,
+    zone: &str,
+    identity_label: &str,
+    pair_code: &str,
+    pair_code_hash: &str,
+) -> Result<NostrEvent> {
+    let mut rid = [0u8; 6];
+    rand::thread_rng().fill_bytes(&mut rid);
+    let request_id = format!("req-nvr-{}", hex::encode(rid));
+
+    let payload = serde_json::json!({
+        "type": "pair_request",
+        "identity": identity_label,
+        "requestId": request_id,
+        "code": pair_code,
+        "codeHash": pair_code_hash,
+        "devicePk": cfg.nostr_pubkey.clone(),
+        "deviceDid": format!("did:key:{}", cfg.nostr_pubkey.clone()),
+        "deviceLabel": cfg.device_label.clone(),
+        "ts": util::now_ms(),
+        "ttl": 120,
+    });
+
+    let tags = vec![
+        vec!["t".to_string(), "constitute".to_string()],
+        vec!["i".to_string(), identity_label.to_string()],
+        vec!["z".to_string(), zone.to_string()],
+    ];
+
+    let unsigned = nostr::build_unsigned_event(
+        &cfg.nostr_pubkey,
+        APP_KIND,
+        tags,
+        serde_json::to_string(&payload)?,
+        util::now_unix_seconds(),
+    );
+    nostr::sign_event(&unsigned, &cfg.nostr_sk_hex)
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pair_request_event_contains_required_tags_and_payload() {
+        let path = std::env::temp_dir().join(format!(
+            "constitute-nvr-swarm-test-{}.json",
+            std::process::id()
+        ));
+        let cfg = crate::config::Config::load_or_create(&path)
+            .expect("create temp config")
+            .0;
+        let _ = std::fs::remove_file(&path);
+
+        let ev = build_pair_request_event(&cfg, "zone-test", "Identity", "123456", "hash123")
+            .expect("pair request event");
+        assert_eq!(ev.kind, APP_KIND);
+        assert!(ev.tags.iter().any(|t| t.get(0).map(String::as_str) == Some("t") && t.get(1).map(String::as_str) == Some("constitute")));
+        assert!(ev.tags.iter().any(|t| t.get(0).map(String::as_str) == Some("z") && t.get(1).map(String::as_str) == Some("zone-test")));
+
+        let payload: serde_json::Value = serde_json::from_str(&ev.content).expect("json payload");
+        assert_eq!(payload.get("type").and_then(|v| v.as_str()), Some("pair_request"));
+        assert_eq!(payload.get("identity").and_then(|v| v.as_str()), Some("Identity"));
+        assert_eq!(payload.get("codeHash").and_then(|v| v.as_str()), Some("hash123"));
+    }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,3 +13,14 @@ pub fn now_ms() -> u64 {
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
 }
+
+
+pub fn sha256_b64url(input: &str) -> String {
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update(input.as_bytes());
+    let digest = hasher.finalize();
+    URL_SAFE_NO_PAD.encode(digest)
+}


### PR DESCRIPTION
## Summary
This delivers the next non-manual roadmap slice for NVR convergence:
- manifest-driven UI linkage fields in swarm device records
- source lifecycle command surface + runtime state machine
- service metrics publication in swarm device records

## What Changed
- Extended NVR config contract:
  - `api.public_ws_url`
  - `ui.repo`
  - `ui.ref`
  - `ui.manifest_url`
  - `ui.entry`
- Extended swarm device record payload:
  - `ingestProtocols`, `capabilities`
  - `uiRepo`, `uiRef`, `uiManifestUrl`, `uiEntry`
  - `sessionWsUrl`
  - `metrics` (`uptimeSec`, peer counts, camera counts)
- Added encrypted API commands:
  - `list_source_states`
  - `upsert_source`
  - `remove_source`
- Added recorder runtime state machine with restart/backoff telemetry.
- Updated protocol/operations/roadmap docs and `config.example.json`.

## Validation
- `cargo test --quiet`

## Roadmap Impact
- Advances `docs/ROADMAP.md` Iteration 2 items:
  - ONVIF source lifecycle state machine
  - reconnect/backoff policy
  - service metrics in swarm records
- Delivers `constitute-nvr#6` contract fields for manifest-driven UI auto-enable.

Related to #1, #3, #6