### PR TITLE
feat(nvr): converge site time policy and camera assurance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,6 +109,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +488,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "cipher"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +599,8 @@ dependencies = [
  "base64 0.22.1",
  "cfb-mode",
  "chacha20poly1305",
+ "chrono",
+ "chrono-tz",
  "clap",
  "futures-util",
  "hex",
@@ -595,6 +627,12 @@ dependencies = [
  "webrtc-util",
  "x25519-dalek",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -1267,6 +1305,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1735,6 +1797,24 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -2403,6 +2483,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
@@ -3396,10 +3482,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ axum = { version = "0.8", features = ["ws"] }
 base64 = "0.22"
 cfb-mode = "0.8"
 chacha20poly1305 = { version = "0.10", features = ["std"] }
+chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 futures-util = "0.3"
 hex = "0.4"

--- a/config.example.json
+++ b/config.example.json
@@ -55,7 +55,10 @@
     "host_ip": "192.168.250.1",
     "dhcp_enabled": true,
     "dhcp_range_start": "192.168.250.50",
-    "dhcp_range_end": "192.168.250.199"
+    "dhcp_range_end": "192.168.250.199",
+    "ntp_enabled": true,
+    "ntp_server": "192.168.250.1",
+    "timezone": "America/Phoenix"
   },
   "live_preview": {
     "udp_port_min": 41000,

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -17,7 +17,32 @@
 - RTSP port observed on `554/tcp` after native enablement
 - Reolink cloud/P2P endpoint behavior observed: yes (`p2p.reolink.com`, `devices-apis.reolink.com`)
 - RTSP ingest path: pending sustained validation in this repo
-- Interim PTZ status: native `9000` pose readback works, but native `SetPtzPos` is still not a trustworthy actuation path on the lab `E1 Outdoor SE`; the attempted CGI pulse fallback is also currently hitting camera-side login/session exhaustion (`rspCode -5: max session`), so PTZ UI is hidden for now while session reuse/cleanup and real fulfillment are sorted out
+- Interim PTZ status: native `9000` pose readback works, but native `SetPtzPos` is still not a trustworthy actuation path on the lab `E1 Outdoor SE`, so PTZ UI remains hidden while real fulfillment is revisited
+- Reolink presentation/name apply status: verified live on `2026-04-16`
+  - CGI session cleanup now closes camera-side login slots after each operation instead of leaking them
+  - camera name / OSD overlay apply was proven on the lab camera by driving `Reolink E1 Outdoor SE` -> `Carport` -> `Test` -> `Carport`
+  - requested-field verification is now based on real camera readback, not desired-value fallback
+- Reolink site-time policy status: active for current pass
+  - site-wide NTP/timezone policy now belongs to `camera_network`, not to per-camera settings
+  - ONVIF is the authority for normalized time fields (`time_mode`, `ntp_server`, `timezone`)
+  - CGI remains the authority for OSD/name and raw clock-display format write/readback
+  - current driver policy hardcodes the on-camera clock display to `MM/DD/YYYY` plus 24-hour time with seconds
+  - live feed proof on `2026-04-17` showed that changing `camera_network.timezone` updates the baked timestamp in the camera image through the CGI time payload:
+    - `UTC` produced `04/18/2026 12:14:27 am SAT`
+    - `America/Phoenix` produced `04/17/2026 05:14:56 pm FRI`
+  - implication: feed-truth for clock presentation is the Reolink CGI time payload (`timeZone`, `timeFmt`, `hourFmt`, `isDst`), not the ONVIF timezone label
+  - current verification matches that split:
+    - `time_mode` / `ntp_server` verify from ONVIF
+    - `timezone` verifies from the feed-facing CGI time payload
+  - follow-up live proof on `2026-04-17`:
+    - the lab Fedora host required `confdir /etc/chrony.d` in `/etc/chrony.conf` before the bootstrap-written chrony drop-in was actually loaded and UDP `123` was served on the camera NIC
+    - Reolink apply now also seeds the current site-local wall clock in the CGI time payload while leaving NTP enabled, so the baked feed clock converges immediately instead of waiting for the camera's next poll
+    - final feed proof after the fix showed `04/17/2026 18:05:44 FRI`
+  - current proven format state on this model:
+    - `MM/DD/YYYY`
+    - 24-hour time with seconds
+    - weekday suffix still present
+  - no surfaced Reolink `GetTime` / `SetTime` or OSD control has been proven for hiding or reordering weekday on this model
 - Current automation status: native DHCP bootstrap is implemented; configured-camera control can fall back to native CGI for ports/P2P, but first-boot provisioning still depends on the proprietary 9000 path and remains the blocking native-Rust gap
 - Recommended status: test candidate with camera-jail policy enabled
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -26,6 +26,8 @@ Install flow notes:
 - auto-update timer is enabled by default (`constitute-nvr-update.timer`)
 - updater rolls back binary when restart/health validation fails
 - install bootstrap now provisions the dedicated camera NIC, selects a non-colliding `/24`, and binds `dnsmasq` DHCP on that NIC
+- camera bootstrap must also leave the host serving NTP on the camera NIC
+  - when chrony drop-ins are used, bootstrap now ensures the matching `confdir` line is present in `/etc/chrony.conf` so Fedora-class hosts actually load `/etc/chrony.d`
 - source-build/dev installs are expected to update through `constitute-nvr-update.timer`; in-process source updates are intentionally skipped
 
 ## 2) Service Checks
@@ -35,6 +37,8 @@ systemctl status constitute-nvr
 journalctl -u constitute-nvr -n 100 --no-pager
 systemctl status constitute-nvr-update.timer
 systemctl list-timers | grep constitute-nvr-update
+chronyd -p -f /etc/chrony.conf
+ss -ulpn | grep ':123 '
 ```
 
 ## Persistence Contract
@@ -58,6 +62,9 @@ Critical fields before ingest:
 - `camera_network.subnet_cidr`
 - `camera_network.host_ip`
 - `camera_network.dhcp_enabled`
+- `camera_network.ntp_enabled`
+- `camera_network.ntp_server`
+- `camera_network.timezone`
 - `autoprovision.reolink_*` (when auto-provision enabled)
 - `cameras[]`
 
@@ -79,6 +86,9 @@ constitute-nvr --probe-reolink-ip 192.168.1.20
 Notes:
 - Binding UDP/67 generally requires root or `CAP_NET_BIND_SERVICE`.
 - Current automation covers lease + vendor discovery + standards readiness checks.
+- After bootstrap, verify host NTP serving for the camera subnet:
+  - `chronyd -p -f /etc/chrony.conf` should include the camera-subnet `allow` / `local` directives
+  - `ss -ulpn | grep ':123 '` should show `chronyd` listening on UDP `123`
 - CGI setup path covers RTSP/ONVIF/P2P toggles when HTTP API is available; proprietary `9000` path remains fallback/R&D for HTTP-disabled devices.
 
 ## 6) Health Endpoint
@@ -89,7 +99,7 @@ curl -s http://127.0.0.1:8456/health | jq .
 
 Notes:
 - `/health` is intentionally redacted; camera credentials and raw credential-bearing RTSP URLs are never returned.
-- `cameraNetwork` should reflect the provisioned camera NIC and DHCP range.
+- `cameraNetwork` should reflect the provisioned camera NIC, DHCP range, and active site-time policy (`ntp_enabled`, `ntp_server`, `timezone`).
 
 ## 7) Camera Hardening Script
 Audit-only:

--- a/scripts/linux/bootstrap-camera-network.sh
+++ b/scripts/linux/bootstrap-camera-network.sh
@@ -304,6 +304,32 @@ detect_chrony_dropin() {
   CHRONY_DROPIN="/etc/chrony.d/constitute-nvr-camera.conf"
 }
 
+ensure_chrony_dropin_loaded() {
+  local dropin_dir include_line
+  dropin_dir="$(dirname "$CHRONY_DROPIN")"
+  case "$dropin_dir" in
+    /etc/chrony/conf.d)
+      include_line="confdir /etc/chrony/conf.d"
+      ;;
+    /etc/chrony.d)
+      include_line="confdir /etc/chrony.d"
+      ;;
+    *)
+      return
+      ;;
+  esac
+
+  if [[ ! -f /etc/chrony.conf ]]; then
+    return
+  fi
+  if grep -Fxq "$include_line" /etc/chrony.conf; then
+    return
+  fi
+
+  log "ensuring chrony loads ${dropin_dir}"
+  printf '\n%s\n' "$include_line" | run_sudo tee -a /etc/chrony.conf >/dev/null
+}
+
 restart_chrony() {
   local unit=""
   if systemctl list-unit-files chronyd.service --no-legend >/dev/null 2>&1; then
@@ -368,6 +394,7 @@ EOF
 
 write_chrony_config() {
   detect_chrony_dropin
+  ensure_chrony_dropin_loaded
   run_sudo mkdir -p "$(dirname "$CHRONY_DROPIN")"
   cat <<EOF | run_sudo tee "$CHRONY_DROPIN" >/dev/null
 # Managed by constitute-nvr camera bootstrap.

--- a/src/api.rs
+++ b/src/api.rs
@@ -68,6 +68,7 @@ struct HealthCameraNetworkView {
     dhcp_range_end: String,
     ntp_enabled: bool,
     ntp_server: String,
+    timezone: String,
     dns_server: String,
 }
 
@@ -137,6 +138,7 @@ async fn health(State(state): State<Arc<ApiState>>) -> Json<Value> {
         dhcp_range_end: cfg.camera_network.dhcp_range_end.clone(),
         ntp_enabled: cfg.camera_network.ntp_enabled,
         ntp_server: cfg.camera_network.ntp_server.clone(),
+        timezone: cfg.camera_network.timezone.clone(),
         dns_server: cfg.camera_network.dns_server.clone(),
     };
     Json(json!({
@@ -897,7 +899,6 @@ async fn handle_command(
             } else {
                 model
             };
-            let ntp_server = { state.cfg.lock().await.camera_network.ntp_server.clone() };
             let camera_cfg = CameraConfig {
                 source_id: source_id.clone(),
                 name: source_name.clone(),
@@ -925,8 +926,6 @@ async fn handle_command(
                 segment_secs: 10,
                 desired: CameraDesiredConfig {
                     display_name: source_name.clone(),
-                    ntp_server,
-                    timezone: "UTC".to_string(),
                     overlay_text: source_name.clone(),
                     overlay_timestamp: true,
                     ..Default::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,19 +116,22 @@ pub enum CameraTimeMode {
     Manual,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CameraHardeningConfig {
-    #[serde(default = "default_camera_hardening_enable_onvif")]
+    #[serde(default = "default_camera_hardening_enable_onvif", alias = "enableOnvif")]
     pub enable_onvif: bool,
-    #[serde(default = "default_camera_hardening_enable_rtsp")]
+    #[serde(default = "default_camera_hardening_enable_rtsp", alias = "enableRtsp")]
     pub enable_rtsp: bool,
-    #[serde(default = "default_camera_hardening_disable_p2p")]
+    #[serde(default = "default_camera_hardening_disable_p2p", alias = "disableP2p")]
     pub disable_p2p: bool,
-    #[serde(default = "default_camera_hardening_disable_http")]
+    #[serde(default = "default_camera_hardening_disable_http", alias = "disableHttp")]
     pub disable_http: bool,
-    #[serde(default = "default_camera_hardening_disable_https")]
+    #[serde(default = "default_camera_hardening_disable_https", alias = "disableHttps")]
     pub disable_https: bool,
-    #[serde(default = "default_camera_hardening_preserve_proprietary_9000")]
+    #[serde(
+        default = "default_camera_hardening_preserve_proprietary_9000",
+        alias = "preserveProprietary9000"
+    )]
     pub preserve_proprietary_9000: bool,
 }
 
@@ -147,23 +150,23 @@ impl Default for CameraHardeningConfig {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct CameraDesiredConfig {
-    #[serde(default)]
+    #[serde(default, alias = "displayName")]
     pub display_name: String,
-    #[serde(default)]
+    #[serde(default, alias = "timeMode")]
     pub time_mode: CameraTimeMode,
-    #[serde(default)]
+    #[serde(default, alias = "ntpServer")]
     pub ntp_server: String,
-    #[serde(default)]
+    #[serde(default, alias = "manualTime")]
     pub manual_time: String,
     #[serde(default)]
     pub timezone: String,
-    #[serde(default)]
+    #[serde(default, alias = "overlayText")]
     pub overlay_text: String,
-    #[serde(default = "default_camera_overlay_timestamp")]
+    #[serde(default = "default_camera_overlay_timestamp", alias = "overlayTimestamp")]
     pub overlay_timestamp: bool,
-    #[serde(default)]
+    #[serde(default, alias = "desiredPassword")]
     pub desired_password: String,
-    #[serde(default)]
+    #[serde(default, alias = "generatePassword")]
     pub generate_password: bool,
     #[serde(default)]
     pub hardening: CameraHardeningConfig,
@@ -251,6 +254,8 @@ pub struct CameraNetworkConfig {
     pub ntp_enabled: bool,
     #[serde(default)]
     pub ntp_server: String,
+    #[serde(default = "default_camera_network_timezone", alias = "timeZone")]
+    pub timezone: String,
     #[serde(default)]
     pub dns_server: String,
     #[serde(default = "default_camera_network_lease_file")]
@@ -643,6 +648,18 @@ fn apply_camera_network_defaults(cfg: &mut CameraNetworkConfig) -> bool {
         cfg.lease_file = default_camera_network_lease_file();
         changed = true;
     }
+    match normalize_site_timezone_candidate(&cfg.timezone) {
+        Some(normalized) if normalized != cfg.timezone => {
+            cfg.timezone = normalized;
+            changed = true;
+        }
+        None if cfg.timezone.trim().is_empty() => {
+            cfg.timezone = default_camera_network_timezone();
+            changed = true;
+        }
+        None => {}
+        _ => {}
+    }
     if cfg.subnet_cidr.trim().is_empty() {
         return changed;
     }
@@ -687,6 +704,10 @@ fn default_camera_network_ntp_enabled() -> bool {
     true
 }
 
+fn default_camera_network_timezone() -> String {
+    detect_system_timezone().unwrap_or_else(|| "UTC".to_string())
+}
+
 fn default_camera_network_lease_file() -> String {
     "/var/lib/misc/dnsmasq.leases".to_string()
 }
@@ -708,7 +729,7 @@ fn apply_live_preview_defaults(cfg: &mut LivePreviewConfig) -> bool {
     changed
 }
 
-fn apply_camera_defaults(camera: &mut CameraConfig, network: &CameraNetworkConfig) -> bool {
+fn apply_camera_defaults(camera: &mut CameraConfig, _network: &CameraNetworkConfig) -> bool {
     let mut changed = false;
     if camera.driver_id.trim().is_empty() {
         camera.driver_id = if camera.source_id.trim().starts_with("reolink-") {
@@ -745,14 +766,6 @@ fn apply_camera_defaults(camera: &mut CameraConfig, network: &CameraNetworkConfi
         camera.desired.display_name = camera.name.trim().to_string();
         changed = true;
     }
-    if camera.desired.ntp_server.trim().is_empty() && !network.ntp_server.trim().is_empty() {
-        camera.desired.ntp_server = network.ntp_server.trim().to_string();
-        changed = true;
-    }
-    if camera.desired.timezone.trim().is_empty() {
-        camera.desired.timezone = "UTC".to_string();
-        changed = true;
-    }
     if camera.desired.overlay_text.trim().is_empty() && !camera.name.trim().is_empty() {
         camera.desired.overlay_text = camera.name.trim().to_string();
         changed = true;
@@ -766,6 +779,55 @@ fn apply_camera_defaults(camera: &mut CameraConfig, network: &CameraNetworkConfi
     }
     changed |= sync_camera_credential_state(camera);
     changed
+}
+
+fn detect_system_timezone() -> Option<String> {
+    detect_system_timezone_from_sources(
+        std::env::var("TZ").ok(),
+        fs::read_to_string("/etc/timezone").ok(),
+        fs::read_link("/etc/localtime")
+            .ok()
+            .map(|path| path.to_string_lossy().to_string()),
+    )
+}
+
+fn detect_system_timezone_from_sources(
+    env_tz: Option<String>,
+    etc_timezone: Option<String>,
+    localtime_link: Option<String>,
+) -> Option<String> {
+    for candidate in [env_tz, etc_timezone, localtime_link] {
+        if let Some(value) = candidate
+            && let Some(normalized) = normalize_site_timezone_candidate(&value)
+        {
+            return Some(normalized);
+        }
+    }
+    None
+}
+
+fn normalize_site_timezone_candidate(value: &str) -> Option<String> {
+    let trimmed = value
+        .trim()
+        .trim_matches(char::from(0))
+        .trim_start_matches(':')
+        .replace('\\', "/");
+    if trimmed.is_empty() {
+        return None;
+    }
+    if let Some(rest) = trimmed.split("zoneinfo/").nth(1) {
+        return normalize_site_timezone_candidate(rest);
+    }
+    if trimmed.eq_ignore_ascii_case("UTC") || trimmed.eq_ignore_ascii_case("Etc/UTC") {
+        return Some("UTC".to_string());
+    }
+    let valid = trimmed
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '_' | '-' | '+'));
+    if valid && trimmed.contains('/') {
+        return Some(trimmed);
+    }
+    None
 }
 
 fn infer_camera_model(camera: &CameraConfig) -> String {
@@ -1154,6 +1216,39 @@ mod tests {
     }
 
     #[test]
+    fn camera_desired_config_accepts_camel_case_api_fields() {
+        let desired: CameraDesiredConfig = serde_json::from_value(serde_json::json!({
+            "displayName": "Carport",
+            "timeMode": "ntp",
+            "ntpServer": "192.168.250.1",
+            "manualTime": "",
+            "timezone": "UTC",
+            "overlayText": "Carport",
+            "overlayTimestamp": true,
+            "desiredPassword": "secret",
+            "generatePassword": false,
+            "hardening": {
+                "enableOnvif": true,
+                "enableRtsp": true,
+                "disableP2p": true,
+                "disableHttp": false,
+                "disableHttps": false,
+                "preserveProprietary9000": true
+            }
+        }))
+        .expect("camera desired config");
+
+        assert_eq!(desired.display_name, "Carport");
+        assert_eq!(desired.ntp_server, "192.168.250.1");
+        assert_eq!(desired.overlay_text, "Carport");
+        assert!(desired.overlay_timestamp);
+        assert_eq!(desired.desired_password, "secret");
+        assert!(desired.hardening.enable_onvif);
+        assert!(desired.hardening.disable_p2p);
+        assert!(desired.hardening.preserve_proprietary_9000);
+    }
+
+    #[test]
     fn apply_defaults_derives_camera_network_ranges() {
         let mut cfg = Config::default_generated();
         cfg.camera_network.subnet_cidr = "192.168.250.0/24".to_string();
@@ -1164,6 +1259,42 @@ mod tests {
         assert_eq!(cfg.camera_network.host_ip, "192.168.250.1");
         assert_eq!(cfg.camera_network.dhcp_range_start, "192.168.250.50");
         assert_eq!(cfg.camera_network.dhcp_range_end, "192.168.250.199");
+    }
+
+    #[test]
+    fn apply_defaults_derives_camera_network_timezone_from_host_sources() {
+        assert_eq!(
+            detect_system_timezone_from_sources(
+                Some("America/Phoenix".to_string()),
+                None,
+                None,
+            ),
+            Some("America/Phoenix".to_string())
+        );
+        assert_eq!(
+            detect_system_timezone_from_sources(
+                None,
+                Some("America/Phoenix\n".to_string()),
+                None,
+            ),
+            Some("America/Phoenix".to_string())
+        );
+        assert_eq!(
+            detect_system_timezone_from_sources(
+                None,
+                None,
+                Some("/usr/share/zoneinfo/America/Phoenix".to_string()),
+            ),
+            Some("America/Phoenix".to_string())
+        );
+    }
+
+    #[test]
+    fn apply_defaults_falls_back_to_utc_when_timezone_cannot_be_detected() {
+        assert_eq!(
+            detect_system_timezone_from_sources(None, None, None),
+            None
+        );
     }
 
     #[test]
@@ -1367,7 +1498,6 @@ mod tests {
         assert_eq!(camera.vendor, "Reolink");
         assert_eq!(camera.model, "E1 Outdoor SE");
         assert!(camera.ptz_capable);
-        assert_eq!(camera.desired.ntp_server, "192.168.250.1");
         assert_eq!(camera.desired.overlay_text, "Reolink E1 Outdoor SE");
         assert_eq!(camera.desired.display_name, "Reolink E1 Outdoor SE");
     }

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -1,6 +1,6 @@
 use crate::camera;
 use crate::config::{
-    CameraConfig, CameraDesiredConfig, CameraTimeMode, Config, adopt_camera_active_password,
+    CameraConfig, CameraDesiredConfig, Config, adopt_camera_active_password,
     camera_credential_candidates, finalize_camera_password_rotation, mark_camera_rotation_failed,
     mark_camera_rotation_pending,
 };
@@ -8,6 +8,8 @@ use crate::onvif;
 use crate::reolink;
 use crate::reolink_cgi;
 use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
+use chrono_tz::Tz;
 use regex::Regex;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
@@ -25,6 +27,7 @@ const REOLINK_CGI_FALLBACK_MIN_PULSE_MS: u64 = 180;
 const REOLINK_CGI_FALLBACK_MAX_PULSE_MS: u64 = 1_200;
 const REOLINK_CGI_FALLBACK_SPEED: i32 = 32;
 const REOLINK_OBSERVED_STEP_MAX_ATTEMPTS: usize = 8;
+const CAMERA_TIME_MAX_DRIFT_SECS: i64 = 90;
 
 pub trait CameraDriver {
     fn match_candidate(&self, candidate: &DiscoveredCameraCandidate) -> Option<DriverMatch>;
@@ -58,8 +61,16 @@ pub struct CameraNetworkSummary {
     pub dhcp_range_end: String,
     pub ntp_enabled: bool,
     pub ntp_server: String,
+    pub timezone: String,
     pub dns_server: String,
     pub lease_file: String,
+}
+
+#[derive(Clone, Debug, Default)]
+struct SiteTimePolicy {
+    ntp_enabled: bool,
+    ntp_server: String,
+    timezone: String,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -292,7 +303,7 @@ impl CameraDriver for ReolinkDriver {
             live_view: true,
             ptz: camera.ptz_capable,
             time_sync: true,
-            manual_time: true,
+            manual_time: false,
             timezone: true,
             overlay_text: true,
             overlay_timestamp: true,
@@ -349,15 +360,104 @@ pub fn camera_network_summary(cfg: &Config) -> CameraNetworkSummary {
         dhcp_range_end: cfg.camera_network.dhcp_range_end.clone(),
         ntp_enabled: cfg.camera_network.ntp_enabled,
         ntp_server: cfg.camera_network.ntp_server.clone(),
+        timezone: cfg.camera_network.timezone.clone(),
         dns_server: cfg.camera_network.dns_server.clone(),
         lease_file: cfg.camera_network.lease_file.clone(),
     }
 }
 
+fn site_time_policy(cfg: &Config) -> SiteTimePolicy {
+    SiteTimePolicy {
+        ntp_enabled: cfg.camera_network.ntp_enabled,
+        ntp_server: cfg.camera_network.ntp_server.trim().to_string(),
+        timezone: first_nonempty(&cfg.camera_network.timezone, "UTC"),
+    }
+}
+
+fn observed_site_time_offset_secs(
+    site_timezone: &str,
+    observed_manual_time: &str,
+    now_utc: DateTime<Utc>,
+) -> Option<i64> {
+    let tz: Tz = site_timezone.trim().parse().ok()?;
+    let naive = NaiveDateTime::parse_from_str(observed_manual_time.trim(), "%Y-%m-%dT%H:%M:%S")
+        .ok()?;
+    let local = match tz.from_local_datetime(&naive) {
+        LocalResult::Single(value) => value,
+        LocalResult::Ambiguous(first, _) => first,
+        LocalResult::None => return None,
+    };
+    Some((local.with_timezone(&Utc) - now_utc).num_seconds().abs())
+}
+
+fn site_local_time_string(site_timezone: &str, now_utc: DateTime<Utc>) -> Option<String> {
+    let tz: Tz = site_timezone.trim().parse().ok()?;
+    Some(
+        now_utc
+            .with_timezone(&tz)
+            .format("%Y-%m-%dT%H:%M:%S")
+            .to_string(),
+    )
+}
+
+fn to_onvif_site_time_policy(policy: &SiteTimePolicy) -> onvif::OnvifSiteTimePolicy {
+    onvif::OnvifSiteTimePolicy {
+        ntp_enabled: policy.ntp_enabled,
+        ntp_server: policy.ntp_server.clone(),
+        timezone: policy.timezone.clone(),
+    }
+}
+
+fn reolink_observed_time_mode(
+    onvif_state: Option<&onvif::OnvifState>,
+    presentation: &reolink_cgi::ReolinkPresentationState,
+) -> String {
+    onvif_state
+        .map(|state| state.time_mode.clone())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| presentation.time_mode.clone())
+}
+
+fn reolink_observed_ntp_server(
+    onvif_state: Option<&onvif::OnvifState>,
+    presentation: &reolink_cgi::ReolinkPresentationState,
+) -> String {
+    onvif_state
+        .map(|state| state.ntp_server.clone())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| presentation.ntp_server.clone())
+}
+
+fn reolink_observed_manual_time(
+    onvif_state: Option<&onvif::OnvifState>,
+    presentation: &reolink_cgi::ReolinkPresentationState,
+) -> String {
+    if !presentation.manual_time.trim().is_empty() {
+        return presentation.manual_time.clone();
+    }
+    onvif_state
+        .map(|state| state.manual_time.clone())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
+fn reolink_observed_timezone(
+    onvif_state: Option<&onvif::OnvifState>,
+    presentation: &reolink_cgi::ReolinkPresentationState,
+) -> String {
+    if !presentation.timezone.trim().is_empty() {
+        return presentation.timezone.clone();
+    }
+    onvif_state
+        .map(|state| state.timezone.clone())
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_default()
+}
+
 pub async fn list_inventory(cfg: &Config) -> Result<CameraInventory> {
     let mut mounted = Vec::with_capacity(cfg.cameras.len());
     for camera in &cfg.cameras {
-        mounted.push(read_mounted_camera(camera).await);
+        mounted.push(read_mounted_camera(cfg, camera).await);
     }
     Ok(CameraInventory {
         mounted,
@@ -471,8 +571,6 @@ pub async fn mount_candidate(
         segment_secs: 10,
         desired: CameraDesiredConfig {
             display_name: display_name.clone(),
-            ntp_server: cfg.camera_network.ntp_server.clone(),
-            timezone: "UTC".to_string(),
             overlay_text: display_name.clone(),
             overlay_timestamp: true,
             desired_password: request.desired_password.trim().to_string(),
@@ -485,7 +583,7 @@ pub async fn mount_candidate(
     camera = apply_driver_mount(cfg, &camera).await?;
     Ok(CameraMountResult {
         configured: camera.clone(),
-        mounted: read_mounted_camera(&camera).await,
+        mounted: read_mounted_camera(cfg, &camera).await,
     })
 }
 
@@ -501,15 +599,59 @@ pub async fn apply_mounted_camera(
         .ok_or_else(|| anyhow!("camera source is not configured"))?;
     let mut next = existing.clone();
     next.desired = request.desired.clone();
-    if !request.desired.display_name.trim().is_empty() {
-        next.name = request.desired.display_name.trim().to_string();
-    }
+    sync_display_name_and_linked_overlay(&existing, &mut next);
     normalize_camera_defaults(cfg, &mut next);
+    let requested_fields = requested_apply_fields(&existing, &next);
     next = apply_driver_desired(cfg, &existing, &next).await?;
+    let mounted = read_mounted_camera(cfg, &next).await;
+    let verification_failures =
+        requested_verification_failures(&mounted.verification, &requested_fields);
+    if !verification_failures.is_empty() {
+        let requested_name = next.desired.display_name.trim();
+        let observed_name = mounted.observed.display_name.trim();
+        let detail = if verification_failures.iter().any(|field| field == "display_name")
+            && !requested_name.is_empty()
+        {
+            format!(
+                "requested camera name {:?}, observed {:?}",
+                requested_name,
+                if observed_name.is_empty() {
+                    "<empty>"
+                } else {
+                    observed_name
+                }
+            )
+        } else {
+            mounted.verification.message.clone()
+        };
+        return Err(anyhow!(
+            "camera apply did not verify requested field(s): {} ({})",
+            verification_failures.join(", "),
+            detail
+        ));
+    }
     Ok(CameraApplyResult {
         configured: next.clone(),
-        mounted: read_mounted_camera(&next).await,
+        mounted,
     })
+}
+
+fn sync_display_name_and_linked_overlay(existing: &CameraConfig, next: &mut CameraConfig) {
+    let requested_display_name = next.desired.display_name.trim();
+    if requested_display_name.is_empty() {
+        return;
+    }
+    let previous_display_name = camera_display_name(existing);
+    let requested_overlay_text = next.desired.overlay_text.trim();
+    next.name = requested_display_name.to_string();
+    // Treat overlay text as linked to the display name unless the operator
+    // has explicitly diverged it to a different value.
+    if requested_overlay_text.is_empty()
+        || (!previous_display_name.trim().is_empty()
+            && requested_overlay_text == previous_display_name.trim())
+    {
+        next.desired.overlay_text = requested_display_name.to_string();
+    }
 }
 
 pub async fn read_camera(cfg: &Config, source_id: &str) -> Result<MountedCamera> {
@@ -519,7 +661,7 @@ pub async fn read_camera(cfg: &Config, source_id: &str) -> Result<MountedCamera>
         .find(|camera| camera.source_id.trim() == source_id.trim())
         .cloned()
         .ok_or_else(|| anyhow!("camera source is not configured"))?;
-    Ok(read_mounted_camera(&camera).await)
+    Ok(read_mounted_camera(cfg, &camera).await)
 }
 
 pub async fn control_mounted_camera(
@@ -1383,13 +1525,13 @@ async fn control_reolink_cgi_fallback(
     })
 }
 
-pub async fn read_mounted_camera(camera: &CameraConfig) -> MountedCamera {
+pub async fn read_mounted_camera(cfg: &Config, camera: &CameraConfig) -> MountedCamera {
     let base_capabilities = driver_capabilities(camera);
     match read_observed_state(camera).await {
         Ok(observed) => {
             let capabilities =
                 capabilities_for_observed(camera, base_capabilities.clone(), &observed);
-            let display_name = first_nonempty(&camera_display_name(camera), &observed.display_name);
+            let display_name = first_nonempty(&observed.display_name, &camera_display_name(camera));
             let vendor = first_nonempty(&camera.vendor, &observed.vendor);
             let model = first_nonempty(&camera.model, &observed.model);
             MountedCamera {
@@ -1409,6 +1551,7 @@ pub async fn read_mounted_camera(camera: &CameraConfig) -> MountedCamera {
                 desired_pose: observed.current_pose.clone(),
                 pose_status: observed.pose_status.clone(),
                 verification: verification_for_observed(
+                    cfg,
                     camera,
                     &observed,
                     &capabilities,
@@ -1421,7 +1564,7 @@ pub async fn read_mounted_camera(camera: &CameraConfig) -> MountedCamera {
             let observed = fallback_observed_state(camera).await;
             let capabilities =
                 capabilities_for_observed(camera, base_capabilities.clone(), &observed);
-            let display_name = first_nonempty(&camera_display_name(camera), &observed.display_name);
+            let display_name = first_nonempty(&observed.display_name, &camera_display_name(camera));
             let vendor = first_nonempty(&camera.vendor, &observed.vendor);
             let model = first_nonempty(&camera.model, &observed.model);
             MountedCamera {
@@ -1445,7 +1588,7 @@ pub async fn read_mounted_camera(camera: &CameraConfig) -> MountedCamera {
                     status: "failed".to_string(),
                     message: error.to_string(),
                     failed_fields: vec!["read_state".to_string()],
-                    unsupported_fields: unsupported_fields(camera, &capabilities),
+                    unsupported_fields: unsupported_fields(cfg, camera, &capabilities),
                     ..Default::default()
                 },
             }
@@ -1489,6 +1632,8 @@ fn capabilities_for_observed(
 ) -> CameraCapabilitySet {
     if camera.driver_id.trim() == DRIVER_ID_REOLINK {
         capabilities = reolink_runtime_capabilities(capabilities, observed);
+    } else if camera.driver_id.trim() == DRIVER_ID_GENERIC_ONVIF_RTSP {
+        capabilities = generic_onvif_runtime_capabilities(capabilities, observed);
     }
     if observed.ptz_capable {
         capabilities.ptz = true;
@@ -1501,15 +1646,25 @@ fn reolink_runtime_capabilities(
     observed: &ObservedCameraState,
 ) -> CameraCapabilitySet {
     match observed_management_plane(observed).as_deref() {
-        Some("onvif") => {
+        Some("hybrid") | Some("onvif") => {
             capabilities.time_sync = true;
-            let bridge_capable = reolink_onvif_bridge_capable(observed);
-            capabilities.manual_time = bridge_capable;
-            capabilities.timezone = bridge_capable;
-            capabilities.overlay_text = bridge_capable;
-            capabilities.overlay_timestamp = bridge_capable;
-            capabilities.password_rotate = bridge_capable;
-            capabilities.hardening_profile = bridge_capable;
+            capabilities.manual_time = false;
+            capabilities.timezone = true;
+            capabilities.overlay_text = true;
+            capabilities.overlay_timestamp = true;
+            capabilities.password_rotate = true;
+            capabilities.hardening_profile = true;
+            capabilities.raw_probe = true;
+            capabilities.ptz = observed.ptz_capable;
+        }
+        Some("cgi") => {
+            capabilities.time_sync = false;
+            capabilities.manual_time = false;
+            capabilities.timezone = false;
+            capabilities.overlay_text = true;
+            capabilities.overlay_timestamp = true;
+            capabilities.password_rotate = true;
+            capabilities.hardening_profile = true;
             capabilities.raw_probe = true;
             capabilities.ptz = observed.ptz_capable;
         }
@@ -1529,6 +1684,29 @@ fn reolink_runtime_capabilities(
     capabilities
 }
 
+fn generic_onvif_runtime_capabilities(
+    mut capabilities: CameraCapabilitySet,
+    observed: &ObservedCameraState,
+) -> CameraCapabilitySet {
+    match observed_management_plane(observed).as_deref() {
+        Some("onvif") => {
+            capabilities.time_sync = true;
+            capabilities.manual_time = false;
+            capabilities.timezone = true;
+            capabilities.raw_probe = true;
+        }
+        Some("transport_only") | Some("unreachable") => {
+            capabilities.time_sync = false;
+            capabilities.manual_time = false;
+            capabilities.timezone = false;
+            capabilities.ptz = false;
+            capabilities.raw_probe = true;
+        }
+        _ => {}
+    }
+    capabilities
+}
+
 fn observed_management_plane(observed: &ObservedCameraState) -> Option<String> {
     observed
         .raw
@@ -1536,15 +1714,6 @@ fn observed_management_plane(observed: &ObservedCameraState) -> Option<String> {
         .and_then(Value::as_str)
         .map(|value| value.trim().to_ascii_lowercase())
         .filter(|value| !value.is_empty())
-}
-
-fn reolink_onvif_bridge_capable(observed: &ObservedCameraState) -> bool {
-    observed
-        .raw
-        .get("onvif")
-        .and_then(|value| value.get("networkProtocolsSupported"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
 }
 
 async fn apply_driver_mount(cfg: &Config, camera: &CameraConfig) -> Result<CameraConfig> {
@@ -1561,8 +1730,25 @@ async fn apply_driver_desired(
 ) -> Result<CameraConfig> {
     match next.driver_id.trim() {
         DRIVER_ID_REOLINK => apply_reolink_desired(cfg, existing, next).await,
+        DRIVER_ID_GENERIC_ONVIF_RTSP => apply_generic_onvif_desired(cfg, next).await,
         _ => Ok(next.clone()),
     }
+}
+
+async fn apply_generic_onvif_desired(cfg: &Config, next: &CameraConfig) -> Result<CameraConfig> {
+    let policy = site_time_policy(cfg);
+    if !policy.ntp_enabled {
+        return Ok(next.clone());
+    }
+    let _ = onvif::apply_site_time_settings(
+        &next.onvif_host,
+        next.onvif_port.max(1),
+        &next.username,
+        &next.password,
+        &to_onvif_site_time_policy(&policy),
+    )
+    .await;
+    Ok(next.clone())
 }
 
 async fn apply_reolink_desired(
@@ -1585,7 +1771,7 @@ async fn apply_reolink_desired(
             existing,
             next,
             ports.onvif && next.desired.hardening.enable_onvif,
-            !ports.onvif,
+            ports.onvif && next.desired.hardening.enable_onvif,
         )
         .await;
     }
@@ -1608,8 +1794,6 @@ fn reolink_desired_requires_cgi(existing: &CameraConfig, next: &CameraConfig) ->
         || !desired.desired_password.trim().is_empty()
         || desired.overlay_text != current.overlay_text
         || desired.overlay_timestamp != current.overlay_timestamp
-        || desired.timezone != current.timezone
-        || desired.manual_time != current.manual_time
         || desired.hardening.enable_onvif != current.hardening.enable_onvif
         || desired.hardening.enable_rtsp != current.hardening.enable_rtsp
         || desired.hardening.disable_p2p != current.hardening.disable_p2p
@@ -1626,7 +1810,7 @@ async fn apply_reolink_onvif_bridge_desired(
 ) -> Result<CameraConfig> {
     let _ = apply_reolink_onvif_desired(cfg, existing, next).await?;
     ensure_reolink_cgi_lane_via_onvif(existing).await?;
-    apply_reolink_cgi_desired(cfg, existing, next, true, false).await
+    apply_reolink_cgi_desired(cfg, existing, next, true, true).await
 }
 
 async fn apply_reolink_cgi_desired(
@@ -1634,7 +1818,7 @@ async fn apply_reolink_cgi_desired(
     existing: &CameraConfig,
     next: &CameraConfig,
     allow_onvif_only_final_state: bool,
-    apply_time_via_cgi: bool,
+    apply_site_time_via_onvif: bool,
 ) -> Result<CameraConfig> {
     let desired = &next.desired;
     let final_cgi_disabled = desired.hardening.disable_http && desired.hardening.disable_https;
@@ -1742,33 +1926,42 @@ async fn apply_reolink_cgi_desired(
         );
     }
 
-    if let Err(error) =
-        reolink_cgi::apply_presentation_state(&reolink_cgi::ReolinkPresentationApplyRequest {
-            connection: active_connection.clone(),
-            time_mode: apply_time_via_cgi.then(|| time_mode_label(&desired.time_mode).to_string()),
-            ntp_server: if apply_time_via_cgi {
-                nonempty_option(&first_nonempty(
-                    &desired.ntp_server,
-                    &cfg.camera_network.ntp_server,
-                ))
-            } else {
-                None
-            },
-            manual_time: if apply_time_via_cgi {
-                nonempty_option(&desired.manual_time)
-            } else {
-                None
-            },
-            timezone: if apply_time_via_cgi {
-                nonempty_option(&desired.timezone)
-            } else {
-                None
-            },
-            overlay_text: nonempty_option(&desired.overlay_text),
-            overlay_timestamp: Some(desired.overlay_timestamp),
-        })
+    let site_time = site_time_policy(cfg);
+    if apply_site_time_via_onvif && site_time.ntp_enabled {
+        if let Err(error) = onvif::apply_site_time_settings(
+            &next.onvif_host,
+            next.onvif_port.max(1),
+            &next.username,
+            &active_password,
+            &to_onvif_site_time_policy(&site_time),
+        )
         .await
-    {
+        {
+            let suffix = format!("failed applying site time policy through ONVIF: {error}");
+            updated.credentials.last_rotation_error =
+                if updated.credentials.last_rotation_error.trim().is_empty() {
+                    suffix
+                } else {
+                    format!("{}; {}", updated.credentials.last_rotation_error, suffix)
+                };
+        }
+    }
+
+    if let Err(error) = reolink_cgi::apply_presentation_state(&reolink_cgi::ReolinkPresentationApplyRequest {
+        connection: active_connection.clone(),
+        // Reolink keeps the feed-facing clock presentation in CGI. Apply the
+        // feed-facing fields on that lane and seed the current site-local wall
+        // clock so the baked timestamp converges immediately instead of waiting
+        // for the camera's next NTP poll. NTP mode/server remain ONVIF-owned.
+        time_mode: None,
+        ntp_server: None,
+        manual_time: site_local_time_string(&site_time.timezone, Utc::now()),
+        timezone: nonempty_option(&site_time.timezone),
+        enforce_clock_display: true,
+        overlay_text: nonempty_option(&desired.overlay_text),
+        overlay_timestamp: Some(desired.overlay_timestamp),
+    })
+    .await {
         let suffix = format!("failed applying presentation state: {error}");
         updated.credentials.last_rotation_error =
             if updated.credentials.last_rotation_error.trim().is_empty() {
@@ -1844,17 +2037,14 @@ async fn apply_reolink_onvif_desired(
     existing: &CameraConfig,
     next: &CameraConfig,
 ) -> Result<CameraConfig> {
-    let desired = &next.desired;
     let mut updated = next.clone();
-    let ntp_server = first_nonempty(&desired.ntp_server, &cfg.camera_network.ntp_server);
-    let mut normalized_desired = desired.clone();
-    normalized_desired.ntp_server = ntp_server;
-    onvif::apply_time_settings(
+    let site_time = site_time_policy(cfg);
+    onvif::apply_site_time_settings(
         &next.onvif_host,
         next.onvif_port.max(1),
         &next.username,
         &existing.password,
-        &normalized_desired,
+        &to_onvif_site_time_policy(&site_time),
     )
     .await?;
     adopt_camera_active_password(
@@ -2063,33 +2253,54 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
             let presentation = reolink_cgi::read_presentation_state(&connection)
                 .await
                 .unwrap_or_default();
+            let onvif_state = if ports.onvif {
+                onvif::read_state(
+                    &camera.onvif_host,
+                    camera.onvif_port.max(1),
+                    &camera.username,
+                    &connection.password,
+                )
+                .await
+                .ok()
+            } else {
+                None
+            };
             let ptz_capable = reolink_ptz_capable(camera, &probe, &presentation);
             let native_ptz = if probe.proprietary_port_open {
                 try_reolink_native_ptz_observation(camera, &[connection.password.clone()]).await
             } else {
                 None
             };
+            let management_plane = if onvif_state.is_some() {
+                "hybrid"
+            } else {
+                "cgi"
+            };
             return Ok(ObservedCameraState {
-                display_name: camera_display_name(camera),
+                display_name: presentation.overlay_text.trim().to_string(),
                 driver_id: camera.driver_id.clone(),
-                vendor: first_nonempty(&camera.vendor, "Reolink"),
-                model: first_nonempty(&camera.model, &presentation.model),
+                vendor: first_nonempty(
+                    &camera.vendor,
+                    &onvif_state
+                        .as_ref()
+                        .map(|state| first_nonempty(&state.manufacturer, "Reolink"))
+                        .unwrap_or_else(|| "Reolink".to_string()),
+                ),
+                model: first_nonempty(
+                    &camera.model,
+                    &onvif_state
+                        .as_ref()
+                        .map(|state| first_nonempty(&state.model, &presentation.model))
+                        .unwrap_or_else(|| presentation.model.clone()),
+                ),
                 ip: camera.onvif_host.clone(),
                 mac_address: camera.mac_address.clone(),
-                time_mode: first_nonempty(
-                    &presentation.time_mode,
-                    time_mode_label(&camera.desired.time_mode),
-                ),
-                ntp_server: first_nonempty(&presentation.ntp_server, &camera.desired.ntp_server),
-                manual_time: first_nonempty(&presentation.manual_time, &camera.desired.manual_time),
-                timezone: first_nonempty(&presentation.timezone, &camera.desired.timezone),
-                overlay_text: first_nonempty(
-                    &presentation.overlay_text,
-                    &camera.desired.overlay_text,
-                ),
-                overlay_timestamp: presentation
-                    .overlay_timestamp
-                    .or(Some(camera.desired.overlay_timestamp)),
+                time_mode: reolink_observed_time_mode(onvif_state.as_ref(), &presentation),
+                ntp_server: reolink_observed_ntp_server(onvif_state.as_ref(), &presentation),
+                manual_time: reolink_observed_manual_time(onvif_state.as_ref(), &presentation),
+                timezone: reolink_observed_timezone(onvif_state.as_ref(), &presentation),
+                overlay_text: presentation.overlay_text.clone(),
+                overlay_timestamp: presentation.overlay_timestamp,
                 ptz_capable,
                 current_pose: native_ptz
                     .as_ref()
@@ -2106,7 +2317,11 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
                     "cgi".to_string()
                 },
                 services: json!({
-                    "managementPlane": "cgi",
+                    "managementPlane": management_plane,
+                    "timeManagementPlane": if onvif_state.is_some() { "hybrid" } else { "cgi" },
+                    "normalizedTimeManagementPlane": if onvif_state.is_some() { "onvif" } else { "cgi" },
+                    "feedClockManagementPlane": "cgi",
+                    "presentationManagementPlane": "cgi",
                     "ptzManagementPlane": if native_ptz.is_some() { "reolink_native_absolute" } else { "cgi" },
                     "http": state.state.normal.get("iHttpPortEnable").cloned().unwrap_or(json!(0)),
                     "https": state.state.normal.get("iHttpsPortEnable").cloned().unwrap_or(json!(0)),
@@ -2115,12 +2330,15 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
                     "p2p": state.state.p2p.get("iEnable").cloned().unwrap_or(json!(0)),
                     "proprietary9000": probe.proprietary_port_open,
                     "onvifXAddr": probe.onvif_xaddr,
+                    "networkProtocols": onvif_state.as_ref().map(|state| state.network_protocols.clone()).unwrap_or_default(),
+                    "networkProtocolsSupported": onvif_state.as_ref().map(|state| state.network_protocols_writable).unwrap_or(false),
                 }),
                 raw: json!({
-                    "managementPlane": "cgi",
+                    "managementPlane": management_plane,
                     "probe": probe,
                     "state": state.state,
                     "presentation": presentation,
+                    "onvif": onvif_state.as_ref().map(|state| state.raw.clone()),
                     "nativePtz": native_ptz.as_ref().map(reolink_native_ptz_json),
                 }),
             });
@@ -2152,8 +2370,16 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
             } else {
                 None
             };
+            let management_plane = if !presentation.overlay_text.trim().is_empty()
+                || presentation.overlay_timestamp.is_some()
+                || !presentation.clock_date_format.trim().is_empty()
+            {
+                "hybrid"
+            } else {
+                "onvif"
+            };
             return Ok(ObservedCameraState {
-                display_name: camera_display_name(camera),
+                display_name: presentation.overlay_text.trim().to_string(),
                 driver_id: camera.driver_id.clone(),
                 vendor: first_nonempty(
                     &camera.vendor,
@@ -2162,26 +2388,11 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
                 model: first_nonempty(&camera.model, &onvif_state.model),
                 ip: camera.onvif_host.clone(),
                 mac_address: camera.mac_address.clone(),
-                time_mode: first_nonempty(
-                    &onvif_state.time_mode,
-                    &first_nonempty(
-                        &presentation.time_mode,
-                        time_mode_label(&camera.desired.time_mode),
-                    ),
-                ),
-                ntp_server: first_nonempty(&onvif_state.ntp_server, &camera.desired.ntp_server),
-                manual_time: first_nonempty(
-                    &onvif_state.manual_time,
-                    &first_nonempty(&presentation.manual_time, &camera.desired.manual_time),
-                ),
-                timezone: first_nonempty(
-                    &onvif_state.timezone,
-                    &first_nonempty(&presentation.timezone, &camera.desired.timezone),
-                ),
-                overlay_text: first_nonempty(
-                    &presentation.overlay_text,
-                    &camera.desired.overlay_text,
-                ),
+                time_mode: reolink_observed_time_mode(Some(&onvif_state), &presentation),
+                ntp_server: reolink_observed_ntp_server(Some(&onvif_state), &presentation),
+                manual_time: reolink_observed_manual_time(Some(&onvif_state), &presentation),
+                timezone: reolink_observed_timezone(Some(&onvif_state), &presentation),
+                overlay_text: presentation.overlay_text.clone(),
                 overlay_timestamp: presentation.overlay_timestamp,
                 ptz_capable,
                 current_pose: native_ptz
@@ -2203,7 +2414,11 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
                     "onvif".to_string()
                 },
                 services: json!({
-                    "managementPlane": "onvif",
+                    "managementPlane": management_plane,
+                    "timeManagementPlane": if management_plane == "hybrid" { "hybrid" } else { "onvif" },
+                    "normalizedTimeManagementPlane": "onvif",
+                    "feedClockManagementPlane": if management_plane == "hybrid" { "cgi" } else { "onvif" },
+                    "presentationManagementPlane": if management_plane == "hybrid" { "cgi" } else { "onvif" },
                     "ptzManagementPlane": if native_ptz.is_some() { "reolink_native_absolute" } else { "onvif" },
                     "http": ports.http,
                     "https": ports.https,
@@ -2218,7 +2433,7 @@ async fn read_reolink_observed_state(camera: &CameraConfig) -> Result<ObservedCa
                     "networkProtocolsSupported": onvif_state.network_protocols_writable,
                 }),
                 raw: json!({
-                    "managementPlane": "onvif",
+                    "managementPlane": management_plane,
                     "probe": probe,
                     "onvif": onvif_state.raw,
                     "presentation": presentation,
@@ -2347,16 +2562,19 @@ async fn probe_reolink_candidate(
                 "vendor": first_nonempty(&candidate.signatures.vendor, &first_nonempty(&onvif_state.manufacturer, "Reolink")),
                 "model": first_nonempty(&onvif_state.model, &candidate.signatures.model),
                 "ip": candidate.ip,
-                "timeMode": onvif_state.time_mode,
-                "ntpServer": onvif_state.ntp_server,
+                "timeMode": reolink_observed_time_mode(Some(&onvif_state), &presentation),
+                "ntpServer": reolink_observed_ntp_server(Some(&onvif_state), &presentation),
                 "manualTime": first_nonempty(&onvif_state.manual_time, &presentation.manual_time),
-                "timezone": first_nonempty(&onvif_state.timezone, &presentation.timezone),
+                "timezone": reolink_observed_timezone(Some(&onvif_state), &presentation),
                 "overlayText": presentation.overlay_text,
                 "overlayTimestamp": presentation.overlay_timestamp,
                 "ptzCapable": ptz_capable,
             },
             "services": {
                 "managementPlane": "onvif",
+                "timeManagementPlane": if presentation.timezone.trim().is_empty() { "onvif" } else { "hybrid" },
+                "normalizedTimeManagementPlane": "onvif",
+                "feedClockManagementPlane": if presentation.timezone.trim().is_empty() { "onvif" } else { "cgi" },
                 "http": ports.http,
                 "https": ports.https,
                 "onvif": ports.onvif,
@@ -2385,6 +2603,53 @@ async fn probe_reolink_candidate(
 
 async fn read_generic_observed_state(camera: &CameraConfig) -> Result<ObservedCameraState> {
     let ports = probe_common_ports(&camera.onvif_host).await;
+    if ports.onvif {
+        if let Ok(onvif_state) = onvif::read_state(
+            &camera.onvif_host,
+            camera.onvif_port.max(1),
+            &camera.username,
+            &camera.password,
+        )
+        .await
+        {
+            return Ok(ObservedCameraState {
+                display_name: camera_display_name(camera),
+                driver_id: camera.driver_id.clone(),
+                vendor: first_nonempty(&camera.vendor, &onvif_state.manufacturer),
+                model: first_nonempty(&camera.model, &onvif_state.model),
+                ip: camera.onvif_host.clone(),
+                mac_address: camera.mac_address.clone(),
+                time_mode: onvif_state.time_mode.clone(),
+                ntp_server: onvif_state.ntp_server.clone(),
+                manual_time: onvif_state.manual_time.clone(),
+                timezone: onvif_state.timezone.clone(),
+                overlay_text: camera.desired.overlay_text.clone(),
+                overlay_timestamp: Some(camera.desired.overlay_timestamp),
+                ptz_capable: camera.ptz_capable || onvif_state.ptz_capable,
+                current_pose: CameraPose {
+                    pan: onvif_state.current_pose.as_ref().and_then(|pose| pose.pan),
+                    tilt: onvif_state.current_pose.as_ref().and_then(|pose| pose.tilt),
+                    zoom: onvif_state.current_pose.as_ref().and_then(|pose| pose.zoom),
+                },
+                pose_status: onvif_state.pose_status.clone(),
+                pose_source: "onvif".to_string(),
+                services: json!({
+                    "managementPlane": "onvif",
+                    "http": ports.http,
+                    "https": ports.https,
+                    "rtsp": ports.rtsp,
+                    "onvif": ports.onvif,
+                    "proprietary9000": ports.proprietary_9000,
+                    "mediaService": onvif_state.media_service_url,
+                    "ptzService": onvif_state.ptz_service_url,
+                }),
+                raw: json!({
+                    "managementPlane": "onvif",
+                    "onvif": onvif_state.raw,
+                }),
+            });
+        }
+    }
     Ok(ObservedCameraState {
         display_name: camera_display_name(camera),
         driver_id: camera.driver_id.clone(),
@@ -2392,10 +2657,10 @@ async fn read_generic_observed_state(camera: &CameraConfig) -> Result<ObservedCa
         model: camera.model.clone(),
         ip: camera.onvif_host.clone(),
         mac_address: camera.mac_address.clone(),
-        time_mode: time_mode_label(&camera.desired.time_mode).to_string(),
-        ntp_server: camera.desired.ntp_server.clone(),
-        manual_time: camera.desired.manual_time.clone(),
-        timezone: camera.desired.timezone.clone(),
+        time_mode: String::new(),
+        ntp_server: String::new(),
+        manual_time: String::new(),
+        timezone: String::new(),
         overlay_text: camera.desired.overlay_text.clone(),
         overlay_timestamp: Some(camera.desired.overlay_timestamp),
         ptz_capable: camera.ptz_capable,
@@ -2403,13 +2668,16 @@ async fn read_generic_observed_state(camera: &CameraConfig) -> Result<ObservedCa
         pose_status: String::new(),
         pose_source: String::new(),
         services: json!({
+            "managementPlane": if ports.onvif { "transport_only" } else { "unreachable" },
             "http": ports.http,
             "https": ports.https,
             "rtsp": ports.rtsp,
             "onvif": ports.onvif,
             "proprietary9000": ports.proprietary_9000,
         }),
-        raw: json!({}),
+        raw: json!({
+            "managementPlane": if ports.onvif { "transport_only" } else { "unreachable" },
+        }),
     })
 }
 
@@ -2447,21 +2715,29 @@ async fn fallback_observed_state(camera: &CameraConfig) -> ObservedCameraState {
 }
 
 fn verification_for_observed(
+    cfg: &Config,
     camera: &CameraConfig,
     observed: &ObservedCameraState,
     capabilities: &CameraCapabilitySet,
     failed_fields: Vec<String>,
 ) -> CameraReconcileResult {
+    let site_time = site_time_policy(cfg);
     let mut drift_fields = Vec::new();
+    if !camera.desired.display_name.trim().is_empty()
+        && camera.desired.display_name.trim() != observed.display_name.trim()
+    {
+        drift_fields.push("display_name".to_string());
+    }
     if capabilities.time_sync
-        && observed.time_mode.trim() != time_mode_label(&camera.desired.time_mode)
+        && site_time.ntp_enabled
+        && observed.time_mode.trim() != "ntp"
     {
         drift_fields.push("time_mode".to_string());
     }
     if capabilities.time_sync
-        && !camera.desired.ntp_server.trim().is_empty()
-        && !camera
-            .desired
+        && site_time.ntp_enabled
+        && !site_time.ntp_server.trim().is_empty()
+        && !site_time
             .ntp_server
             .trim()
             .eq_ignore_ascii_case(observed.ntp_server.trim())
@@ -2469,10 +2745,24 @@ fn verification_for_observed(
         drift_fields.push("ntp_server".to_string());
     }
     if capabilities.timezone
-        && !camera.desired.timezone.trim().is_empty()
-        && camera.desired.timezone.trim() != observed.timezone.trim()
+        && site_time.ntp_enabled
+        && !site_time.timezone.trim().is_empty()
+        && site_time.timezone.trim() != observed.timezone.trim()
     {
         drift_fields.push("timezone".to_string());
+    }
+    if capabilities.time_sync
+        && site_time.ntp_enabled
+        && !site_time.timezone.trim().is_empty()
+        && !observed.manual_time.trim().is_empty()
+        && observed_site_time_offset_secs(
+            &site_time.timezone,
+            &observed.manual_time,
+            Utc::now(),
+        )
+        .is_some_and(|offset| offset > CAMERA_TIME_MAX_DRIFT_SECS)
+    {
+        drift_fields.push("time_clock".to_string());
     }
     if capabilities.overlay_text
         && !camera.desired.overlay_text.trim().is_empty()
@@ -2500,25 +2790,27 @@ fn verification_for_observed(
             "drift" => "camera configuration drift detected".to_string(),
             _ => "camera configuration verified".to_string(),
         },
-        applied_fields: applied_fields(camera, capabilities),
+        applied_fields: applied_fields(cfg, camera, capabilities),
         failed_fields,
-        unsupported_fields: unsupported_fields(camera, capabilities),
+        unsupported_fields: unsupported_fields(cfg, camera, capabilities),
         drift_fields,
         verified: status == "verified",
     }
 }
 
-fn applied_fields(camera: &CameraConfig, capabilities: &CameraCapabilitySet) -> Vec<String> {
+fn applied_fields(
+    cfg: &Config,
+    camera: &CameraConfig,
+    capabilities: &CameraCapabilitySet,
+) -> Vec<String> {
+    let site_time = site_time_policy(cfg);
     let mut fields = vec!["display_name".to_string()];
-    if capabilities.time_sync {
+    if capabilities.time_sync && site_time.ntp_enabled {
         fields.extend(
             ["time_mode", "ntp_server", "timezone"]
                 .into_iter()
                 .map(String::from),
         );
-    }
-    if capabilities.manual_time {
-        fields.push("manual_time".to_string());
     }
     if capabilities.overlay_text {
         fields.push("overlay_text".to_string());
@@ -2537,15 +2829,17 @@ fn applied_fields(camera: &CameraConfig, capabilities: &CameraCapabilitySet) -> 
     fields
 }
 
-fn unsupported_fields(camera: &CameraConfig, capabilities: &CameraCapabilitySet) -> Vec<String> {
+fn unsupported_fields(
+    cfg: &Config,
+    camera: &CameraConfig,
+    capabilities: &CameraCapabilitySet,
+) -> Vec<String> {
+    let site_time = site_time_policy(cfg);
     let mut fields = Vec::new();
-    if !capabilities.time_sync && !camera.desired.ntp_server.trim().is_empty() {
+    if !capabilities.time_sync && site_time.ntp_enabled {
         fields.push("ntp_server".to_string());
     }
-    if !capabilities.manual_time && !camera.desired.manual_time.trim().is_empty() {
-        fields.push("manual_time".to_string());
-    }
-    if !capabilities.timezone && !camera.desired.timezone.trim().is_empty() {
+    if !capabilities.timezone && site_time.ntp_enabled {
         fields.push("timezone".to_string());
     }
     if !capabilities.overlay_text && !camera.desired.overlay_text.trim().is_empty() {
@@ -2988,13 +3282,6 @@ fn push_unique_string(items: &mut Vec<String>, value: &str) {
     }
 }
 
-fn time_mode_label(mode: &CameraTimeMode) -> &'static str {
-    match mode {
-        CameraTimeMode::Ntp => "ntp",
-        CameraTimeMode::Manual => "manual",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3138,12 +3425,12 @@ mod tests {
         let caps = capabilities_for_observed(&camera, driver_capabilities(&camera), &observed);
         assert!(caps.time_sync);
         assert!(!caps.manual_time);
-        assert!(!caps.timezone);
+        assert!(caps.timezone);
         assert!(caps.ptz);
-        assert!(!caps.overlay_text);
-        assert!(!caps.overlay_timestamp);
-        assert!(!caps.password_rotate);
-        assert!(!caps.hardening_profile);
+        assert!(caps.overlay_text);
+        assert!(caps.overlay_timestamp);
+        assert!(caps.password_rotate);
+        assert!(caps.hardening_profile);
     }
 
     #[test]
@@ -3356,4 +3643,317 @@ mod tests {
 
         assert!(reolink_observed_step_plan(profile, requested, target, observed).is_none());
     }
+
+    #[test]
+    fn display_name_change_keeps_overlay_text_linked_by_default() {
+        let existing = CameraConfig {
+            source_id: "cam".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "10.0.0.1".to_string(),
+            onvif_port: 8000,
+            rtsp_url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            vendor: String::new(),
+            model: String::new(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Front Door".to_string(),
+                overlay_text: "Front Door".to_string(),
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        };
+        let mut next = existing.clone();
+        next.desired.display_name = "Driveway".to_string();
+        next.desired.overlay_text = "Front Door".to_string();
+
+        sync_display_name_and_linked_overlay(&existing, &mut next);
+
+        assert_eq!(next.name, "Driveway");
+        assert_eq!(next.desired.overlay_text, "Driveway");
+    }
+
+    #[test]
+    fn display_name_change_preserves_custom_overlay_text() {
+        let existing = CameraConfig {
+            source_id: "cam".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "10.0.0.1".to_string(),
+            onvif_port: 8000,
+            rtsp_url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            vendor: String::new(),
+            model: String::new(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Front Door".to_string(),
+                overlay_text: "Package Zone".to_string(),
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        };
+        let mut next = existing.clone();
+        next.desired.display_name = "Driveway".to_string();
+        next.desired.overlay_text = "Package Zone".to_string();
+
+        sync_display_name_and_linked_overlay(&existing, &mut next);
+
+        assert_eq!(next.name, "Driveway");
+        assert_eq!(next.desired.overlay_text, "Package Zone");
+    }
+
+    #[test]
+    fn reolink_observed_timezone_prefers_feed_truth_from_presentation() {
+        let onvif_state = onvif::OnvifState {
+            timezone: "UTC+7:00:00DST+6:00:00,M3.2.0/02:00:00,M10.5.0/02:00:00".to_string(),
+            ..Default::default()
+        };
+        let presentation = reolink_cgi::ReolinkPresentationState {
+            timezone: "America/Phoenix".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            reolink_observed_timezone(Some(&onvif_state), &presentation),
+            "America/Phoenix"
+        );
+    }
+
+    #[test]
+    fn reolink_observed_manual_time_prefers_feed_truth_from_presentation() {
+        let onvif_state = onvif::OnvifState {
+            manual_time: "2026-04-17T18:04:28".to_string(),
+            ..Default::default()
+        };
+        let presentation = reolink_cgi::ReolinkPresentationState {
+            manual_time: "2026-04-17T17:59:13".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            reolink_observed_manual_time(Some(&onvif_state), &presentation),
+            "2026-04-17T17:59:13"
+        );
+    }
+
+    #[test]
+    fn reolink_verification_accepts_site_timezone_when_feed_truth_matches() {
+        let cfg: Config = serde_json::from_value(json!({
+            "node_id": "nvr-test",
+            "service_version": "0.1.0",
+            "nostr_pubkey": "pk",
+            "nostr_sk_hex": "sk",
+            "swarm": {
+                "bind": "0.0.0.0:4050",
+                "peers": [],
+                "zones": [],
+                "endpoint_hint": ""
+            },
+            "api": {
+                "bind": "127.0.0.1:8456",
+                "identity_id": "id-test",
+                "identity_secret_hex": "secret",
+                "server_secret_hex": "server"
+            },
+            "storage": {
+                "root": "/tmp/constitute-nvr",
+                "encryption_key_hex": "key"
+            },
+            "update": {},
+            "camera_network": {
+                "ntp_enabled": true,
+                "ntp_server": "192.168.250.1",
+                "timezone": "America/Phoenix"
+            }
+        }))
+        .expect("config");
+
+        let camera = CameraConfig {
+            source_id: "cam".to_string(),
+            name: "Carport".to_string(),
+            onvif_host: "10.0.0.1".to_string(),
+            onvif_port: 8000,
+            rtsp_url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            vendor: "Reolink".to_string(),
+            model: "E1 Outdoor SE".to_string(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: true,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Carport".to_string(),
+                overlay_text: "Carport".to_string(),
+                overlay_timestamp: true,
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        };
+        let observed = ObservedCameraState {
+            display_name: "Carport".to_string(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            time_mode: "ntp".to_string(),
+            ntp_server: "192.168.250.1".to_string(),
+            timezone: "America/Phoenix".to_string(),
+            overlay_text: "Carport".to_string(),
+            overlay_timestamp: Some(true),
+            raw: json!({
+                "managementPlane": "hybrid",
+                "presentation": { "timezone": "America/Phoenix" },
+                "onvif": { "time": { "timezone": "UTC+7:00:00DST+6:00:00,M3.2.0/02:00:00,M10.5.0/02:00:00" } }
+            }),
+            ..Default::default()
+        };
+        let verification = verification_for_observed(
+            &cfg,
+            &camera,
+            &observed,
+            &CameraCapabilitySet {
+                time_sync: true,
+                timezone: true,
+                overlay_text: true,
+                overlay_timestamp: true,
+                ..Default::default()
+            },
+            Vec::new(),
+        );
+        assert!(verification.verified);
+        assert!(verification.drift_fields.is_empty());
+    }
+
+    #[test]
+    fn observed_site_time_offset_secs_accepts_current_phoenix_time() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 0, 45, 0).single().unwrap();
+        assert_eq!(
+            observed_site_time_offset_secs("America/Phoenix", "2026-04-17T17:45:30", now),
+            Some(30)
+        );
+    }
+
+    #[test]
+    fn site_local_time_string_formats_current_phoenix_time() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 0, 45, 0).single().unwrap();
+        assert_eq!(
+            site_local_time_string("America/Phoenix", now).as_deref(),
+            Some("2026-04-17T17:45:00")
+        );
+    }
+
+    #[test]
+    fn observed_site_time_offset_secs_detects_large_clock_lead() {
+        let now = Utc.with_ymd_and_hms(2026, 4, 18, 0, 45, 0).single().unwrap();
+        assert_eq!(
+            observed_site_time_offset_secs("America/Phoenix", "2026-04-17T17:50:30", now),
+            Some(330)
+        );
+    }
+
+    #[test]
+    fn requested_apply_fields_include_display_and_overlay_changes() {
+        let existing = CameraConfig {
+            source_id: "cam".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "10.0.0.1".to_string(),
+            onvif_port: 8000,
+            rtsp_url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            vendor: String::new(),
+            model: String::new(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Front Door".to_string(),
+                overlay_text: "Front Door".to_string(),
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        };
+        let mut next = existing.clone();
+        next.desired.display_name = "Carport".to_string();
+        next.desired.overlay_text = "Carport".to_string();
+        next.name = "Carport".to_string();
+
+        let fields = requested_apply_fields(&existing, &next);
+        assert!(fields.iter().any(|field| field == "display_name"));
+        assert!(fields.iter().any(|field| field == "overlay_text"));
+    }
+
+    #[test]
+    fn requested_verification_failures_intersect_requested_fields_only() {
+        let verification = CameraReconcileResult {
+            status: "drift".to_string(),
+            message: "camera configuration drift detected".to_string(),
+            drift_fields: vec![
+                "display_name".to_string(),
+                "timezone".to_string(),
+                "overlay_text".to_string(),
+            ],
+            ..Default::default()
+        };
+
+        let failures = requested_verification_failures(
+            &verification,
+            &["display_name".to_string(), "overlay_text".to_string()],
+        );
+        assert_eq!(failures, vec!["display_name".to_string(), "overlay_text".to_string()]);
+    }
+}
+
+fn requested_apply_fields(existing: &CameraConfig, next: &CameraConfig) -> Vec<String> {
+    let mut fields = Vec::new();
+    if next.desired.display_name.trim() != existing.desired.display_name.trim()
+        || next.name.trim() != existing.name.trim()
+    {
+        fields.push("display_name".to_string());
+    }
+    if next.desired.overlay_text.trim() != existing.desired.overlay_text.trim() {
+        fields.push("overlay_text".to_string());
+    }
+    if next.desired.overlay_timestamp != existing.desired.overlay_timestamp {
+        fields.push("overlay_timestamp".to_string());
+    }
+    if next.desired.desired_password.trim() != existing.desired.desired_password.trim()
+        || next.desired.generate_password != existing.desired.generate_password
+    {
+        fields.push("password_rotate".to_string());
+    }
+    if next.desired.hardening != existing.desired.hardening {
+        fields.push("hardening".to_string());
+    }
+    fields
+}
+
+fn requested_verification_failures(
+    verification: &CameraReconcileResult,
+    requested_fields: &[String],
+) -> Vec<String> {
+    let mut failures = Vec::new();
+    for field in requested_fields {
+        if verification.failed_fields.iter().any(|item| item == field)
+            || verification.drift_fields.iter().any(|item| item == field)
+        {
+            failures.push(field.clone());
+        }
+    }
+    failures.sort();
+    failures.dedup();
+    failures
 }

--- a/src/live.rs
+++ b/src/live.rs
@@ -815,8 +815,6 @@ mod tests {
             segment_secs: 10,
             desired: crate::config::CameraDesiredConfig {
                 display_name: "Front".to_string(),
-                ntp_server: "10.0.0.1".to_string(),
-                timezone: "UTC".to_string(),
                 overlay_text: "Front".to_string(),
                 overlay_timestamp: true,
                 ..Default::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -486,8 +486,6 @@ async fn run_reolink_autoprovision(cfg: &mut Config, cfg_path: &Path) -> Result<
                 segment_secs: 10,
                 desired: config::CameraDesiredConfig {
                     display_name: source_name.clone(),
-                    ntp_server: cfg.camera_network.ntp_server.clone(),
-                    timezone: "UTC".to_string(),
                     overlay_text: source_name.clone(),
                     overlay_timestamp: true,
                     ..Default::default()

--- a/src/onvif.rs
+++ b/src/onvif.rs
@@ -10,8 +10,6 @@ use std::net::IpAddr;
 use std::time::{Duration, SystemTime};
 use tokio::time::sleep;
 
-use crate::config::{CameraDesiredConfig, CameraTimeMode};
-
 const DEVICE_WSDL: &str = "http://www.onvif.org/ver10/device/wsdl";
 const MEDIA_WSDL: &str = "http://www.onvif.org/ver10/media/wsdl";
 const PTZ_WSDL: &str = "http://www.onvif.org/ver20/ptz/wsdl";
@@ -54,6 +52,13 @@ pub struct OnvifPtzPose {
     pub pan: Option<f32>,
     pub tilt: Option<f32>,
     pub zoom: Option<f32>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct OnvifSiteTimePolicy {
+    pub ntp_enabled: bool,
+    pub ntp_server: String,
+    pub timezone: String,
 }
 
 pub async fn read_state(ip: &str, port: u16, username: &str, password: &str) -> Result<OnvifState> {
@@ -173,6 +178,9 @@ pub async fn read_state(ip: &str, port: u16, username: &str, password: &str) -> 
         .map(|doc| (parse_ptz_pose(&doc), parse_ptz_move_status(&doc)))
         .unwrap_or((None, String::new()));
 
+    let raw_timezone = descendant_text(&time_doc, "TZ");
+    let normalized_timezone = normalize_onvif_timezone(&raw_timezone);
+
     Ok(OnvifState {
         manufacturer: descendant_text(&info_doc, "Manufacturer"),
         model: descendant_text(&info_doc, "Model"),
@@ -184,7 +192,7 @@ pub async fn read_state(ip: &str, port: u16, username: &str, password: &str) -> 
         ptz_service_url,
         profile_token: profile_token.clone(),
         time_mode: descendant_text(&time_doc, "DateTimeType").to_ascii_lowercase(),
-        timezone: descendant_text(&time_doc, "TZ"),
+        timezone: normalized_timezone.clone(),
         ntp_server: ntp_doc.as_ref().map(first_ntp_server).unwrap_or_default(),
         manual_time: local_datetime_value(&time_doc),
         ptz_capable,
@@ -208,7 +216,8 @@ pub async fn read_state(ip: &str, port: u16, username: &str, password: &str) -> 
             },
             "time": {
                 "mode": descendant_text(&time_doc, "DateTimeType"),
-                "timezone": descendant_text(&time_doc, "TZ"),
+                "timezone": normalized_timezone,
+                "timezoneRaw": raw_timezone,
                 "localDateTime": local_datetime_value(&time_doc),
                 "ntpServer": ntp_doc.as_ref().map(first_ntp_server).unwrap_or_default(),
             },
@@ -274,73 +283,47 @@ pub async fn set_network_protocol(
     .map(|_| ())
 }
 
-pub async fn apply_time_settings(
+pub async fn apply_site_time_settings(
     ip: &str,
     port: u16,
     username: &str,
     password: &str,
-    desired: &CameraDesiredConfig,
+    policy: &OnvifSiteTimePolicy,
 ) -> Result<()> {
+    if !policy.ntp_enabled {
+        return Ok(());
+    }
     let state = read_state(ip, port, username, password).await?;
     let client = http_client()?;
-    let timezone = if desired.timezone.trim().is_empty() {
+    let timezone = if policy.timezone.trim().is_empty() {
         state.timezone.trim().to_string()
     } else {
-        desired.timezone.trim().to_string()
+        policy.timezone.trim().to_string()
     };
-
-    if matches!(desired.time_mode, CameraTimeMode::Ntp) {
-        let ntp_server = desired.ntp_server.trim();
-        if !ntp_server.is_empty() {
-            soap_call(
-                &client,
-                &state.device_service_url,
-                username,
-                password,
-                &format!("{DEVICE_WSDL}/SetNTP"),
-                &format!(
-                    "<tds:SetNTP><tds:FromDHCP>false</tds:FromDHCP>{}</tds:SetNTP>",
-                    ntp_manual_entry(ntp_server)
-                ),
-            )
-            .await
-            .context("ONVIF SetNTP failed")?;
-        }
-
-        let timezone_xml = if timezone.is_empty() {
-            String::new()
-        } else {
-            format!(
-                "<tds:TimeZone><tt:TZ>{}</tt:TZ></tds:TimeZone>",
-                escape_xml(&timezone)
-            )
-        };
+    let ntp_server = policy.ntp_server.trim();
+    if !ntp_server.is_empty() {
         soap_call(
             &client,
             &state.device_service_url,
             username,
             password,
-            &format!("{DEVICE_WSDL}/SetSystemDateAndTime"),
+            &format!("{DEVICE_WSDL}/SetNTP"),
             &format!(
-                "<tds:SetSystemDateAndTime><tds:DateTimeType>NTP</tds:DateTimeType><tds:DaylightSavings>false</tds:DaylightSavings>{timezone_xml}</tds:SetSystemDateAndTime>"
+                "<tds:SetNTP><tds:FromDHCP>false</tds:FromDHCP>{}</tds:SetNTP>",
+                ntp_manual_entry(ntp_server)
             ),
         )
         .await
-        .context("ONVIF SetSystemDateAndTime (NTP) failed")?;
-        return Ok(());
+        .context("ONVIF SetNTP failed")?;
     }
 
-    let manual_time = desired.manual_time.trim();
-    if manual_time.is_empty() {
-        return Err(anyhow!("manual_time is required when time_mode is manual"));
-    }
-    let manual_xml = build_manual_datetime_xml(manual_time)?;
+    let onvif_timezone = onvif_timezone_value(&timezone);
     let timezone_xml = if timezone.is_empty() {
         String::new()
     } else {
         format!(
             "<tds:TimeZone><tt:TZ>{}</tt:TZ></tds:TimeZone>",
-            escape_xml(&timezone)
+            escape_xml(&onvif_timezone)
         )
     };
     soap_call(
@@ -350,11 +333,11 @@ pub async fn apply_time_settings(
         password,
         &format!("{DEVICE_WSDL}/SetSystemDateAndTime"),
         &format!(
-            "<tds:SetSystemDateAndTime><tds:DateTimeType>Manual</tds:DateTimeType><tds:DaylightSavings>false</tds:DaylightSavings>{timezone_xml}<tds:UTCDateTime>{manual_xml}</tds:UTCDateTime></tds:SetSystemDateAndTime>"
+            "<tds:SetSystemDateAndTime><tds:DateTimeType>NTP</tds:DateTimeType><tds:DaylightSavings>false</tds:DaylightSavings>{timezone_xml}</tds:SetSystemDateAndTime>"
         ),
     )
     .await
-    .context("ONVIF SetSystemDateAndTime (manual) failed")?;
+    .context("ONVIF SetSystemDateAndTime (NTP) failed")?;
     Ok(())
 }
 
@@ -806,6 +789,35 @@ fn first_ntp_server(doc: &Document<'_>) -> String {
         .unwrap_or_default()
 }
 
+fn normalize_onvif_timezone(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match trimmed {
+        "UTC" | "GMT+00:00:00" | "UTC+00:00:00" => "UTC".to_string(),
+        "MST7"
+        | "MST7:00:00"
+        | "UTC+7:00:00"
+        | "UTC+07:00:00"
+        | "GMT+7:00:00"
+        | "GMT+07:00:00" => "America/Phoenix".to_string(),
+        _ => trimmed.to_string(),
+    }
+}
+
+fn onvif_timezone_value(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    match trimmed {
+        "UTC" => "UTC".to_string(),
+        "America/Phoenix" => "UTC+07:00:00".to_string(),
+        other => other.to_string(),
+    }
+}
+
 fn ntp_manual_entry(server: &str) -> String {
     let trimmed = server.trim();
     if trimmed.parse::<IpAddr>().is_ok() {
@@ -901,5 +913,13 @@ mod tests {
     fn ntp_manual_entry_uses_ipv4_or_dns() {
         assert!(ntp_manual_entry("192.168.250.1").contains("IPv4Address"));
         assert!(ntp_manual_entry("pool.ntp.org").contains("DNSname"));
+    }
+
+    #[test]
+    fn maps_phoenix_onvif_timezone_bidirectionally() {
+        assert_eq!(onvif_timezone_value("America/Phoenix"), "UTC+07:00:00");
+        assert_eq!(normalize_onvif_timezone("UTC+07:00:00"), "America/Phoenix");
+        assert_eq!(normalize_onvif_timezone("GMT+07:00:00"), "America/Phoenix");
+        assert_eq!(normalize_onvif_timezone("MST7"), "America/Phoenix");
     }
 }

--- a/src/reolink_cgi.rs
+++ b/src/reolink_cgi.rs
@@ -13,11 +13,22 @@ use reqwest::{Client, header};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::{error::Error, fmt};
+use tokio::time::{Duration, Instant, sleep};
+use tracing::warn;
 
 const HTTP_TIMEOUT_SECS: u64 = 10;
 const HTTP_ENDPOINTS: [(&str, u16); 2] = [("http", 80), ("https", 443)];
 const HTTPS_FIRST_ENDPOINTS: [(&str, u16); 2] = [("https", 443), ("http", 80)];
 const ZERO_BLOCK: usize = 16;
+const PRESENTATION_VERIFY_TIMEOUT_SECS: u64 = 8;
+const PRESENTATION_VERIFY_POLL_MILLIS: u64 = 500;
+const REOLINK_TIME_FMT_MM_DD_YYYY: i64 = 1;
+const REOLINK_TIME_FMT_MM_DD_YYYY_LABEL: &str = "MM/DD/YYYY";
+const REOLINK_TIME_FMT_YYYY_MM_DD_LABEL: &str = "YYYY/MM/DD";
+const REOLINK_TIME_FMT_DD_MM_YYYY_LABEL: &str = "DD/MM/YYYY";
+const REOLINK_HOUR_FMT_24H: i64 = 0;
+const REOLINK_TIMEZONE_UTC_SECONDS: i64 = 0;
+const REOLINK_TIMEZONE_PHOENIX_SECONDS: i64 = 25_200;
 
 type Aes128CfbEnc = cfb_mode::Encryptor<Aes128>;
 type Aes128CfbDec = cfb_mode::Decryptor<Aes128>;
@@ -228,6 +239,10 @@ pub struct ReolinkPresentationState {
     #[serde(default)]
     pub timezone: String,
     #[serde(default)]
+    pub clock_date_format: String,
+    #[serde(default)]
+    pub clock_hour_format: String,
+    #[serde(default)]
     pub overlay_text: String,
     #[serde(default)]
     pub overlay_timestamp: Option<bool>,
@@ -250,6 +265,8 @@ pub struct ReolinkPresentationApplyRequest {
     pub manual_time: Option<String>,
     #[serde(default)]
     pub timezone: Option<String>,
+    #[serde(default)]
+    pub enforce_clock_display: bool,
     #[serde(default)]
     pub overlay_text: Option<String>,
     #[serde(default)]
@@ -512,6 +529,32 @@ impl ReolinkHttpSession {
         Ok(())
     }
 
+    async fn logout(&mut self) -> Result<()> {
+        self.send_command("Logout", json!({})).await?;
+        Ok(())
+    }
+
+    async fn read_state_snapshot(&mut self) -> Result<ReolinkStateSnapshot> {
+        let net = self.get_net_port().await?;
+        let p2p = self.get_p2p().await?;
+        Ok(ReolinkStateSnapshot {
+            normal: serde_json::to_value(net.normal()).context("failed encoding CGI normal state")?,
+            advanced: serde_json::to_value(net.advanced())
+                .context("failed encoding CGI advanced state")?,
+            p2p: serde_json::to_value(p2p.config()).context("failed encoding CGI p2p state")?,
+            ..ReolinkStateSnapshot::default()
+        })
+    }
+
+    async fn read_presentation_state(&mut self) -> Result<ReolinkPresentationState> {
+        let time_entry = self.send_command("GetTime", json!({})).await.ok();
+        let osd_entry = self.send_command("GetOsd", json!({})).await.ok();
+        Ok(build_presentation_state(
+            time_entry.as_ref(),
+            osd_entry.as_ref(),
+        ))
+    }
+
     async fn send_command(&mut self, cmd: &str, param: Value) -> Result<Value> {
         let first = self.send_command_entry(cmd, param).await?;
         if let Some(error) = command_error(cmd, &first) {
@@ -665,63 +708,62 @@ pub async fn setup(request: &ReolinkSetupRequest) -> Result<ReolinkSetupBridgeRe
         }
     };
 
-    let before_net = session.get_net_port().await?;
-    let before_p2p = session.get_p2p().await?;
-    let before_normal = before_net.normal();
-    let before_advanced = before_net.advanced();
+    let result = async {
+        let before_net = session.get_net_port().await?;
+        let before_p2p = session.get_p2p().await?;
+        let before_normal = before_net.normal();
+        let before_advanced = before_net.advanced();
 
-    let target_normal = merge_normal(&before_normal, request.normal.as_ref());
-    let target_advanced = merge_advanced(&before_advanced, request.advanced.as_ref());
-    let target_p2p = merge_p2p(request.p2p.as_ref());
+        let target_normal = merge_normal(&before_normal, request.normal.as_ref());
+        let target_advanced = merge_advanced(&before_advanced, request.advanced.as_ref());
+        let target_p2p = merge_p2p(request.p2p.as_ref());
 
-    let target_net = ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
-    if target_net != before_net {
-        session.set_net_port(&target_net).await?;
+        let target_net =
+            ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
+        if target_net != before_net {
+            session.set_net_port(&target_net).await?;
+        }
+
+        let target_p2p_wire = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p);
+        if target_p2p_wire != before_p2p {
+            session.set_p2p(&target_p2p_wire).await?;
+        }
+
+        if !bootstrapped && !desired_password.is_empty() && desired_password != login_password {
+            session
+                .modify_user(&request.username, &login_password, desired_password)
+                .await?;
+        }
+
+        let after_net = session.get_net_port().await?;
+        let after_p2p = session.get_p2p().await?;
+
+        Ok::<ReolinkSetupBridgeResult, anyhow::Error>(ReolinkSetupBridgeResult {
+            ip: request.ip.clone(),
+            username: request.username.clone(),
+            before_normal,
+            before_advanced,
+            before_p2p: before_p2p.config(),
+            after_normal: after_net.normal(),
+            after_advanced: after_net.advanced(),
+            after_p2p: after_p2p.config(),
+        })
     }
-
-    let target_p2p_wire = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p);
-    if target_p2p_wire != before_p2p {
-        session.set_p2p(&target_p2p_wire).await?;
-    }
-
-    if !bootstrapped && !desired_password.is_empty() && desired_password != login_password {
-        session
-            .modify_user(&request.username, &login_password, desired_password)
-            .await?;
-    }
-
-    let after_net = session.get_net_port().await?;
-    let after_p2p = session.get_p2p().await?;
-
-    Ok(ReolinkSetupBridgeResult {
-        ip: request.ip.clone(),
-        username: request.username.clone(),
-        before_normal,
-        before_advanced,
-        before_p2p: before_p2p.config(),
-        after_normal: after_net.normal(),
-        after_advanced: after_net.advanced(),
-        after_p2p: after_p2p.config(),
-    })
+    .await;
+    best_effort_logout(&mut session, "setup").await;
+    result
 }
 
 pub async fn read_state(
     request: &crate::reolink::ReolinkConnectRequest,
 ) -> Result<ReolinkStateResult> {
     let mut session = login_existing_session(request).await?;
-    let net = session.get_net_port().await?;
-    let p2p = session.get_p2p().await?;
-    Ok(ReolinkStateResult {
-        state: ReolinkStateSnapshot {
-            normal: serde_json::to_value(net.normal())
-                .context("failed encoding CGI normal state")?,
-            advanced: serde_json::to_value(net.advanced())
-                .context("failed encoding CGI advanced state")?,
-            p2p: serde_json::to_value(p2p.config()).context("failed encoding CGI p2p state")?,
-            ..ReolinkStateSnapshot::default()
-        },
+    let result = session.read_state_snapshot().await.map(|state| ReolinkStateResult {
+        state,
         active_password: request.password.clone(),
-    })
+    });
+    best_effort_logout(&mut session, "read_state").await;
+    result
 }
 
 pub async fn apply_state(request: &ReolinkStateApplyRequest) -> Result<ReolinkStateApplyResult> {
@@ -739,75 +781,78 @@ pub async fn apply_state(request: &ReolinkStateApplyRequest) -> Result<ReolinkSt
     }
 
     let mut session = login_existing_session(&request.connection).await?;
-    let before_net = session.get_net_port().await?;
-    let before_p2p = session.get_p2p().await?;
+    let result = async {
+        let before_net = session.get_net_port().await?;
+        let before_p2p = session.get_p2p().await?;
 
-    let before_normal = before_net.normal();
-    let before_advanced = before_net.advanced();
-    let before_p2p_cfg = before_p2p.config();
+        let before_normal = before_net.normal();
+        let before_advanced = before_net.advanced();
+        let before_p2p_cfg = before_p2p.config();
 
-    let target_normal = match request.normal.as_ref() {
-        Some(value) => serde_json::from_value::<ReolinkNormalPortConfig>(value.clone())
-            .context("invalid CGI normal port state payload")?,
-        None => before_normal.clone(),
-    };
-    let target_advanced = match request.advanced.as_ref() {
-        Some(value) => serde_json::from_value::<ReolinkAdvancedPortConfig>(value.clone())
-            .context("invalid CGI advanced port state payload")?,
-        None => before_advanced.clone(),
-    };
-    let target_p2p_cfg = match request.p2p.as_ref() {
-        Some(value) => serde_json::from_value::<ReolinkP2PConfig>(value.clone())
-            .context("invalid CGI P2P state payload")?,
-        None => before_p2p_cfg.clone(),
-    };
+        let target_normal = match request.normal.as_ref() {
+            Some(value) => serde_json::from_value::<ReolinkNormalPortConfig>(value.clone())
+                .context("invalid CGI normal port state payload")?,
+            None => before_normal.clone(),
+        };
+        let target_advanced = match request.advanced.as_ref() {
+            Some(value) => serde_json::from_value::<ReolinkAdvancedPortConfig>(value.clone())
+                .context("invalid CGI advanced port state payload")?,
+            None => before_advanced.clone(),
+        };
+        let target_p2p_cfg = match request.p2p.as_ref() {
+            Some(value) => serde_json::from_value::<ReolinkP2PConfig>(value.clone())
+                .context("invalid CGI P2P state payload")?,
+            None => before_p2p_cfg.clone(),
+        };
 
-    let target_net = ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
-    if target_net != before_net {
-        session.set_net_port(&target_net).await?;
+        let target_net =
+            ReolinkCgiNetPort::with_updates(&before_net, &target_normal, &target_advanced);
+        if target_net != before_net {
+            session.set_net_port(&target_net).await?;
+        }
+
+        let target_p2p = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p_cfg);
+        if target_p2p != before_p2p {
+            session.set_p2p(&target_p2p).await?;
+        }
+
+        let after_net = session.get_net_port().await?;
+        let after_p2p = session.get_p2p().await?;
+
+        Ok::<ReolinkStateApplyResult, anyhow::Error>(ReolinkStateApplyResult {
+            before: ReolinkStateSnapshot {
+                normal: serde_json::to_value(before_normal)
+                    .context("failed encoding CGI pre-update normal state")?,
+                advanced: serde_json::to_value(before_advanced)
+                    .context("failed encoding CGI pre-update advanced state")?,
+                p2p: serde_json::to_value(before_p2p_cfg)
+                    .context("failed encoding CGI pre-update p2p state")?,
+                ..ReolinkStateSnapshot::default()
+            },
+            after: ReolinkStateSnapshot {
+                normal: serde_json::to_value(after_net.normal())
+                    .context("failed encoding CGI post-update normal state")?,
+                advanced: serde_json::to_value(after_net.advanced())
+                    .context("failed encoding CGI post-update advanced state")?,
+                p2p: serde_json::to_value(after_p2p.config())
+                    .context("failed encoding CGI post-update p2p state")?,
+                ..ReolinkStateSnapshot::default()
+            },
+            active_password: request.connection.password.clone(),
+        })
     }
-
-    let target_p2p = ReolinkCgiP2P::with_updates(&before_p2p, &target_p2p_cfg);
-    if target_p2p != before_p2p {
-        session.set_p2p(&target_p2p).await?;
-    }
-
-    let after_net = session.get_net_port().await?;
-    let after_p2p = session.get_p2p().await?;
-
-    Ok(ReolinkStateApplyResult {
-        before: ReolinkStateSnapshot {
-            normal: serde_json::to_value(before_normal)
-                .context("failed encoding CGI pre-update normal state")?,
-            advanced: serde_json::to_value(before_advanced)
-                .context("failed encoding CGI pre-update advanced state")?,
-            p2p: serde_json::to_value(before_p2p_cfg)
-                .context("failed encoding CGI pre-update p2p state")?,
-            ..ReolinkStateSnapshot::default()
-        },
-        after: ReolinkStateSnapshot {
-            normal: serde_json::to_value(after_net.normal())
-                .context("failed encoding CGI post-update normal state")?,
-            advanced: serde_json::to_value(after_net.advanced())
-                .context("failed encoding CGI post-update advanced state")?,
-            p2p: serde_json::to_value(after_p2p.config())
-                .context("failed encoding CGI post-update p2p state")?,
-            ..ReolinkStateSnapshot::default()
-        },
-        active_password: request.connection.password.clone(),
-    })
+    .await;
+    best_effort_logout(&mut session, "apply_state").await;
+    result
 }
 
 pub async fn read_presentation_state(
     request: &crate::reolink::ReolinkConnectRequest,
 ) -> Result<ReolinkPresentationState> {
     let mut session = login_existing_session(request).await?;
-    let time_entry = session.send_command("GetTime", json!({})).await.ok();
-    let osd_entry = session.send_command("GetOsd", json!({})).await.ok();
-    Ok(build_presentation_state(
-        time_entry.as_ref(),
-        osd_entry.as_ref(),
-    ))
+    let result = session.read_presentation_state().await;
+    best_effort_logout(&mut session, "read_presentation_state").await;
+    result
 }
 
 pub async fn apply_presentation_state(
@@ -822,6 +867,7 @@ pub async fn apply_presentation_state(
         || request.ntp_server.is_some()
         || request.manual_time.is_some()
         || request.timezone.is_some()
+        || request.enforce_clock_display
     {
         if let Some(mut time_value) = time_entry
             .as_ref()
@@ -856,12 +902,13 @@ pub async fn apply_presentation_state(
         }
     }
 
-    let state = read_presentation_state(&request.connection).await?;
-    if errors.is_empty() {
-        Ok(state)
+    let result = if errors.is_empty() {
+        verify_presentation_apply(&mut session, request).await
     } else {
         Err(anyhow!(errors.join(" | ")))
-    }
+    };
+    best_effort_logout(&mut session, "apply_presentation_state").await;
+    result
 }
 
 pub async fn ptz_command(
@@ -870,7 +917,7 @@ pub async fn ptz_command(
     speed: i32,
 ) -> Result<()> {
     let mut session = login_existing_session_prefer_https(request).await?;
-    session
+    let result = session
         .send_command(
             "PtzCtrl",
             json!({
@@ -879,13 +926,15 @@ pub async fn ptz_command(
                 "speed": speed.max(1),
             }),
         )
-        .await?;
-    Ok(())
+        .await
+        .map(|_| ());
+    best_effort_logout(&mut session, "ptz_command").await;
+    result
 }
 
 pub async fn ptz_stop(request: &crate::reolink::ReolinkConnectRequest) -> Result<()> {
     let mut session = login_existing_session_prefer_https(request).await?;
-    session
+    let result = session
         .send_command(
             "PtzCtrl",
             json!({
@@ -893,8 +942,10 @@ pub async fn ptz_stop(request: &crate::reolink::ReolinkConnectRequest) -> Result
                 "op": "Stop",
             }),
         )
-        .await?;
-    Ok(())
+        .await
+        .map(|_| ());
+    best_effort_logout(&mut session, "ptz_stop").await;
+    result
 }
 
 async fn login_existing_session(
@@ -1009,6 +1060,93 @@ async fn bootstrap_user(
     Ok(())
 }
 
+async fn best_effort_logout(session: &mut ReolinkHttpSession, context: &str) {
+    if let Err(error) = session.logout().await {
+        warn!(context, error = %error, "failed closing Reolink CGI session");
+    }
+}
+
+async fn verify_presentation_apply(
+    session: &mut ReolinkHttpSession,
+    request: &ReolinkPresentationApplyRequest,
+) -> Result<ReolinkPresentationState> {
+    let deadline = Instant::now() + Duration::from_secs(PRESENTATION_VERIFY_TIMEOUT_SECS);
+    let mut last_state = session.read_presentation_state().await?;
+    if presentation_verify_failures(&last_state, request).is_empty() {
+        return Ok(last_state);
+    }
+
+    loop {
+        if Instant::now() >= deadline {
+            let failures = presentation_verify_failures(&last_state, request);
+            return Err(anyhow!(
+                "requested presentation state did not verify: {} (observed overlay {:?}, timestamp {:?}, time mode {:?}, ntp {:?}, timezone {:?}, date format {:?}, hour format {:?})",
+                failures.join(", "),
+                last_state.overlay_text,
+                last_state.overlay_timestamp,
+                last_state.time_mode,
+                last_state.ntp_server,
+                last_state.timezone,
+                last_state.clock_date_format,
+                last_state.clock_hour_format,
+            ));
+        }
+        sleep(Duration::from_millis(PRESENTATION_VERIFY_POLL_MILLIS)).await;
+        last_state = session.read_presentation_state().await?;
+        if presentation_verify_failures(&last_state, request).is_empty() {
+            return Ok(last_state);
+        }
+    }
+}
+
+fn presentation_verify_failures(
+    observed: &ReolinkPresentationState,
+    request: &ReolinkPresentationApplyRequest,
+) -> Vec<&'static str> {
+    let mut fields = Vec::new();
+    if let Some(expected) = &request.time_mode
+        && !expected.trim().is_empty()
+        && observed.time_mode.trim() != expected.trim()
+    {
+        fields.push("time_mode");
+    }
+    if let Some(expected) = &request.ntp_server
+        && observed.ntp_server.trim() != expected.trim()
+    {
+        fields.push("ntp_server");
+    }
+    if let Some(expected) = &request.manual_time
+        && !expected.trim().is_empty()
+        && observed.manual_time.trim() != expected.trim()
+    {
+        fields.push("manual_time");
+    }
+    if let Some(expected) = &request.timezone
+        && observed.timezone.trim() != expected.trim()
+    {
+        fields.push("timezone");
+    }
+    if request.enforce_clock_display {
+        if observed.clock_date_format.trim() != "MM/DD/YYYY" {
+            fields.push("clock_date_format");
+        }
+        if observed.clock_hour_format.trim() != "24h" {
+            fields.push("clock_hour_format");
+        }
+    }
+    if let Some(expected) = &request.overlay_text
+        && observed.overlay_text.trim() != expected.trim()
+    {
+        fields.push("overlay_text");
+    }
+    if let Some(expected) = request.overlay_timestamp
+        && observed.overlay_timestamp != Some(expected)
+    {
+        fields.push("overlay_timestamp");
+    }
+    fields
+}
+
 fn merge_normal(
     current: &ReolinkNormalPortConfig,
     requested: Option<&ReolinkNormalPortConfig>,
@@ -1085,7 +1223,9 @@ fn build_presentation_state(
         },
         ntp_server: string_at_any(&time_value, &["ntpServer", "NtpServer", "server"]),
         manual_time: manual_time_from_value(&time_value),
-        timezone: string_at_any(&time_value, &["timeZone", "TimeZone", "zone"]),
+        timezone: reolink_timezone_label(&time_value),
+        clock_date_format: reolink_date_format_label(&time_value),
+        clock_hour_format: reolink_hour_format_label(&time_value),
         overlay_text: overlay_text_from_value(&osd_value),
         overlay_timestamp: overlay_timestamp_from_value(&osd_value),
         time: time_value,
@@ -1102,7 +1242,19 @@ fn mutate_time_value(value: &mut Value, request: &ReolinkPresentationApplyReques
         set_string_at_any(value, &["ntpServer", "NtpServer", "server"], server);
     }
     if let Some(zone) = &request.timezone {
-        set_string_at_any(value, &["timeZone", "TimeZone", "zone"], zone);
+        set_reolink_timezone_at_any(value, &["timeZone", "TimeZone", "zone"], zone);
+        if zone.trim().eq_ignore_ascii_case("America/Phoenix") {
+            set_i64_at_any(value, &["isDst", "IsDst"], 0);
+        }
+    }
+    if request.enforce_clock_display {
+        set_reolink_date_format_at_any(
+            value,
+            &["timeFmt", "TimeFmt"],
+            REOLINK_TIME_FMT_MM_DD_YYYY,
+            REOLINK_TIME_FMT_MM_DD_YYYY_LABEL,
+        );
+        set_i64_at_any(value, &["hourFmt", "HourFmt"], REOLINK_HOUR_FMT_24H);
     }
     if let Some(manual_time) = &request.manual_time {
         if let Some((year, month, day, hour, minute, second)) =
@@ -1475,5 +1627,212 @@ mod tests {
         .expect("entry");
         let error = command_error("Login", &entry).expect("error");
         assert!(error.is_rsp_code(-505));
+    }
+
+    #[test]
+    fn presentation_verify_failures_detect_requested_overlay_drift() {
+        let observed = ReolinkPresentationState {
+            overlay_text: "Reolink E1 Outdoor SE".to_string(),
+            overlay_timestamp: Some(true),
+            ..Default::default()
+        };
+        let request = ReolinkPresentationApplyRequest {
+            connection: crate::reolink::ReolinkConnectRequest {
+                ip: "192.168.0.10".to_string(),
+                username: "admin".to_string(),
+                password: "test".to_string(),
+                channel: 0,
+            },
+            overlay_text: Some("Carport".to_string()),
+            overlay_timestamp: Some(true),
+            time_mode: None,
+            ntp_server: None,
+            manual_time: None,
+            timezone: None,
+            enforce_clock_display: false,
+        };
+        assert_eq!(
+            presentation_verify_failures(&observed, &request),
+            vec!["overlay_text"]
+        );
+    }
+
+    #[test]
+    fn presentation_verify_failures_accept_matching_requested_fields() {
+        let observed = ReolinkPresentationState {
+            overlay_text: "Test".to_string(),
+            overlay_timestamp: Some(false),
+            time_mode: "ntp".to_string(),
+            ntp_server: "pool.ntp.org".to_string(),
+            timezone: "UTC".to_string(),
+            ..Default::default()
+        };
+        let request = ReolinkPresentationApplyRequest {
+            connection: crate::reolink::ReolinkConnectRequest {
+                ip: "192.168.0.10".to_string(),
+                username: "admin".to_string(),
+                password: "test".to_string(),
+                channel: 0,
+            },
+            overlay_text: Some("Test".to_string()),
+            overlay_timestamp: Some(false),
+            time_mode: Some("ntp".to_string()),
+            ntp_server: Some("pool.ntp.org".to_string()),
+            manual_time: None,
+            timezone: Some("UTC".to_string()),
+            enforce_clock_display: false,
+        };
+        assert!(presentation_verify_failures(&observed, &request).is_empty());
+    }
+
+    #[test]
+    fn reolink_date_format_label_accepts_string_payloads() {
+        let value = json!({
+            "timeFmt": "DD/MM/YYYY",
+            "hourFmt": 0
+        });
+        assert_eq!(reolink_date_format_label(&value), "DD/MM/YYYY");
+        assert_eq!(reolink_hour_format_label(&value), "24h");
+    }
+
+    #[test]
+    fn reolink_hour_format_label_maps_one_to_12h() {
+        let value = json!({
+            "hourFmt": 1
+        });
+        assert_eq!(reolink_hour_format_label(&value), "12h");
+    }
+
+    #[test]
+    fn set_reolink_date_format_preserves_string_wire_shape() {
+        let mut value = json!({
+            "timeFmt": "DD/MM/YYYY"
+        });
+        set_reolink_date_format_at_any(
+            &mut value,
+            &["timeFmt", "TimeFmt"],
+            REOLINK_TIME_FMT_MM_DD_YYYY,
+            REOLINK_TIME_FMT_MM_DD_YYYY_LABEL,
+        );
+        assert_eq!(
+            value.get("timeFmt").and_then(Value::as_str),
+            Some(REOLINK_TIME_FMT_MM_DD_YYYY_LABEL)
+        );
+    }
+
+    #[test]
+    fn reolink_timezone_label_accepts_numeric_payloads() {
+        let value = json!({
+            "timeZone": 25200,
+            "isDst": 0
+        });
+        assert_eq!(reolink_timezone_label(&value), "America/Phoenix");
+    }
+
+    #[test]
+    fn set_reolink_timezone_preserves_numeric_wire_shape() {
+        let mut value = json!({
+            "timeZone": 28800
+        });
+        set_reolink_timezone_at_any(&mut value, &["timeZone", "TimeZone", "zone"], "America/Phoenix");
+        assert_eq!(value.get("timeZone").and_then(Value::as_i64), Some(REOLINK_TIMEZONE_PHOENIX_SECONDS));
+    }
+}
+
+fn set_reolink_date_format_at_any(value: &mut Value, keys: &[&str], next_i64: i64, next_label: &str) {
+    if let Some(map) = value.as_object_mut() {
+        for key in keys {
+            if let Some(existing) = map.get(*key) {
+                let replacement = if existing.is_string() {
+                    Value::String(next_label.to_string())
+                } else {
+                    Value::Number(next_i64.into())
+                };
+                map.insert((*key).to_string(), replacement);
+                return;
+            }
+        }
+        if let Some(key) = keys.first() {
+            map.insert((*key).to_string(), Value::String(next_label.to_string()));
+        }
+    }
+}
+
+fn reolink_date_format_label(value: &Value) -> String {
+    let string_value = string_at_any(value, &["timeFmt", "TimeFmt"]);
+    match string_value.trim() {
+        REOLINK_TIME_FMT_MM_DD_YYYY_LABEL => return REOLINK_TIME_FMT_MM_DD_YYYY_LABEL.to_string(),
+        REOLINK_TIME_FMT_YYYY_MM_DD_LABEL => return REOLINK_TIME_FMT_YYYY_MM_DD_LABEL.to_string(),
+        REOLINK_TIME_FMT_DD_MM_YYYY_LABEL => return REOLINK_TIME_FMT_DD_MM_YYYY_LABEL.to_string(),
+        "" => {}
+        other => return format!("raw:{other}"),
+    }
+    match int_at_any(value, &["timeFmt", "TimeFmt"]) {
+        Some(REOLINK_TIME_FMT_MM_DD_YYYY) => REOLINK_TIME_FMT_MM_DD_YYYY_LABEL.to_string(),
+        Some(0) => REOLINK_TIME_FMT_YYYY_MM_DD_LABEL.to_string(),
+        Some(2) => REOLINK_TIME_FMT_DD_MM_YYYY_LABEL.to_string(),
+        Some(other) => format!("raw:{other}"),
+        None => String::new(),
+    }
+}
+
+fn reolink_hour_format_label(value: &Value) -> String {
+    match int_at_any(value, &["hourFmt", "HourFmt"]) {
+        Some(REOLINK_HOUR_FMT_24H) => "24h".to_string(),
+        Some(1) => "12h".to_string(),
+        Some(other) => format!("raw:{other}"),
+        None => String::new(),
+    }
+}
+
+fn reolink_timezone_label(value: &Value) -> String {
+    let string_value = string_at_any(value, &["timeZone", "TimeZone", "zone"]);
+    match string_value.trim() {
+        "UTC" => return "UTC".to_string(),
+        "America/Phoenix" | "MST7" | "UTC+07:00:00" | "GMT+07:00:00" => {
+            return "America/Phoenix".to_string();
+        }
+        "" => {}
+        other => return other.to_string(),
+    }
+    match int_at_any(value, &["timeZone", "TimeZone", "zone"]) {
+        Some(REOLINK_TIMEZONE_UTC_SECONDS) => "UTC".to_string(),
+        Some(REOLINK_TIMEZONE_PHOENIX_SECONDS) => "America/Phoenix".to_string(),
+        Some(other) => format!("raw:{other}"),
+        None => String::new(),
+    }
+}
+
+fn reolink_timezone_seconds(label: &str) -> Option<i64> {
+    match label.trim() {
+        "UTC" => Some(REOLINK_TIMEZONE_UTC_SECONDS),
+        "America/Phoenix" => Some(REOLINK_TIMEZONE_PHOENIX_SECONDS),
+        _ => None,
+    }
+}
+
+fn set_reolink_timezone_at_any(value: &mut Value, keys: &[&str], next_label: &str) {
+    let trimmed = next_label.trim();
+    let numeric = reolink_timezone_seconds(trimmed);
+    if let Some(map) = value.as_object_mut() {
+        for key in keys {
+            if let Some(existing) = map.get(*key) {
+                let replacement = if existing.is_i64() || existing.is_u64() {
+                    numeric
+                        .map(|seconds| Value::Number(seconds.into()))
+                        .unwrap_or_else(|| Value::String(trimmed.to_string()))
+                } else {
+                    Value::String(trimmed.to_string())
+                };
+                map.insert((*key).to_string(), replacement);
+                return;
+            }
+        }
+        if let Some(key) = keys.first() {
+            let replacement = numeric
+                .map(|seconds| Value::Number(seconds.into()))
+                .unwrap_or_else(|| Value::String(trimmed.to_string()));
+            map.insert((*key).to_string(), replacement);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- move camera time to site policy under `camera_network` and converge Reolink time authority by concern
- harden camera presentation/name assurance around verified hardware readback and CGI session cleanup
- align Reolink observed state, verification, and operator docs with the proven live camera behavior

## Verification
- cargo build --quiet
- cargo test --quiet
