### PR TITLE
feat(nvr): add XM 40E driver and validated live/media support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "des",
  "futures-util",
  "hex",
  "hkdf",
@@ -856,6 +857,15 @@ checksum = "8f0314b72bed045f3a68671b3c86328386762c93f82d98c65c3cb5e5f573dd68"
 dependencies = [
  "derive_builder_core",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "des"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdd80ce8ce993de27e9f063a444a4d53ce8e8db4c1f00cc03af5ad5a9867a1e"
+dependencies = [
+ "cipher 0.4.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ chacha20poly1305 = { version = "0.10", features = ["std"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 chrono-tz = "0.10"
 clap = { version = "4.5", features = ["derive"] }
+des = "0.8"
 futures-util = "0.3"
 hex = "0.4"
 hkdf = "0.12"

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Installer behavior:
 - skips reinstall/restart when installed binary hash is unchanged
 - installs systemd service and self-update timer by default
 - updater keeps config/state out of release paths and rolls back binary on failed restart/health check
+- provisions decoder-capable host `ffmpeg` for live preview, including HEVC camera support on Fedora-class hosts
 - provisions an isolated camera NIC with a collision-checked `/24` and `dnsmasq` DHCP
 - optionally applies camera-interface hardening (DHCP + RTSP/ONVIF + optional NTP lane)
 

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -8,6 +8,48 @@
 - RTSP ingest: pending
 - Recommended status: test candidate
 
+### XM / NetSurveillance 40E
+- Lab discovery address: `192.168.0.201` (factory-static, off the managed `192.168.250.0/24` subnet)
+- Discovery requirement: host camera NIC must carry an explicit onboarding alias on the matching `/24` (for example `192.168.0.2/24`)
+- HTTP/web UI fingerprint:
+  - `Server: gSOAP/2.8`
+  - legacy plugin UI assets such as `api_pluginPlay/api_plugin.js`, `raw_player.js`, and `IPCConfigCtrl`
+- Live model fingerprint:
+  - `fsVersion="40E_19_DL_c1_V3-A-RTMP-H5 V3.4.0.3 build 2025-01-09 17:38:27"`
+  - serial `EF00000006092ABD`
+- RTSP ingest path: verified live on `2026-04-17`
+  - `rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream`
+- Stream facts proved on the lab camera:
+  - main stream: HEVC `2560x1440`
+  - substream: HEVC `640x360`
+  - tested RTSP profile variants on `2026-04-17` remained HEVC-only; no H.264 profile was found in the validated live paths
+- Current driver status:
+  - supported as `xm_40e`
+  - discovery, probe, ingest, live preview, baked-title apply, and site-time apply are in scope
+  - live service proof on `2026-04-18`:
+    - mounted as `xm-192-168-0-201` on the lab host
+    - `/health` reported the XM source `running`
+    - recorded segments were created under `/data/constitute-nvr/segments/xm-192-168-0-201`
+    - baked feed title was driven `Front Door -> Test -> Front Door`
+    - baked feed clock was verified live with:
+      - NTP mode
+      - NTP server `192.168.0.2`
+      - 24-hour time
+      - weekday hidden
+  - recorder note:
+    - this model exposes `pcm_mulaw` audio alongside HEVC video
+    - iteration-1 ingest records video-only MP4 segments because copying `pcm_mulaw` audio into MP4 is not container-safe
+  - preview note:
+    - live preview depends on host HEVC decode because the validated RTSP profiles are HEVC
+    - installer/runtime now treat decoder-capable `ffmpeg` as part of the supported contract
+  - XM-specific management notes:
+    - baked feed title is controlled by `TitleOverlay.TitleUtf8`
+    - site time is controlled by `/setTimeConfig` with manual seed -> NTP transition
+    - the effective NTP alias for this camera is `192.168.0.2`
+    - a second XM `UserOverlay` lane can leak stale text into the lower-left corner; the active driver now clears that lane on apply so the feed only shows the main title and clock
+- PTZ is not supported on this model
+- Recommended status: supported for discovery, ingest, live preview, baked title, and site time when an onboarding alias exists on the camera NIC
+
 ### Reolink E1 Outdoor SE PoE Pan Cam
 - First boot requires DHCP lease before the camera exposes an address
 - Proprietary LAN discovery observed on UDP `2000/3000`

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -25,9 +25,11 @@ Install flow notes:
 - unchanged binary hash skips reinstall/restart (unless install context flags are provided)
 - auto-update timer is enabled by default (`constitute-nvr-update.timer`)
 - updater rolls back binary when restart/health validation fails
+- installer now requires decoder-capable host `ffmpeg`; on Fedora-class hosts it provisions RPM Fusion codec support when HEVC decode is missing
 - install bootstrap now provisions the dedicated camera NIC, selects a non-colliding `/24`, and binds `dnsmasq` DHCP on that NIC
 - camera bootstrap must also leave the host serving NTP on the camera NIC
   - when chrony drop-ins are used, bootstrap now ensures the matching `confdir` line is present in `/etc/chrony.conf` so Fedora-class hosts actually load `/etc/chrony.d`
+- factory-static cameras on off-subnet defaults can be reached by provisioning explicit camera-NIC onboarding aliases (for example `192.168.0.2/24`)
 - source-build/dev installs are expected to update through `constitute-nvr-update.timer`; in-process source updates are intentionally skipped
 
 ## 2) Service Checks
@@ -68,6 +70,11 @@ Critical fields before ingest:
 - `autoprovision.reolink_*` (when auto-provision enabled)
 - `cameras[]`
 
+Camera-NIC onboarding aliases:
+- use `bootstrap-camera-network.sh --onboarding-alias <cidr>` to add explicit extra `/24` addresses on the dedicated camera NIC for factory-static cameras
+- when `--camera-cidr` is specified explicitly, bootstrap now honors that exact subnet instead of silently reselecting a neighboring `/24`
+- current discovery scans `/24` subnets already assigned to the camera NIC; it does not invent off-subnet reachability on its own
+
 ## 4) ONVIF Discovery Smoke
 
 ```bash
@@ -90,6 +97,14 @@ Notes:
   - `chronyd -p -f /etc/chrony.conf` should include the camera-subnet `allow` / `local` directives
   - `ss -ulpn | grep ':123 '` should show `chronyd` listening on UDP `123`
 - CGI setup path covers RTSP/ONVIF/P2P toggles when HTTP API is available; proprietary `9000` path remains fallback/R&D for HTTP-disabled devices.
+- For cheap generic/XM cameras that ship static on another `/24`, use onboarding aliases instead of this Reolink-only bootstrap path.
+- XM / NetSurveillance `40E` note:
+  - active driver is `xm_40e`, not the old generic `xm_rtsp` placeholder
+  - current recording uses video-only MP4 segmentation because the validated lab camera exposes `pcm_mulaw` audio that cannot be copied directly into MP4
+  - live preview for this camera requires HEVC decode on the host because the validated RTSP profiles are HEVC, not H.264
+  - site time for the lab XM camera is served from the host-side onboarding alias `192.168.0.2`
+  - the baked feed title is driven through `TitleOverlay.TitleUtf8`
+  - the hidden XM `UserOverlay` lane must stay cleared so stale lower-left text does not leak into the baked feed
 
 ## 6) Health Endpoint
 
@@ -142,7 +157,7 @@ sudo /usr/local/bin/constitute-nvr-self-update --service-name constitute-nvr --t
 ```
 
 ## Known POC Limits
-- depends on host `ffmpeg`
+- depends on installer-managed host `ffmpeg`; install now fails if HEVC decode support cannot be provisioned
 - release checksums are hash-verified but not signature-verified yet
 - TURN remains a documented stub; same-LAN and NAT-friendly direct ICE paths are the active target for this iteration
 

--- a/scripts/linux/bootstrap-camera-network.sh
+++ b/scripts/linux/bootstrap-camera-network.sh
@@ -9,6 +9,7 @@ CAMERA_CIDR=""
 HOST_IP=""
 DHCP_RANGE_START=""
 DHCP_RANGE_END=""
+declare -a ONBOARDING_ALIASES=()
 DNSMASQ_CONF="/etc/dnsmasq.d/constitute-nvr-camera.conf"
 CHRONY_DROPIN=""
 
@@ -31,6 +32,7 @@ Options:
   --host-ip <ip>             Host IP on camera subnet (default: .1)
   --dhcp-range-start <ip>    DHCP pool start (default: .50)
   --dhcp-range-end <ip>      DHCP pool end (default: .199)
+  --onboarding-alias <cidr>  Additional IPv4 alias on the camera NIC for factory-static cameras
   --print-env                Emit CAMERA_* shell assignments on success
   -h, --help                 Show help
 EOF
@@ -84,6 +86,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --dhcp-range-end)
       DHCP_RANGE_END="${2:?missing value for --dhcp-range-end}"
+      shift 2
+      ;;
+    --onboarding-alias)
+      ONBOARDING_ALIASES+=("${2:?missing value for --onboarding-alias}")
       shift 2
       ;;
     --print-env)
@@ -167,7 +173,7 @@ select_camera_iface() {
 
 derive_network_values() {
   local json
-  json="$(python3 - <<'PY'
+  json="$(CAMERA_CIDR="$CAMERA_CIDR" python3 - <<'PY'
 import ipaddress
 import json
 import os
@@ -208,7 +214,16 @@ candidates = [
 ]
 
 if requested:
-    candidates = [requested] + [c for c in candidates if c != requested]
+    chosen = ipaddress.ip_network(requested, strict=False)
+    data = {
+        "camera_cidr": str(chosen),
+        "host_ip": str(chosen.network_address + 1),
+        "dhcp_range_start": str(chosen.network_address + 50),
+        "dhcp_range_end": str(chosen.network_address + 199),
+        "prefix": chosen.prefixlen,
+    }
+    print(json.dumps(data))
+    sys.exit(0)
 
 chosen = None
 for candidate in candidates:
@@ -372,6 +387,9 @@ apply_networkmanager_config() {
     ipv4.never-default yes \
     ipv6.method disabled \
     >/dev/null
+  for alias in "${ONBOARDING_ALIASES[@]}"; do
+    run_sudo nmcli connection modify "$connection_name" +ipv4.addresses "$alias" >/dev/null
+  done
   run_sudo ip -4 addr flush dev "$CAMERA_IFACE" >/dev/null 2>&1 || true
   run_sudo nmcli connection up "$connection_name" ifname "$CAMERA_IFACE" >/dev/null
 }
@@ -411,6 +429,7 @@ CAMERA_CIDR=${CAMERA_CIDR}
 CAMERA_HOST_IP=${HOST_IP}
 CAMERA_DHCP_RANGE_START=${DHCP_RANGE_START}
 CAMERA_DHCP_RANGE_END=${DHCP_RANGE_END}
+CAMERA_ONBOARDING_ALIASES=${ONBOARDING_ALIASES[*]}
 EOF
 }
 

--- a/scripts/linux/install-wizard.sh
+++ b/scripts/linux/install-wizard.sh
@@ -118,6 +118,55 @@ require_cmd() {
   fi
 }
 
+ffmpeg_has_hevc_decoder() {
+  command -v ffmpeg >/dev/null 2>&1 || return 1
+  ffmpeg -decoders 2>/dev/null | awk '$2 == "hevc" { found = 1 } END { exit(found ? 0 : 1) }'
+}
+
+ensure_ffmpeg_preview_stack() {
+  if ffmpeg_has_hevc_decoder; then
+    return 0
+  fi
+
+  if command -v dnf >/dev/null 2>&1; then
+    local fedora_release=""
+    fedora_release="$(rpm -E %fedora 2>/dev/null || true)"
+    if [[ -z "$fedora_release" ]]; then
+      echo "unable to determine Fedora release for ffmpeg codec bootstrap" >&2
+      exit 1
+    fi
+
+    if ! rpm -q rpmfusion-free-release >/dev/null 2>&1 || ! rpm -q rpmfusion-nonfree-release >/dev/null 2>&1; then
+      log "installing RPM Fusion release repos for decoder-capable ffmpeg"
+      run_sudo dnf install -y \
+        "https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${fedora_release}.noarch.rpm" \
+        "https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${fedora_release}.noarch.rpm"
+    fi
+
+    if ! ffmpeg_has_hevc_decoder; then
+      log "installing HEVC-capable ffmpeg codec support"
+      run_sudo dnf install -y libavcodec-freeworld --allowerasing >/dev/null 2>&1 || true
+    fi
+
+    if ! ffmpeg_has_hevc_decoder; then
+      log "switching Fedora host from ffmpeg-free to full ffmpeg"
+      run_sudo dnf swap -y ffmpeg-free ffmpeg --allowerasing >/dev/null
+    fi
+  elif command -v apt-get >/dev/null 2>&1; then
+    log "installing ffmpeg via apt-get"
+    run_sudo apt-get update >/dev/null
+    run_sudo apt-get install -y ffmpeg >/dev/null
+  else
+    echo "unable to provision ffmpeg with HEVC decode support automatically" >&2
+    exit 1
+  fi
+
+  if ! ffmpeg_has_hevc_decoder; then
+    echo "ffmpeg is installed but still lacks HEVC decoder support; live preview for HEVC cameras cannot work" >&2
+    exit 1
+  fi
+}
+
 confirm() {
   local prompt="$1"
   local default_yes="$2"
@@ -443,6 +492,8 @@ fi
 require_cmd systemctl
 require_cmd curl
 require_cmd python3
+
+ensure_ffmpeg_preview_stack
 
 SRC_DIR=""
 TMP_DIR=""

--- a/src/camera.rs
+++ b/src/camera.rs
@@ -1,4 +1,5 @@
 use crate::config::{CameraConfig, Config};
+use crate::drivers::driver_is_xm;
 use anyhow::{Result, anyhow};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -136,24 +137,7 @@ async fn record_loop(
         let baseline_segments = count_segment_files(&out_dir).await?;
 
         let mut cmd = Command::new("ffmpeg");
-        cmd.arg("-hide_banner")
-            .arg("-loglevel")
-            .arg("warning")
-            .arg("-rtsp_transport")
-            .arg("tcp")
-            .arg("-i")
-            .arg(&cam.rtsp_url)
-            .arg("-c")
-            .arg("copy")
-            .arg("-f")
-            .arg("segment")
-            .arg("-segment_time")
-            .arg(cam.segment_secs.to_string())
-            .arg("-reset_timestamps")
-            .arg("1")
-            .arg("-strftime")
-            .arg("1")
-            .arg(output_pattern.to_string_lossy().to_string())
+        cmd.args(build_ffmpeg_record_args(&cam, &output_pattern))
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .kill_on_drop(true);
@@ -256,6 +240,40 @@ fn backoff_secs(attempt: u64) -> u64 {
     let p = attempt.clamp(1, 6);
     let secs = 2_u64.pow(p as u32);
     secs.min(30)
+}
+
+fn build_ffmpeg_record_args(cam: &CameraConfig, output_pattern: &std::path::Path) -> Vec<String> {
+    let mut args = vec![
+        "-hide_banner".to_string(),
+        "-loglevel".to_string(),
+        "warning".to_string(),
+        "-rtsp_transport".to_string(),
+        "tcp".to_string(),
+        "-i".to_string(),
+        cam.rtsp_url.clone(),
+    ];
+    if driver_is_xm(&cam.driver_id) {
+        args.extend([
+            "-map".to_string(),
+            "0:v:0".to_string(),
+            "-c:v".to_string(),
+            "copy".to_string(),
+        ]);
+    } else {
+        args.extend(["-c".to_string(), "copy".to_string()]);
+    }
+    args.extend([
+        "-f".to_string(),
+        "segment".to_string(),
+        "-segment_time".to_string(),
+        cam.segment_secs.to_string(),
+        "-reset_timestamps".to_string(),
+        "1".to_string(),
+        "-strftime".to_string(),
+        "1".to_string(),
+        output_pattern.to_string_lossy().to_string(),
+    ]);
+    args
 }
 
 async fn update_state(
@@ -380,5 +398,32 @@ mod tests {
         assert_eq!(backoff_secs(1), 2);
         assert_eq!(backoff_secs(2), 4);
         assert_eq!(backoff_secs(8), 30);
+    }
+
+    #[test]
+    fn xm_record_args_use_video_only_copy() {
+        let camera = CameraConfig {
+            source_id: "xm-1".to_string(),
+            name: "XM".to_string(),
+            onvif_host: "192.168.0.201".to_string(),
+            onvif_port: 8000,
+            rtsp_url: "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream".to_string(),
+            username: "admin".to_string(),
+            password: "123456".to_string(),
+            driver_id: "xm_40e".to_string(),
+            vendor: "XM/NetSurveillance".to_string(),
+            model: "XM RTSP camera".to_string(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: Default::default(),
+            credentials: Default::default(),
+        };
+        let args = build_ffmpeg_record_args(&camera, &PathBuf::from("/tmp/out-%Y%m%dT%H%M%S.mp4"));
+        assert!(args.windows(2).any(|pair| pair == ["-map", "0:v:0"]));
+        assert!(args.windows(2).any(|pair| pair == ["-c:v", "copy"]));
+        assert!(!args.windows(2).any(|pair| pair == ["-c", "copy"]));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -734,13 +734,23 @@ fn apply_camera_defaults(camera: &mut CameraConfig, _network: &CameraNetworkConf
     if camera.driver_id.trim().is_empty() {
         camera.driver_id = if camera.source_id.trim().starts_with("reolink-") {
             "reolink".to_string()
+        } else if camera.source_id.trim().starts_with("xm-") {
+            "xm_40e".to_string()
         } else {
             "generic_onvif_rtsp".to_string()
         };
         changed = true;
     }
+    if camera.driver_id.trim() == "xm_rtsp" {
+        camera.driver_id = "xm_40e".to_string();
+        changed = true;
+    }
     if camera.vendor.trim().is_empty() && camera.driver_id == "reolink" {
         camera.vendor = "Reolink".to_string();
+        changed = true;
+    }
+    if camera.vendor.trim().is_empty() && camera.driver_id == "xm_40e" {
+        camera.vendor = "XM/NetSurveillance".to_string();
         changed = true;
     }
     if camera.model.trim().is_empty() {
@@ -766,7 +776,10 @@ fn apply_camera_defaults(camera: &mut CameraConfig, _network: &CameraNetworkConf
         camera.desired.display_name = camera.name.trim().to_string();
         changed = true;
     }
-    if camera.desired.overlay_text.trim().is_empty() && !camera.name.trim().is_empty() {
+    if camera.driver_id != "xm_40e"
+        && camera.desired.overlay_text.trim().is_empty()
+        && !camera.name.trim().is_empty()
+    {
         camera.desired.overlay_text = camera.name.trim().to_string();
         changed = true;
     }
@@ -1500,5 +1513,36 @@ mod tests {
         assert!(camera.ptz_capable);
         assert_eq!(camera.desired.overlay_text, "Reolink E1 Outdoor SE");
         assert_eq!(camera.desired.display_name, "Reolink E1 Outdoor SE");
+    }
+
+    #[test]
+    fn apply_defaults_migrates_legacy_xm_driver_to_xm_40e() {
+        let mut cfg = Config::default_generated();
+        cfg.cameras.push(CameraConfig {
+            source_id: "xm-192-168-0-201".to_string(),
+            name: "XM Camera".to_string(),
+            onvif_host: "192.168.0.201".to_string(),
+            onvif_port: 8000,
+            rtsp_url: "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream".to_string(),
+            username: "admin".to_string(),
+            password: "123456".to_string(),
+            driver_id: "xm_rtsp".to_string(),
+            vendor: String::new(),
+            model: String::new(),
+            mac_address: String::new(),
+            rtsp_port: 0,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig::default(),
+            credentials: CameraCredentialState::default(),
+        });
+
+        cfg.apply_defaults();
+        let camera = &cfg.cameras[0];
+        assert_eq!(camera.driver_id, "xm_40e");
+        assert_eq!(camera.vendor, "XM/NetSurveillance");
+        assert_eq!(camera.desired.display_name, "XM Camera");
+        assert_eq!(camera.desired.overlay_text, "");
     }
 }

--- a/src/drivers.rs
+++ b/src/drivers.rs
@@ -7,19 +7,26 @@ use crate::config::{
 use crate::onvif;
 use crate::reolink;
 use crate::reolink_cgi;
+use crate::xm;
 use anyhow::{Context, Result, anyhow};
-use chrono::{DateTime, LocalResult, NaiveDateTime, TimeZone, Utc};
+use chrono::{DateTime, LocalResult, NaiveDateTime, Offset, TimeZone, Utc};
 use chrono_tz::Tz;
+use futures_util::stream::{self, StreamExt};
 use regex::Regex;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
+use std::net::Ipv4Addr;
+use std::process::Command;
 use tokio::net::TcpStream;
+use tokio::process::Command as TokioCommand;
 use tokio::time::{Duration, Instant, sleep, timeout};
 
 pub const DRIVER_ID_REOLINK: &str = "reolink";
+pub const DRIVER_ID_XM_40E: &str = "xm_40e";
+pub const DRIVER_ID_XM_RTSP: &str = "xm_rtsp";
 pub const DRIVER_ID_GENERIC_ONVIF_RTSP: &str = "generic_onvif_rtsp";
 const REOLINK_NATIVE_PTZ_SETTLE_TIMEOUT_MS: u64 = 5_000;
 const REOLINK_NATIVE_PTZ_POLL_INTERVAL_MS: u64 = 250;
@@ -268,6 +275,7 @@ pub struct ProbeCameraRequest {
 }
 
 struct ReolinkDriver;
+struct Xm40eDriver;
 struct GenericOnvifRtspDriver;
 
 impl CameraDriver for ReolinkDriver {
@@ -342,6 +350,35 @@ impl CameraDriver for GenericOnvifRtspDriver {
     }
 }
 
+impl CameraDriver for Xm40eDriver {
+    fn match_candidate(&self, candidate: &DiscoveredCameraCandidate) -> Option<DriverMatch> {
+        if !candidate_looks_like_xm(candidate) || !candidate.transports.rtsp {
+            return None;
+        }
+        Some(DriverMatch {
+            driver_id: DRIVER_ID_XM_40E.to_string(),
+            kind: "vendor_driver".to_string(),
+            confidence: if candidate.transports.onvif { 88 } else { 82 },
+            reason: "matched XM/NetSurveillance 40E-class footprint".to_string(),
+            mountable: true,
+        })
+    }
+
+    fn capabilities(&self, _camera: &CameraConfig) -> CameraCapabilitySet {
+        CameraCapabilitySet {
+            live_view: true,
+            ptz: false,
+            time_sync: true,
+            manual_time: false,
+            timezone: true,
+            overlay_text: false,
+            overlay_timestamp: false,
+            raw_probe: true,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 struct LeaseEntry {
     ip: String,
@@ -374,6 +411,60 @@ fn site_time_policy(cfg: &Config) -> SiteTimePolicy {
     }
 }
 
+pub fn driver_is_xm(driver_id: &str) -> bool {
+    matches!(
+        driver_id.trim(),
+        DRIVER_ID_XM_40E | DRIVER_ID_XM_RTSP
+    )
+}
+
+fn same_ipv4_subnet(left: Ipv4Addr, right: Ipv4Addr, prefix: u8) -> bool {
+    if prefix > 32 {
+        return false;
+    }
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (u32::from(left) & mask) == (u32::from(right) & mask)
+}
+
+fn effective_ntp_server_for_camera(cfg: &Config, camera: &CameraConfig) -> Option<String> {
+    let host = camera.onvif_host.trim().parse::<Ipv4Addr>().ok()?;
+    let iface = cfg.camera_network.interface.trim();
+    if iface.is_empty() {
+        return None;
+    }
+    interface_ipv4_cidrs(iface).into_iter().find_map(|(addr, prefix)| {
+        same_ipv4_subnet(addr, host, prefix).then(|| addr.to_string())
+    })
+}
+
+fn effective_site_time_policy(cfg: &Config, camera: &CameraConfig) -> SiteTimePolicy {
+    let mut policy = site_time_policy(cfg);
+    if let Some(ntp_server) = effective_ntp_server_for_camera(cfg, camera) {
+        policy.ntp_server = ntp_server;
+    }
+    policy
+}
+
+fn site_timezone_code(site_timezone: &str, now_utc: DateTime<Utc>) -> Option<i32> {
+    let tz: Tz = site_timezone.trim().parse().ok()?;
+    let local = now_utc.with_timezone(&tz);
+    Some(local.offset().fix().local_minus_utc() / 60 + 720)
+}
+
+fn site_local_time_string_for_xm(site_timezone: &str, now_utc: DateTime<Utc>) -> Option<String> {
+    let tz: Tz = site_timezone.trim().parse().ok()?;
+    Some(
+        now_utc
+            .with_timezone(&tz)
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string(),
+    )
+}
+
 fn observed_site_time_offset_secs(
     site_timezone: &str,
     observed_manual_time: &str,
@@ -388,6 +479,22 @@ fn observed_site_time_offset_secs(
         LocalResult::None => return None,
     };
     Some((local.with_timezone(&Utc) - now_utc).num_seconds().abs())
+}
+
+fn observed_timezone_matches(policy: &SiteTimePolicy, observed: &ObservedCameraState) -> bool {
+    if policy.timezone.trim().is_empty() {
+        return true;
+    }
+    if policy.timezone.trim() == observed.timezone.trim() {
+        return true;
+    }
+    observed
+        .raw
+        .get("time")
+        .and_then(|value| value.get("timezoneCode"))
+        .and_then(Value::as_i64)
+        .and_then(|code| site_timezone_code(&policy.timezone, Utc::now()).map(|expected| code == expected as i64))
+        .unwrap_or(false)
 }
 
 fn site_local_time_string(site_timezone: &str, now_utc: DateTime<Utc>) -> Option<String> {
@@ -511,6 +618,32 @@ pub async fn discover_candidates(cfg: &Config) -> Result<Vec<DiscoveredCameraCan
         candidate.transports.proprietary_9000 = true;
     }
 
+    for discovered in discover_interface_scan_candidates(cfg).await {
+        let candidate = map
+            .entry(discovered.ip.clone())
+            .or_insert_with(|| blank_candidate(&discovered.ip));
+        candidate.mac = first_nonempty(&candidate.mac, &discovered.mac);
+        candidate.lease_hostname =
+            first_nonempty(&candidate.lease_hostname, &discovered.lease_hostname);
+        for seen in &discovered.discovered_via {
+            push_unique_string(&mut candidate.discovered_via, seen);
+        }
+        candidate.signatures.vendor =
+            first_nonempty(&candidate.signatures.vendor, &discovered.signatures.vendor);
+        candidate.signatures.model =
+            first_nonempty(&candidate.signatures.model, &discovered.signatures.model);
+        candidate.signatures.public_title = first_nonempty(
+            &candidate.signatures.public_title,
+            &discovered.signatures.public_title,
+        );
+        candidate.transports.http = candidate.transports.http || discovered.transports.http;
+        candidate.transports.https = candidate.transports.https || discovered.transports.https;
+        candidate.transports.rtsp = candidate.transports.rtsp || discovered.transports.rtsp;
+        candidate.transports.onvif = candidate.transports.onvif || discovered.transports.onvif;
+        candidate.transports.proprietary_9000 =
+            candidate.transports.proprietary_9000 || discovered.transports.proprietary_9000;
+    }
+
     let client = http_client()?;
     for candidate in map.values_mut() {
         hydrate_candidate(candidate, &client).await?;
@@ -571,8 +704,12 @@ pub async fn mount_candidate(
         segment_secs: 10,
         desired: CameraDesiredConfig {
             display_name: display_name.clone(),
-            overlay_text: display_name.clone(),
-            overlay_timestamp: true,
+            overlay_text: if driver_is_xm(&driver_match.driver_id) {
+                String::new()
+            } else {
+                display_name.clone()
+            },
+            overlay_timestamp: !driver_is_xm(&driver_match.driver_id),
             desired_password: request.desired_password.trim().to_string(),
             generate_password: request.generate_password,
             ..Default::default()
@@ -639,6 +776,10 @@ pub async fn apply_mounted_camera(
 fn sync_display_name_and_linked_overlay(existing: &CameraConfig, next: &mut CameraConfig) {
     let requested_display_name = next.desired.display_name.trim();
     if requested_display_name.is_empty() {
+        return;
+    }
+    if driver_is_xm(&existing.driver_id) || driver_is_xm(&next.driver_id) {
+        next.name = requested_display_name.to_string();
         return;
     }
     let previous_display_name = camera_display_name(existing);
@@ -708,6 +849,18 @@ pub async fn probe_camera(cfg: &Config, request: ProbeCameraRequest) -> Result<V
             Ok(result) => result,
             Err(error) => json!({
                 "driverId": DRIVER_ID_REOLINK,
+                "status": "error",
+                "message": error.to_string(),
+            }),
+        }
+    } else if driver_is_xm(effective_driver)
+        && !request.username.trim().is_empty()
+        && !request.password.trim().is_empty()
+    {
+        match probe_xm_candidate(&candidate, &request).await {
+            Ok(result) => result,
+            Err(error) => json!({
+                "driverId": DRIVER_ID_XM_40E,
                 "status": "error",
                 "message": error.to_string(),
             }),
@@ -1532,11 +1685,11 @@ pub async fn read_mounted_camera(cfg: &Config, camera: &CameraConfig) -> Mounted
             let capabilities =
                 capabilities_for_observed(camera, base_capabilities.clone(), &observed);
             let display_name = first_nonempty(&observed.display_name, &camera_display_name(camera));
-            let vendor = first_nonempty(&camera.vendor, &observed.vendor);
-            let model = first_nonempty(&camera.model, &observed.model);
+            let vendor = first_nonempty(&observed.vendor, &camera.vendor);
+            let model = first_nonempty(&observed.model, &camera.model);
             MountedCamera {
                 source_id: camera.source_id.clone(),
-                driver_id: camera.driver_id.clone(),
+                driver_id: first_nonempty(&observed.driver_id, &camera.driver_id),
                 display_name,
                 vendor,
                 model,
@@ -1565,8 +1718,8 @@ pub async fn read_mounted_camera(cfg: &Config, camera: &CameraConfig) -> Mounted
             let capabilities =
                 capabilities_for_observed(camera, base_capabilities.clone(), &observed);
             let display_name = first_nonempty(&observed.display_name, &camera_display_name(camera));
-            let vendor = first_nonempty(&camera.vendor, &observed.vendor);
-            let model = first_nonempty(&camera.model, &observed.model);
+            let vendor = first_nonempty(&observed.vendor, &camera.vendor);
+            let model = first_nonempty(&observed.model, &camera.model);
             MountedCamera {
                 source_id: camera.source_id.clone(),
                 driver_id: camera.driver_id.clone(),
@@ -1600,6 +1753,9 @@ fn match_candidate(candidate: &DiscoveredCameraCandidate) -> DriverMatch {
     if let Some(matched) = ReolinkDriver.match_candidate(candidate) {
         return matched;
     }
+    if let Some(matched) = Xm40eDriver.match_candidate(candidate) {
+        return matched;
+    }
     if let Some(matched) = GenericOnvifRtspDriver.match_candidate(candidate) {
         return matched;
     }
@@ -1613,15 +1769,19 @@ fn match_candidate(candidate: &DiscoveredCameraCandidate) -> DriverMatch {
 }
 
 fn driver_capabilities(camera: &CameraConfig) -> CameraCapabilitySet {
-    match camera.driver_id.trim() {
-        DRIVER_ID_REOLINK => ReolinkDriver.capabilities(camera),
-        DRIVER_ID_GENERIC_ONVIF_RTSP => GenericOnvifRtspDriver.capabilities(camera),
-        _ => CameraCapabilitySet {
+    if camera.driver_id.trim() == DRIVER_ID_REOLINK {
+        ReolinkDriver.capabilities(camera)
+    } else if driver_is_xm(&camera.driver_id) {
+        Xm40eDriver.capabilities(camera)
+    } else if camera.driver_id.trim() == DRIVER_ID_GENERIC_ONVIF_RTSP {
+        GenericOnvifRtspDriver.capabilities(camera)
+    } else {
+        CameraCapabilitySet {
             live_view: true,
             ptz: camera.ptz_capable,
             raw_probe: true,
             ..Default::default()
-        },
+        }
     }
 }
 
@@ -1720,6 +1880,9 @@ async fn apply_driver_mount(cfg: &Config, camera: &CameraConfig) -> Result<Camer
     if camera.driver_id.trim() == DRIVER_ID_REOLINK {
         return apply_driver_desired(cfg, camera, camera).await;
     }
+    if driver_is_xm(&camera.driver_id) {
+        return apply_xm_40e_desired(cfg, camera, camera).await;
+    }
     Ok(camera.clone())
 }
 
@@ -1728,15 +1891,19 @@ async fn apply_driver_desired(
     existing: &CameraConfig,
     next: &CameraConfig,
 ) -> Result<CameraConfig> {
-    match next.driver_id.trim() {
-        DRIVER_ID_REOLINK => apply_reolink_desired(cfg, existing, next).await,
-        DRIVER_ID_GENERIC_ONVIF_RTSP => apply_generic_onvif_desired(cfg, next).await,
-        _ => Ok(next.clone()),
+    if next.driver_id.trim() == DRIVER_ID_REOLINK {
+        apply_reolink_desired(cfg, existing, next).await
+    } else if driver_is_xm(&next.driver_id) {
+        apply_xm_40e_desired(cfg, existing, next).await
+    } else if next.driver_id.trim() == DRIVER_ID_GENERIC_ONVIF_RTSP {
+        apply_generic_onvif_desired(cfg, next).await
+    } else {
+        Ok(next.clone())
     }
 }
 
 async fn apply_generic_onvif_desired(cfg: &Config, next: &CameraConfig) -> Result<CameraConfig> {
-    let policy = site_time_policy(cfg);
+    let policy = effective_site_time_policy(cfg, next);
     if !policy.ntp_enabled {
         return Ok(next.clone());
     }
@@ -1749,6 +1916,50 @@ async fn apply_generic_onvif_desired(cfg: &Config, next: &CameraConfig) -> Resul
     )
     .await;
     Ok(next.clone())
+}
+
+async fn apply_xm_40e_desired(
+    cfg: &Config,
+    _existing: &CameraConfig,
+    next: &CameraConfig,
+) -> Result<CameraConfig> {
+    let _ = ffprobe_rtsp_stream(&next.rtsp_url)
+        .await
+        .with_context(|| format!("XM RTSP apply validation failed for {}", next.onvif_host))?;
+    let request = xm_connect_request(next)?;
+    let policy = effective_site_time_policy(cfg, next);
+    let desired_display_title = nonempty_option(&camera_display_name(next));
+    let site_time = if policy.ntp_enabled
+        && !policy.ntp_server.trim().is_empty()
+        && !policy.timezone.trim().is_empty()
+    {
+        Some(xm::XmSiteTimePolicy {
+            ntp_server: policy.ntp_server.clone(),
+            timezone_code: site_timezone_code(&policy.timezone, Utc::now())
+                .ok_or_else(|| anyhow!("invalid site timezone {:?}", policy.timezone))?,
+            current_local_time: site_local_time_string_for_xm(&policy.timezone, Utc::now())
+                .ok_or_else(|| anyhow!("invalid site timezone {:?}", policy.timezone))?,
+        })
+    } else {
+        None
+    };
+    let applied = xm::apply_state(
+        &request,
+        desired_display_title.as_deref(),
+        None,
+        site_time.as_ref(),
+    )
+    .await?;
+    let model = applied.system.model_family.trim();
+    let mut updated = next.clone();
+    updated.driver_id = DRIVER_ID_XM_40E.to_string();
+    updated.vendor = "XM/NetSurveillance".to_string();
+    if !model.is_empty() {
+        updated.model = model.to_string();
+    }
+    updated.desired.overlay_text.clear();
+    updated.desired.overlay_timestamp = false;
+    Ok(updated)
 }
 
 async fn apply_reolink_desired(
@@ -2237,9 +2448,12 @@ async fn restore_reolink_onvif_protocols(
 }
 
 async fn read_observed_state(camera: &CameraConfig) -> Result<ObservedCameraState> {
-    match camera.driver_id.trim() {
-        DRIVER_ID_REOLINK => read_reolink_observed_state(camera).await,
-        _ => read_generic_observed_state(camera).await,
+    if camera.driver_id.trim() == DRIVER_ID_REOLINK {
+        read_reolink_observed_state(camera).await
+    } else if driver_is_xm(&camera.driver_id) {
+        read_xm_observed_state(camera).await
+    } else {
+        read_generic_observed_state(camera).await
     }
 }
 
@@ -2601,6 +2815,117 @@ async fn probe_reolink_candidate(
     ))
 }
 
+fn xm_connect_request(camera: &CameraConfig) -> Result<xm::XmConnectRequest> {
+    let host = camera.onvif_host.trim();
+    let username = camera.username.trim();
+    let password = camera.password.trim();
+    if host.is_empty() {
+        return Err(anyhow!("XM host is not configured"));
+    }
+    if username.is_empty() || password.is_empty() {
+        return Err(anyhow!(
+            "XM management credentials are required for {}",
+            camera.source_id
+        ));
+    }
+    Ok(xm::XmConnectRequest {
+        host: host.to_string(),
+        username: username.to_string(),
+        password: password.to_string(),
+    })
+}
+
+async fn probe_xm_candidate(
+    candidate: &DiscoveredCameraCandidate,
+    request: &ProbeCameraRequest,
+) -> Result<Value> {
+    let xm_request = xm::XmConnectRequest {
+        host: candidate.ip.trim().to_string(),
+        username: request.username.trim().to_string(),
+        password: request.password.trim().to_string(),
+    };
+    let xm_state = xm::read_state(&xm_request)
+        .await
+        .context("XM management probe failed")?;
+    let main_url = derive_rtsp_url(
+        candidate,
+        DRIVER_ID_XM_40E,
+        request.username.trim(),
+        request.password.trim(),
+        "",
+    );
+    let preview_url = xm_preview_rtsp_url(&main_url);
+    let main = ffprobe_rtsp_stream(&main_url)
+        .await
+        .context("XM RTSP main stream probe failed")?;
+    let preview = ffprobe_rtsp_stream(&preview_url)
+        .await
+        .unwrap_or(Value::Null);
+    let ports = probe_common_ports(&candidate.ip).await;
+    Ok(json!({
+        "driverId": DRIVER_ID_XM_40E,
+        "status": "ok",
+        "message": "XM 40E management and RTSP paths authenticated and returned live state.",
+        "observed": {
+            "vendor": xm_state.system.vendor,
+            "model": xm_state.system.model_family,
+            "ip": candidate.ip,
+            "displayName": xm_state.video.title_text,
+            "timeMode": xm_state.time.time_mode,
+            "ntpServer": xm_state.time.ntp_server,
+            "manualTime": xm_state.time.current_time_iso,
+            "timezone": xm_state.time.timezone_offset_label,
+        },
+        "services": {
+            "managementPlane": DRIVER_ID_XM_40E,
+            "http": ports.http,
+            "https": ports.https,
+            "rtsp": ports.rtsp,
+            "onvif": ports.onvif,
+            "proprietary9000": ports.proprietary_9000,
+        },
+        "raw": {
+            "managementPlane": DRIVER_ID_XM_40E,
+            "system": xm_state.system,
+            "time": xm_state.time,
+            "video": xm_state.video,
+            "mainStream": main,
+            "previewStream": preview,
+        }
+    }))
+}
+
+async fn ffprobe_rtsp_stream(url: &str) -> Result<Value> {
+    let output = timeout(
+        Duration::from_secs(12),
+        TokioCommand::new("ffprobe")
+            .arg("-v")
+            .arg("error")
+            .arg("-rtsp_transport")
+            .arg("tcp")
+            .arg("-timeout")
+            .arg("5000000")
+            .arg("-i")
+            .arg(url)
+            .arg("-show_entries")
+            .arg("stream=codec_name,codec_type,width,height")
+            .arg("-of")
+            .arg("json")
+            .output(),
+    )
+    .await
+    .context("ffprobe timed out")??;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!(if stderr.is_empty() {
+            "ffprobe failed to read stream".to_string()
+        } else {
+            stderr
+        }));
+    }
+    serde_json::from_slice(&output.stdout).context("ffprobe returned invalid json")
+}
+
 async fn read_generic_observed_state(camera: &CameraConfig) -> Result<ObservedCameraState> {
     let ports = probe_common_ports(&camera.onvif_host).await;
     if ports.onvif {
@@ -2681,6 +3006,49 @@ async fn read_generic_observed_state(camera: &CameraConfig) -> Result<ObservedCa
     })
 }
 
+async fn read_xm_observed_state(camera: &CameraConfig) -> Result<ObservedCameraState> {
+    let ports = probe_common_ports(&camera.onvif_host).await;
+    let xm_state = xm::read_state(&xm_connect_request(camera)?).await?;
+    Ok(ObservedCameraState {
+        display_name: first_nonempty(&xm_state.video.title_text, &camera_display_name(camera)),
+        driver_id: DRIVER_ID_XM_40E.to_string(),
+        vendor: first_nonempty(&xm_state.system.vendor, "XM/NetSurveillance"),
+        model: first_nonempty(&xm_state.system.model_family, "XM Camera"),
+        ip: camera.onvif_host.clone(),
+        mac_address: camera.mac_address.clone(),
+        time_mode: xm_state.time.time_mode.clone(),
+        ntp_server: xm_state.time.ntp_server.clone(),
+        manual_time: xm_state.time.current_time_iso.clone(),
+        timezone: xm_state.time.timezone_offset_label.clone(),
+        overlay_text: xm_state.video.user_title_text.clone(),
+        overlay_timestamp: None,
+        ptz_capable: false,
+        current_pose: CameraPose::default(),
+        pose_status: "unsupported".to_string(),
+        pose_source: String::new(),
+        services: json!({
+            "managementPlane": DRIVER_ID_XM_40E,
+            "timeManagementPlane": "xm_time_config",
+            "nameManagementPlane": "xm_osd_title",
+            "http": ports.http,
+            "https": ports.https,
+            "rtsp": ports.rtsp,
+            "onvif": ports.onvif,
+            "proprietary9000": ports.proprietary_9000,
+            "serialNumber": xm_state.system.serial_number,
+            "firmwareVersion": xm_state.system.firmware_version,
+        }),
+        raw: json!({
+            "managementPlane": DRIVER_ID_XM_40E,
+            "timeManagementPlane": "xm_time_config",
+            "nameManagementPlane": "xm_osd_title",
+            "system": xm_state.system,
+            "time": xm_state.time,
+            "video": xm_state.video,
+        }),
+    })
+}
+
 async fn fallback_observed_state(camera: &CameraConfig) -> ObservedCameraState {
     let ports = probe_common_ports(&camera.onvif_host).await;
     ObservedCameraState {
@@ -2721,7 +3089,7 @@ fn verification_for_observed(
     capabilities: &CameraCapabilitySet,
     failed_fields: Vec<String>,
 ) -> CameraReconcileResult {
-    let site_time = site_time_policy(cfg);
+    let site_time = effective_site_time_policy(cfg, camera);
     let mut drift_fields = Vec::new();
     if !camera.desired.display_name.trim().is_empty()
         && camera.desired.display_name.trim() != observed.display_name.trim()
@@ -2747,7 +3115,7 @@ fn verification_for_observed(
     if capabilities.timezone
         && site_time.ntp_enabled
         && !site_time.timezone.trim().is_empty()
-        && site_time.timezone.trim() != observed.timezone.trim()
+        && !observed_timezone_matches(&site_time, observed)
     {
         drift_fields.push("timezone".to_string());
     }
@@ -2803,7 +3171,7 @@ fn applied_fields(
     camera: &CameraConfig,
     capabilities: &CameraCapabilitySet,
 ) -> Vec<String> {
-    let site_time = site_time_policy(cfg);
+    let site_time = effective_site_time_policy(cfg, camera);
     let mut fields = vec!["display_name".to_string()];
     if capabilities.time_sync && site_time.ntp_enabled {
         fields.extend(
@@ -2834,7 +3202,7 @@ fn unsupported_fields(
     camera: &CameraConfig,
     capabilities: &CameraCapabilitySet,
 ) -> Vec<String> {
-    let site_time = site_time_policy(cfg);
+    let site_time = effective_site_time_policy(cfg, camera);
     let mut fields = Vec::new();
     if !capabilities.time_sync && site_time.ntp_enabled {
         fields.push("ntp_server".to_string());
@@ -2872,11 +3240,27 @@ async fn hydrate_candidate(
     candidate.transports.onvif = candidate.transports.onvif || probe.onvif;
     candidate.transports.proprietary_9000 =
         candidate.transports.proprietary_9000 || probe.proprietary_9000;
-    if candidate.signatures.public_title.trim().is_empty() {
-        candidate.signatures.public_title =
-            fetch_public_title(client, &candidate.ip, probe.http, probe.https)
-                .await
-                .unwrap_or_default();
+    let fingerprint = if candidate.signatures.public_title.trim().is_empty()
+        || candidate.signatures.vendor.trim().is_empty()
+        || candidate.signatures.model.trim().is_empty()
+    {
+        fetch_http_fingerprint(client, &candidate.ip, probe.http, probe.https)
+            .await
+            .unwrap_or_default()
+    } else {
+        HttpFingerprint::default()
+    };
+    if candidate.signatures.public_title.trim().is_empty() && !fingerprint.title.trim().is_empty() {
+        candidate.signatures.public_title = fingerprint.title.clone();
+    }
+    if is_xm_http_fingerprint(&fingerprint) {
+        candidate.signatures.vendor =
+            first_nonempty(&candidate.signatures.vendor, "XM/NetSurveillance");
+        candidate.signatures.model =
+            first_nonempty(&candidate.signatures.model, "XM 40E-class camera");
+        if candidate.signatures.public_title.trim().is_empty() {
+            candidate.signatures.public_title = "XM/NetSurveillance 40E-class camera".to_string();
+        }
     }
     if candidate.signatures.vendor.trim().is_empty() {
         candidate.signatures.vendor = vendor_from_candidate(candidate);
@@ -2962,6 +3346,8 @@ fn build_source_id(candidate: &DiscoveredCameraCandidate, driver_id: &str) -> St
             format!("reolink-{}", candidate.signatures.reolink_uid.trim())
         } else if driver_id == DRIVER_ID_REOLINK {
             format!("reolink-{}", candidate.ip.trim())
+        } else if driver_is_xm(driver_id) {
+            format!("xm-{}", candidate.ip.trim())
         } else {
             format!(
                 "camera-{}-{}",
@@ -2992,6 +3378,8 @@ fn derive_vendor(candidate: &DiscoveredCameraCandidate, driver_id: &str) -> Stri
         candidate.signatures.vendor.trim().to_string()
     } else if driver_id == DRIVER_ID_REOLINK {
         "Reolink".to_string()
+    } else if driver_is_xm(driver_id) {
+        "XM/NetSurveillance".to_string()
     } else {
         "ONVIF/RTSP".to_string()
     }
@@ -3035,7 +3423,26 @@ fn derive_rtsp_url(
             candidate.ip.trim()
         );
     }
+    if driver_is_xm(driver_id) {
+        let user = if username.trim().is_empty() {
+            "admin"
+        } else {
+            username.trim()
+        };
+        let pass = password.trim();
+        return format!(
+            "rtsp://{auth}{}:554/user={}_password={}_channel=1_stream=0.sdp?real_stream",
+            candidate.ip.trim(),
+            user,
+            pass
+        );
+    }
     format!("rtsp://{auth}{}:554/", candidate.ip.trim())
+}
+
+fn xm_preview_rtsp_url(url: &str) -> String {
+    url.replace("_stream=0.sdp?real_stream", "_stream=1.sdp?real_stream")
+        .replace("_stream=0.sdp", "_stream=1.sdp")
 }
 
 fn normalize_camera_defaults(cfg: &Config, camera: &mut CameraConfig) {
@@ -3151,11 +3558,27 @@ fn vendor_from_candidate(candidate: &DiscoveredCameraCandidate) -> String {
     let title = candidate.signatures.public_title.to_ascii_lowercase();
     if title.contains("reolink") || !candidate.signatures.reolink_uid.trim().is_empty() {
         "Reolink".to_string()
+    } else if candidate_looks_like_xm(candidate) {
+        "XM/NetSurveillance".to_string()
     } else if candidate.transports.onvif || candidate.transports.rtsp {
         "ONVIF/RTSP".to_string()
     } else {
         String::new()
     }
+}
+
+fn candidate_looks_like_xm(candidate: &DiscoveredCameraCandidate) -> bool {
+    let vendor = candidate.signatures.vendor.to_ascii_lowercase();
+    let model = candidate.signatures.model.to_ascii_lowercase();
+    let title = candidate.signatures.public_title.to_ascii_lowercase();
+    vendor.contains("xm")
+        || vendor.contains("netsurveillance")
+        || model.contains("40e")
+        || model.contains("xm rtsp")
+        || model.contains("netsurveillance")
+        || title.contains("40e")
+        || title.contains("xm")
+        || title.contains("netsurveillance")
 }
 
 fn model_from_candidate(candidate: &DiscoveredCameraCandidate) -> String {
@@ -3184,6 +3607,82 @@ fn parse_lease_file(path: &str) -> Vec<LeaseEntry> {
             })
         })
         .collect()
+}
+
+async fn discover_interface_scan_candidates(cfg: &Config) -> Vec<DiscoveredCameraCandidate> {
+    let ips = camera_interface_scan_ips(cfg);
+    if ips.is_empty() {
+        return Vec::new();
+    }
+    stream::iter(ips)
+        .map(|ip| async move { active_scan_candidate(&ip).await })
+        .buffer_unordered(96)
+        .filter_map(|candidate| async move { candidate })
+        .collect::<Vec<_>>()
+        .await
+}
+
+fn camera_interface_scan_ips(cfg: &Config) -> Vec<String> {
+    let iface = cfg.camera_network.interface.trim();
+    if iface.is_empty() {
+        return Vec::new();
+    }
+    let primary_host = cfg.camera_network.host_ip.trim();
+    let mut out = HashSet::new();
+    for (addr, prefix) in interface_ipv4_cidrs(iface) {
+        if !primary_host.is_empty() && addr.to_string() == primary_host {
+            continue;
+        }
+        if prefix != 24 {
+            continue;
+        }
+        let network = u32::from(addr) & 0xFFFF_FF00;
+        for host in 1..=254u32 {
+            let ip = Ipv4Addr::from(network + host);
+            if ip == addr {
+                continue;
+            }
+            out.insert(ip.to_string());
+        }
+    }
+    let mut sorted = out.into_iter().collect::<Vec<_>>();
+    sorted.sort();
+    sorted
+}
+
+fn interface_ipv4_cidrs(iface: &str) -> Vec<(Ipv4Addr, u8)> {
+    let output = match Command::new("ip")
+        .args(["-4", "-o", "addr", "show", "dev", iface.trim()])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return Vec::new(),
+    };
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let parts = line.split_whitespace().collect::<Vec<_>>();
+            let idx = parts.iter().position(|part| *part == "inet")?;
+            let cidr = parts.get(idx + 1)?.trim();
+            let (ip, prefix) = cidr.split_once('/')?;
+            Some((ip.parse::<Ipv4Addr>().ok()?, prefix.parse::<u8>().ok()?))
+        })
+        .collect()
+}
+
+async fn active_scan_candidate(ip: &str) -> Option<DiscoveredCameraCandidate> {
+    let ports = probe_common_ports(ip).await;
+    if !(ports.rtsp || ports.onvif) {
+        return None;
+    }
+    let mut candidate = blank_candidate(ip);
+    candidate.transports.http = ports.http;
+    candidate.transports.https = ports.https;
+    candidate.transports.rtsp = ports.rtsp;
+    candidate.transports.onvif = ports.onvif;
+    candidate.transports.proprietary_9000 = ports.proprietary_9000;
+    push_unique_string(&mut candidate.discovered_via, "interface_scan");
+    Some(candidate)
 }
 
 fn host_and_port_from_xaddr(value: &str) -> Option<(String, u16)> {
@@ -3232,7 +3731,19 @@ fn http_client() -> Result<Client> {
         .context("failed building camera discovery http client")
 }
 
-async fn fetch_public_title(client: &Client, ip: &str, http: bool, https: bool) -> Result<String> {
+#[derive(Clone, Debug, Default)]
+struct HttpFingerprint {
+    title: String,
+    server: String,
+    body: String,
+}
+
+async fn fetch_http_fingerprint(
+    client: &Client,
+    ip: &str,
+    http: bool,
+    https: bool,
+) -> Result<HttpFingerprint> {
     let title_re = Regex::new("(?is)<title>(.*?)</title>").context("invalid title regex")?;
     for url in [
         http.then(|| format!("http://{ip}/")),
@@ -3245,18 +3756,44 @@ async fn fetch_public_title(client: &Client, ip: &str, http: bool, https: bool) 
             Ok(response) if response.status().is_success() => response,
             _ => continue,
         };
+        let server = response
+            .headers()
+            .get("server")
+            .and_then(|value| value.to_str().ok())
+            .unwrap_or_default()
+            .trim()
+            .to_string();
         let body = response.text().await.unwrap_or_default();
-        if let Some(captures) = title_re.captures(&body) {
-            let title = captures
-                .get(1)
-                .map(|m| m.as_str().trim())
-                .unwrap_or_default();
-            if !title.is_empty() {
-                return Ok(title.to_string());
-            }
-        }
+        let title = title_re
+            .captures(&body)
+            .and_then(|captures| captures.get(1))
+            .map(|m| m.as_str().trim().to_string())
+            .unwrap_or_default();
+        return Ok(HttpFingerprint {
+            title,
+            server,
+            body,
+        });
     }
-    Ok(String::new())
+    Ok(HttpFingerprint::default())
+}
+
+fn is_xm_http_fingerprint(fingerprint: &HttpFingerprint) -> bool {
+    if fingerprint.body.trim().is_empty() && fingerprint.server.trim().is_empty() {
+        return false;
+    }
+    let server = fingerprint.server.to_ascii_lowercase();
+    let body = fingerprint.body.to_ascii_lowercase();
+    let markers = [
+        "api_pluginplay/api_plugin.js",
+        "api_pluginplay/commonnew.js",
+        "jscore/browserwindow.js",
+        "ipcconfigctrl",
+        "raw_player.js",
+        "pubversion=",
+    ];
+    let hits = markers.iter().filter(|marker| body.contains(**marker)).count();
+    hits >= 2 || (server.contains("gsoap/2.8") && body.contains("api_pluginplay/api_plugin.js"))
 }
 
 fn first_nonempty(preferred: &str, fallback: &str) -> String {
@@ -3323,6 +3860,41 @@ mod tests {
         let matched = match_candidate(&candidate);
         assert_eq!(matched.driver_id, DRIVER_ID_GENERIC_ONVIF_RTSP);
         assert!(matched.mountable);
+    }
+
+    #[test]
+    fn xm_driver_matches_xm_fingerprint_before_generic() {
+        let candidate = DiscoveredCameraCandidate {
+            ip: "192.168.0.201".to_string(),
+            signatures: CameraSignatureSet {
+                vendor: "XM/NetSurveillance".to_string(),
+                model: "XM RTSP camera".to_string(),
+                ..Default::default()
+            },
+            transports: CameraTransportFacts {
+                http: true,
+                rtsp: true,
+                onvif: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let matched = match_candidate(&candidate);
+        assert_eq!(matched.driver_id, DRIVER_ID_XM_40E);
+        assert_eq!(matched.kind, "vendor_driver");
+        assert!(matched.mountable);
+    }
+
+    #[test]
+    fn derive_rtsp_url_uses_xm_path_shape() {
+        let candidate = DiscoveredCameraCandidate {
+            ip: "192.168.0.201".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(
+            derive_rtsp_url(&candidate, DRIVER_ID_XM_40E, "admin", "123456", ""),
+            "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream"
+        );
     }
 
     #[test]
@@ -3712,6 +4284,44 @@ mod tests {
 
         assert_eq!(next.name, "Driveway");
         assert_eq!(next.desired.overlay_text, "Package Zone");
+    }
+
+    #[test]
+    fn xm_display_name_change_does_not_link_hidden_overlay_fields() {
+        let existing = CameraConfig {
+            source_id: "cam".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "10.0.0.1".to_string(),
+            onvif_port: 8000,
+            rtsp_url: String::new(),
+            username: String::new(),
+            password: String::new(),
+            driver_id: DRIVER_ID_XM_40E.to_string(),
+            vendor: String::new(),
+            model: String::new(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Front Door".to_string(),
+                overlay_text: String::new(),
+                overlay_timestamp: false,
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        };
+        let mut next = existing.clone();
+        next.desired.display_name = "Driveway".to_string();
+        next.desired.overlay_text = "Front Door".to_string();
+        next.desired.overlay_timestamp = true;
+
+        sync_display_name_and_linked_overlay(&existing, &mut next);
+
+        assert_eq!(next.name, "Driveway");
+        assert_eq!(next.desired.overlay_text, "Front Door");
+        assert!(next.desired.overlay_timestamp);
     }
 
     #[test]

--- a/src/live.rs
+++ b/src/live.rs
@@ -1,4 +1,5 @@
 use crate::config::{CameraConfig, Config, LivePreviewConfig};
+use crate::drivers::driver_is_xm;
 use crate::nostr::{self, NostrEvent};
 use anyhow::{Context, Result, anyhow};
 use rtp::packet::Packet as RtpPacket;
@@ -25,6 +26,9 @@ use webrtc::peer_connection::configuration::RTCConfiguration;
 use webrtc::peer_connection::peer_connection_state::RTCPeerConnectionState;
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 use webrtc::rtp_transceiver::rtp_codec::RTCRtpCodecCapability;
+use webrtc::rtp_transceiver::rtp_codec::RTPCodecType;
+use webrtc::rtp_transceiver::rtp_transceiver_direction::RTCRtpTransceiverDirection;
+use webrtc::rtp_transceiver::{RTCRtpTransceiver, RTCRtpTransceiverInit};
 use webrtc::track::track_local::TrackLocal;
 use webrtc::track::track_local::TrackLocalWriter;
 use webrtc::track::track_local::track_local_static_rtp::TrackLocalStaticRTP;
@@ -230,7 +234,6 @@ impl PreviewManager {
     ) -> Result<ManagedOfferResponse> {
         let token = validate_launch_token(cfg, &request.launch_token)?;
         let offer = parse_offer_description(&request.offer)?;
-        let preview_codec = select_preview_codec(&request.offer)?;
         let selected = select_sources(cfg, source_ids_from_offer(&request.offer), &token)?;
         let remote_candidates = request_candidates(&request);
         if selected.is_empty() {
@@ -295,17 +298,26 @@ impl PreviewManager {
 
         pc.set_remote_description(offer).await?;
         apply_remote_candidates(&pc, &remote_candidates).await?;
+        let mut offered_video_transceivers = available_offer_video_transceivers(&pc).await;
 
         let mut stops = Vec::new();
         let mut response_sources = Vec::new();
+        let mut answer_msid_tracks = Vec::new();
         for camera in &selected {
+            let preview_codec = select_preview_codec_for_camera(&request.offer, camera)?;
+            let media_stream_id = format!("{session_id}-{}", camera.source_id);
             let track = Arc::new(TrackLocalStaticRTP::new(
                 preview_codec.capability(),
                 camera.source_id.clone(),
-                session_id.clone(),
+                media_stream_id.clone(),
             ));
-            pc.add_track(Arc::clone(&track) as Arc<dyn TrackLocal + Send + Sync>)
-                .await?;
+            answer_msid_tracks.push((media_stream_id, camera.source_id.clone()));
+            attach_preview_track(
+                &pc,
+                &mut offered_video_transceivers,
+                Arc::clone(&track) as Arc<dyn TrackLocal + Send + Sync>,
+            )
+            .await?;
             let (stop_tx, stop_rx) = watch::channel(false);
             stops.push(stop_tx);
             tokio::spawn(run_camera_forwarder(
@@ -329,6 +341,10 @@ impl PreviewManager {
             .local_description()
             .await
             .ok_or_else(|| anyhow!("missing local description"))?;
+        let local_desc = RTCSessionDescription::answer(with_firefox_compatible_answer_msid(
+            &local_desc.sdp,
+            &answer_msid_tracks,
+        ))?;
         let response_candidates = gathered_candidates.lock().await.clone();
 
         self.sessions.lock().await.insert(
@@ -583,8 +599,16 @@ fn offer_description_sdp(value: &Value) -> Option<&str> {
     })
 }
 
-fn select_preview_codec(value: &Value) -> Result<PreviewCodec> {
+fn select_preview_codec_for_camera(value: &Value, camera: &CameraConfig) -> Result<PreviewCodec> {
     let sdp = offer_description_sdp(value).unwrap_or_default();
+    if driver_is_xm(&camera.driver_id) {
+        if sdp.contains("VP8/90000") {
+            return Ok(PreviewCodec::Vp8);
+        }
+        return Err(anyhow!(
+            "browser offer does not advertise VP8, which is required for XM live preview"
+        ));
+    }
     if sdp.contains("H264/90000") {
         return Ok(PreviewCodec::H264);
     }
@@ -643,14 +667,163 @@ fn session_key_for_token(token: &ManagedLaunchTokenPayload) -> String {
     format!("{}:{}", token.device_pk.trim(), token.launch_nonce.trim())
 }
 
+async fn available_offer_video_transceivers(
+    pc: &Arc<RTCPeerConnection>,
+) -> Vec<Arc<RTCRtpTransceiver>> {
+    pc.get_transceivers()
+        .await
+        .into_iter()
+        .filter(|transceiver| transceiver.kind() == RTPCodecType::Video)
+        .collect()
+}
+
+async fn attach_preview_track(
+    pc: &Arc<RTCPeerConnection>,
+    offered_video_transceivers: &mut Vec<Arc<RTCRtpTransceiver>>,
+    track: Arc<dyn TrackLocal + Send + Sync>,
+) -> Result<()> {
+    while let Some(transceiver) = offered_video_transceivers.first().cloned() {
+        offered_video_transceivers.remove(0);
+        let sender = transceiver.sender().await;
+        if sender.track().await.is_some() {
+            continue;
+        }
+        sender.replace_track(Some(track)).await?;
+        transceiver
+            .set_direction(RTCRtpTransceiverDirection::Sendonly)
+            .await;
+        return Ok(());
+    }
+
+    pc.add_transceiver_from_track(
+        track,
+        Some(RTCRtpTransceiverInit {
+            direction: RTCRtpTransceiverDirection::Sendonly,
+            send_encodings: vec![],
+        }),
+    )
+    .await?;
+    Ok(())
+}
+
+fn with_firefox_compatible_answer_msid(
+    sdp: &str,
+    media_stream_tracks: &[(String, String)],
+) -> String {
+    let has_msid_semantic = sdp.lines().any(|line| line.trim() == "a=msid-semantic:WMS *");
+    let mut out = Vec::new();
+    let mut in_video_section = false;
+    let mut video_index = 0usize;
+    let mut saw_msid_in_section = false;
+
+    for raw_line in sdp.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        if line.starts_with("m=") {
+            in_video_section = line.starts_with("m=video ");
+            if in_video_section {
+                video_index = video_index.saturating_add(1);
+            }
+            saw_msid_in_section = false;
+            out.push(line.to_string());
+            continue;
+        }
+
+        out.push(line.to_string());
+        if !has_msid_semantic && line.starts_with("a=group:BUNDLE ") {
+            out.push("a=msid-semantic:WMS *".to_string());
+            continue;
+        }
+
+        if in_video_section && line.starts_with("a=msid:") {
+            saw_msid_in_section = true;
+            continue;
+        }
+
+        if in_video_section && !saw_msid_in_section && line.starts_with("a=mid:") {
+            if let Some((stream_id, track_id)) = media_stream_tracks.get(video_index.saturating_sub(1))
+            {
+                out.push(format!("a=msid:{stream_id} {track_id}"));
+                saw_msid_in_section = true;
+            }
+        }
+    }
+
+    let mut normalized = out.join("\r\n");
+    if !normalized.is_empty() {
+        normalized.push_str("\r\n");
+    }
+    normalized
+}
+
 fn preview_rtsp_url(camera: &CameraConfig) -> String {
     let mut url = camera.rtsp_url.clone();
     if url.contains("h264Preview_01_main") {
         url = url.replace("h264Preview_01_main", "h264Preview_01_sub");
     } else if url.contains("h265Preview_01_main") {
         url = url.replace("h265Preview_01_main", "h265Preview_01_sub");
+    } else if driver_is_xm(&camera.driver_id) {
+        url = url
+            .replace("_stream=0.sdp?real_stream", "_stream=1.sdp?real_stream")
+            .replace("_stream=0.sdp", "_stream=1.sdp");
     }
     url
+}
+
+fn build_live_preview_ffmpeg_args(preview_url: &str, codec: PreviewCodec, udp_port: u16) -> Vec<String> {
+    let mut args = vec![
+        "-nostdin".to_string(),
+        "-loglevel".to_string(),
+        "error".to_string(),
+        "-rtsp_transport".to_string(),
+        "tcp".to_string(),
+    ];
+    if codec == PreviewCodec::Vp8 {
+        // Some RTSP sources do not supply usable PTS for live VP8 preview.
+        // Generate timestamps up front so mixed-camera preview sessions do not stall.
+        args.push("-fflags".to_string());
+        args.push("+genpts".to_string());
+    }
+    args.push("-i".to_string());
+    args.push(preview_url.to_string());
+    args.push("-an".to_string());
+
+    match codec {
+        PreviewCodec::H264 => {
+            args.push("-c:v".to_string());
+            args.push("copy".to_string());
+        }
+        PreviewCodec::Vp8 => {
+            args.extend([
+                "-c:v".to_string(),
+                "libvpx".to_string(),
+                "-deadline".to_string(),
+                "realtime".to_string(),
+                "-cpu-used".to_string(),
+                "8".to_string(),
+                "-pix_fmt".to_string(),
+                "yuv420p".to_string(),
+                "-g".to_string(),
+                "30".to_string(),
+                "-keyint_min".to_string(),
+                "30".to_string(),
+                "-b:v".to_string(),
+                "1M".to_string(),
+                "-maxrate".to_string(),
+                "1M".to_string(),
+                "-bufsize".to_string(),
+                "2M".to_string(),
+            ]);
+        }
+    }
+
+    args.extend([
+        "-f".to_string(),
+        "rtp".to_string(),
+        "-payload_type".to_string(),
+        "96".to_string(),
+        format!("rtp://127.0.0.1:{udp_port}?pkt_size=1200"),
+    ]);
+    args
 }
 
 async fn run_camera_forwarder(
@@ -687,52 +860,13 @@ async fn run_camera_forwarder(
     };
 
     let mut ffmpeg = Command::new("ffmpeg");
-    ffmpeg
-        .arg("-nostdin")
-        .arg("-loglevel")
-        .arg("error")
-        .arg("-rtsp_transport")
-        .arg("tcp")
-        .arg("-i")
-        .arg(&preview_url)
-        .arg("-an");
-
-    match codec {
-        PreviewCodec::H264 => {
-            ffmpeg.arg("-c:v").arg("copy");
-        }
-        PreviewCodec::Vp8 => {
-            ffmpeg
-                .arg("-c:v")
-                .arg("libvpx")
-                .arg("-deadline")
-                .arg("realtime")
-                .arg("-cpu-used")
-                .arg("8")
-                .arg("-pix_fmt")
-                .arg("yuv420p")
-                .arg("-g")
-                .arg("30")
-                .arg("-keyint_min")
-                .arg("30")
-                .arg("-b:v")
-                .arg("1M")
-                .arg("-maxrate")
-                .arg("1M")
-                .arg("-bufsize")
-                .arg("2M");
-        }
-    }
+    ffmpeg.args(build_live_preview_ffmpeg_args(
+        &preview_url,
+        codec,
+        local_addr.port(),
+    ));
 
     let mut child = match ffmpeg
-        .arg("-f")
-        .arg("rtp")
-        .arg("-payload_type")
-        .arg("96")
-        .arg(format!(
-            "rtp://127.0.0.1:{}?pkt_size=1200",
-            local_addr.port()
-        ))
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .spawn()
@@ -787,6 +921,7 @@ async fn run_camera_forwarder(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use webrtc::api::APIBuilder;
 
     fn sample_config() -> Config {
         let path = std::env::temp_dir().join(format!(
@@ -948,8 +1083,9 @@ mod tests {
                 "sdp": "m=video 9 UDP/TLS/RTP/SAVPF 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 H264/90000\r\n"
             }
         });
+        let cfg = sample_config();
         assert_eq!(
-            select_preview_codec(&offer).expect("codec"),
+            select_preview_codec_for_camera(&offer, &cfg.cameras[0]).expect("codec"),
             PreviewCodec::H264
         );
     }
@@ -962,10 +1098,82 @@ mod tests {
                 "sdp": "m=video 9 UDP/TLS/RTP/SAVPF 96\r\na=rtpmap:96 VP8/90000\r\n"
             }
         });
+        let cfg = sample_config();
         assert_eq!(
-            select_preview_codec(&offer).expect("codec"),
+            select_preview_codec_for_camera(&offer, &cfg.cameras[0]).expect("codec"),
             PreviewCodec::Vp8
         );
+    }
+
+    #[test]
+    fn select_preview_codec_prefers_vp8_for_xm_sources() {
+        let offer = json!({
+            "description": {
+                "type": "offer",
+                "sdp": "m=video 9 UDP/TLS/RTP/SAVPF 96 97\r\na=rtpmap:96 VP8/90000\r\na=rtpmap:97 H264/90000\r\n"
+            }
+        });
+        let mut cfg = sample_config();
+        let mut camera = cfg.cameras.remove(0);
+        camera.driver_id = "xm_40e".to_string();
+        assert_eq!(
+            select_preview_codec_for_camera(&offer, &camera).expect("codec"),
+            PreviewCodec::Vp8
+        );
+    }
+
+    #[test]
+    fn select_preview_codec_rejects_xm_without_vp8_offer() {
+        let offer = json!({
+            "description": {
+                "type": "offer",
+                "sdp": "m=video 9 UDP/TLS/RTP/SAVPF 97\r\na=rtpmap:97 H264/90000\r\n"
+            }
+        });
+        let mut cfg = sample_config();
+        let mut camera = cfg.cameras.remove(0);
+        camera.driver_id = "xm_40e".to_string();
+        let err = select_preview_codec_for_camera(&offer, &camera).expect_err("xm should require vp8");
+        assert!(err.to_string().contains("required for XM live preview"));
+    }
+
+    #[test]
+    fn preview_rtsp_url_uses_xm_substream() {
+        let mut cfg = sample_config();
+        let mut camera = cfg.cameras.remove(0);
+        camera.driver_id = "xm_40e".to_string();
+        camera.rtsp_url =
+            "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream"
+                .to_string();
+        assert_eq!(
+            preview_rtsp_url(&camera),
+            "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=1.sdp?real_stream"
+        );
+    }
+
+    #[test]
+    fn live_preview_ffmpeg_args_add_genpts_for_vp8() {
+        let args = build_live_preview_ffmpeg_args(
+            "rtsp://camera.example/sub",
+            PreviewCodec::Vp8,
+            41000,
+        );
+        let ff_idx = args.iter().position(|arg| arg == "-fflags").expect("fflags");
+        assert_eq!(args.get(ff_idx + 1).map(String::as_str), Some("+genpts"));
+        let input_idx = args.iter().position(|arg| arg == "-i").expect("input");
+        assert!(ff_idx < input_idx);
+        assert!(args.iter().any(|arg| arg == "libvpx"));
+    }
+
+    #[test]
+    fn live_preview_ffmpeg_args_omit_genpts_for_h264_copy() {
+        let args = build_live_preview_ffmpeg_args(
+            "rtsp://camera.example/sub",
+            PreviewCodec::H264,
+            41000,
+        );
+        assert!(!args.iter().any(|arg| arg == "+genpts"));
+        assert!(args.iter().any(|arg| arg == "copy"));
     }
 
     #[test]
@@ -975,5 +1183,124 @@ mod tests {
         let payload = validate_launch_token(&cfg, &token).expect("token");
         assert_eq!(payload.gateway_pk, cfg.gateway.host_gateway_pk);
         assert_eq!(payload.service_pk, cfg.nostr_pubkey);
+    }
+
+    #[tokio::test]
+    async fn answer_uses_sendonly_for_recvonly_video_offer_lines() {
+        let mut media_engine = MediaEngine::default();
+        media_engine
+            .register_default_codecs()
+            .expect("register codecs");
+        let api = APIBuilder::new().with_media_engine(media_engine).build();
+        let offerer = Arc::new(
+            api.new_peer_connection(RTCConfiguration::default())
+                .await
+                .expect("offerer"),
+        );
+        let answerer = Arc::new(
+            api.new_peer_connection(RTCConfiguration::default())
+                .await
+                .expect("answerer"),
+        );
+
+        for _ in 0..2 {
+            offerer
+                .add_transceiver_from_kind(
+                    RTPCodecType::Video,
+                    Some(RTCRtpTransceiverInit {
+                        direction: RTCRtpTransceiverDirection::Recvonly,
+                        send_encodings: vec![],
+                    }),
+                )
+                .await
+                .expect("recvonly video transceiver");
+        }
+
+        let offer = offerer.create_offer(None).await.expect("offer");
+        offerer
+            .set_local_description(offer)
+            .await
+            .expect("set local offer");
+        let local_offer = offerer.local_description().await.expect("local offer");
+        answerer
+            .set_remote_description(local_offer)
+            .await
+            .expect("set remote offer");
+
+        let mut offered_video_transceivers = available_offer_video_transceivers(&answerer).await;
+        for idx in 0..2 {
+            let track = Arc::new(TrackLocalStaticRTP::new(
+                PreviewCodec::Vp8.capability(),
+                format!("cam-{idx}"),
+                format!("session-cam-{idx}"),
+            ));
+            attach_preview_track(
+                &answerer,
+                &mut offered_video_transceivers,
+                track as Arc<dyn TrackLocal + Send + Sync>,
+            )
+            .await
+            .expect("attach track");
+        }
+
+        let answer = answerer.create_answer(None).await.expect("answer");
+        answerer
+            .set_local_description(answer)
+            .await
+            .expect("set local answer");
+        let sdp = answerer.local_description().await.expect("local answer").sdp;
+
+        let mut saw_video = 0usize;
+        let mut pending_video = false;
+        for line in sdp.lines() {
+            if line.starts_with("m=video ") {
+                pending_video = true;
+                saw_video += 1;
+                continue;
+            }
+            if line.starts_with("m=") {
+                pending_video = false;
+                continue;
+            }
+            if pending_video && line == "a=sendrecv" {
+                panic!("video answer line negotiated sendrecv instead of sendonly");
+            }
+        }
+        assert_eq!(saw_video, 2);
+        assert_eq!(sdp.matches("a=sendonly").count(), 2);
+        assert!(sdp.contains("msid:session-cam-0 cam-0"));
+        assert!(sdp.contains("msid:session-cam-1 cam-1"));
+    }
+
+    #[test]
+    fn firefox_compatible_answer_adds_media_stream_ids() {
+        let input = concat!(
+            "v=0\r\n",
+            "o=- 1 1 IN IP4 0.0.0.0\r\n",
+            "s=-\r\n",
+            "t=0 0\r\n",
+            "a=group:BUNDLE 0 1\r\n",
+            "m=video 9 UDP/TLS/RTP/SAVPF 120\r\n",
+            "c=IN IP4 0.0.0.0\r\n",
+            "a=setup:active\r\n",
+            "a=mid:0\r\n",
+            "a=sendonly\r\n",
+            "m=video 9 UDP/TLS/RTP/SAVPF 120\r\n",
+            "c=IN IP4 0.0.0.0\r\n",
+            "a=setup:active\r\n",
+            "a=mid:1\r\n",
+            "a=sendonly\r\n"
+        );
+        let output = with_firefox_compatible_answer_msid(
+            input,
+            &[
+                ("session-1".to_string(), "cam-1".to_string()),
+                ("session-1".to_string(), "cam-2".to_string()),
+            ],
+        );
+
+        assert!(output.contains("a=msid-semantic:WMS *\r\n"));
+        assert!(output.contains("a=mid:0\r\na=msid:session-1 cam-1\r\n"));
+        assert!(output.contains("a=mid:1\r\na=msid:session-1 cam-2\r\n"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod storage;
 mod swarm;
 mod update;
 mod util;
+mod xm;
 
 use anyhow::Result;
 use clap::Parser;
@@ -66,7 +67,17 @@ struct Args {
     #[arg(long)]
     read_camera_source: Option<String>,
     #[arg(long)]
+    list_inventory: bool,
+    #[arg(long)]
     probe_camera_source: Option<String>,
+    #[arg(long)]
+    probe_camera_ip: Option<String>,
+    #[arg(long, default_value = "admin")]
+    probe_camera_username: String,
+    #[arg(long)]
+    probe_camera_password: Option<String>,
+    #[arg(long)]
+    probe_camera_driver_id: Option<String>,
     #[arg(long)]
     apply_camera_source: Option<String>,
     #[arg(long)]
@@ -198,11 +209,33 @@ async fn main() -> Result<()> {
         return Ok(());
     }
 
+    if args.list_inventory {
+        let inventory = drivers::list_inventory(&cfg).await?;
+        println!("{}", serde_json::to_string_pretty(&inventory)?);
+        return Ok(());
+    }
+
     if let Some(source_id) = &args.probe_camera_source {
         let result = drivers::probe_camera(
             &cfg,
             drivers::ProbeCameraRequest {
                 source_id: source_id.trim().to_string(),
+                ..Default::default()
+            },
+        )
+        .await?;
+        println!("{}", serde_json::to_string_pretty(&result)?);
+        return Ok(());
+    }
+
+    if let Some(ip) = &args.probe_camera_ip {
+        let result = drivers::probe_camera(
+            &cfg,
+            drivers::ProbeCameraRequest {
+                ip: ip.trim().to_string(),
+                username: args.probe_camera_username.clone(),
+                password: args.probe_camera_password.clone().unwrap_or_default(),
+                driver_id: args.probe_camera_driver_id.clone().unwrap_or_default(),
                 ..Default::default()
             },
         )

--- a/src/reolink.rs
+++ b/src/reolink.rs
@@ -1,3 +1,13 @@
+//! Reolink driver lane.
+//!
+//! Driver-specific operational truth belongs here first, with shared docs kept to
+//! compatibility and operator-facing summaries.
+//!
+//! Active product boundary:
+//! - proprietary discovery/bootstrap and native transport live here
+//! - CGI/ONVIF presentation and site-time behavior are split by concern
+//! - PTZ remains model-sensitive and partially hidden pending full native actuation
+
 use crate::{camera, reolink_cgi, reolink_proto};
 use anyhow::{Context, Result, anyhow};
 use rand::Rng;

--- a/src/xm.rs
+++ b/src/xm.rs
@@ -1,0 +1,863 @@
+//! XM / NetSurveillance 40E driver lane.
+//!
+//! Driver-specific operational truth belongs here first, with only the high-level
+//! compatibility/operator summary duplicated in shared docs.
+//!
+//! Active product boundary:
+//! - authenticated XM SOAP-style management over the camera web endpoint
+//! - baked title via `TitleOverlay.TitleUtf8`
+//! - site time via manual seed -> NTP transition on `TimeConfig`
+//! - hidden `UserOverlay` lane cleared so stale lower-left text does not leak
+//! - no PTZ support on the validated 40E lab model
+
+use anyhow::{Context, Result, anyhow};
+use des::Des;
+use des::cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray};
+use regex::Regex;
+use reqwest::Client;
+use reqwest::header::{ACCEPT, CONTENT_TYPE, HeaderMap, HeaderValue};
+use roxmltree::Document;
+use serde::Serialize;
+
+const XM_LOGIN_KEY: &[u8; 8] = b"WebLogin";
+
+#[derive(Clone, Debug)]
+pub struct XmConnectRequest {
+    pub host: String,
+    pub username: String,
+    pub password: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct XmSiteTimePolicy {
+    pub ntp_server: String,
+    pub timezone_code: i32,
+    pub current_local_time: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmReadState {
+    pub system: XmSystemInfo,
+    pub time: XmTimeConfig,
+    pub video: XmVideoConfig,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmSystemInfo {
+    pub vendor: String,
+    pub model_family: String,
+    pub firmware_version: String,
+    pub kernel_version: String,
+    pub serial_number: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmTimeConfig {
+    pub time_mode: String,
+    pub current_time: String,
+    pub current_time_iso: String,
+    pub timezone_code: i32,
+    pub timezone_offset_minutes: i32,
+    pub timezone_offset_label: String,
+    pub ntp_server: String,
+    pub ntp_port: u16,
+    pub refresh_interval_secs: u32,
+    pub summer_time: XmSummerTime,
+    #[serde(skip_serializing)]
+    pub raw_xml: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmSummerTime {
+    pub enabled: bool,
+    pub automatic: bool,
+    pub offset_minutes: i32,
+    pub start: XmSummerTimePoint,
+    pub end: XmSummerTimePoint,
+}
+
+impl Default for XmSummerTime {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            automatic: false,
+            offset_minutes: 60,
+            start: XmSummerTimePoint::default(),
+            end: XmSummerTimePoint::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmSummerTimePoint {
+    pub month: u8,
+    pub week: u8,
+    pub weekday: u8,
+    pub hour: u8,
+}
+
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct XmVideoConfig {
+    pub overlay_enabled: bool,
+    pub title_text: String,
+    pub title_hex: String,
+    pub user_title_text: String,
+    pub user_title_hex: String,
+    pub time_format: String,
+    pub time_24_or_12: String,
+    pub show_weekday: bool,
+    pub main_stream_format: String,
+    pub preview_stream_format: String,
+    pub preview_requires_transcode: bool,
+    #[serde(skip_serializing)]
+    pub raw_xml: String,
+}
+
+pub async fn read_state(request: &XmConnectRequest) -> Result<XmReadState> {
+    let session = XmSession::connect(request).await?;
+    session.read_state().await
+}
+
+pub async fn apply_state(
+    request: &XmConnectRequest,
+    desired_display_title: Option<&str>,
+    desired_overlay_title: Option<&str>,
+    site_time: Option<&XmSiteTimePolicy>,
+) -> Result<XmReadState> {
+    let session = XmSession::connect(request).await?;
+    let initial = session.read_state().await?;
+    let mut wrote = false;
+
+    if let Some(title) = desired_display_title {
+        let title = title.trim();
+        if !title.is_empty() && title != initial.video.title_text.trim() {
+            let patched = render_overlay_config_xml(&initial.video.raw_xml, title)?;
+            session
+                .write_xml("/setMediaVideoOverlayConfig", &patched)
+                .await
+                .context("XM overlay write failed")?;
+            wrote = true;
+        }
+    }
+
+    match desired_overlay_title.map(str::trim) {
+        Some(title) if !title.is_empty() => {
+            if title != initial.video.user_title_text.trim() {
+                let patched = render_user_overlay_config_xml(&initial.video.raw_xml, title)?;
+                session
+                    .write_xml("/setMediaVideoUserOverlayConfig", &patched)
+                    .await
+                    .context("XM custom title write failed")?;
+                wrote = true;
+            }
+        }
+        _ => {
+            if user_overlay_requires_clear(&initial.video.raw_xml)? {
+                let patched = clear_user_overlay_config_xml(&initial.video.raw_xml)?;
+                session
+                    .write_xml("/setMediaVideoUserOverlayConfig", &patched)
+                    .await
+                    .context("XM user overlay clear failed")?;
+                wrote = true;
+            }
+        }
+    }
+
+    if let Some(policy) = site_time {
+        let desired_ntp_time_xml = render_ntp_time_config_xml(&initial.time, policy);
+        if normalize_for_compare(&desired_ntp_time_xml) != normalize_for_compare(&initial.time.raw_xml)
+        {
+            let manual_seed_xml = render_manual_time_config_xml(&initial.time, policy);
+            session
+                .write_xml("/setTimeConfig", &manual_seed_xml)
+                .await
+                .context("XM manual time seed failed")?;
+            session
+                .write_xml("/setTimeConfig", &desired_ntp_time_xml)
+                .await
+                .context("XM time write failed")?;
+            wrote = true;
+        }
+    }
+
+    if wrote {
+        return session.read_state().await;
+    }
+    Ok(initial)
+}
+
+pub fn timezone_code_to_offset_minutes(code: i32) -> i32 {
+    code - 720
+}
+
+pub fn timezone_offset_label(code: i32) -> String {
+    let offset = timezone_code_to_offset_minutes(code);
+    let sign = if offset >= 0 { '+' } else { '-' };
+    let abs = offset.abs();
+    format!("UTC{}{:02}:{:02}", sign, abs / 60, abs % 60)
+}
+
+fn normalize_for_compare(xml: &str) -> String {
+    xml.chars().filter(|ch| !ch.is_whitespace()).collect()
+}
+
+struct XmSession {
+    client: Client,
+    base_url: String,
+    user_token: String,
+    pass_token: String,
+}
+
+impl XmSession {
+    async fn connect(request: &XmConnectRequest) -> Result<Self> {
+        let host = request.host.trim();
+        if host.is_empty() {
+            return Err(anyhow!("XM host is missing"));
+        }
+        let username = request.username.trim();
+        let password = request.password.trim();
+        if username.is_empty() || password.is_empty() {
+            return Err(anyhow!("XM credentials are required"));
+        }
+
+        let client = xm_http_client()?;
+        let user_token = encode_login_token(username)?;
+        let pass_token = encode_login_token(password)?;
+        let login_xml = soap_request_xml(&user_token, &pass_token, "");
+        let mut last_error = None;
+        for base_url in [format!("http://{host}"), format!("https://{host}")] {
+            match xm_post(&client, &base_url, "/ipcLogin", &login_xml).await {
+                Ok(body) if body.contains("<SystemFunction") => {
+                    return Ok(Self {
+                        client,
+                        base_url,
+                        user_token,
+                        pass_token,
+                    });
+                }
+                Ok(body) => {
+                    last_error = Some(anyhow!(
+                        "XM login returned an unexpected payload from {}: {}",
+                        base_url,
+                        truncate_payload(&body)
+                    ));
+                }
+                Err(error) => {
+                    last_error = Some(error.context(format!("XM login failed via {}", base_url)));
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| anyhow!("XM login failed")))
+    }
+
+    async fn read_state(&self) -> Result<XmReadState> {
+        let system_xml = self.read_xml("/getSystemVersionInfo").await?;
+        let time_xml = self.read_xml("/getTimeConfig").await?;
+        let video_xml = self.read_xml("/getMediaVideoConfig").await?;
+        Ok(XmReadState {
+            system: parse_system_info(&system_xml)?,
+            time: parse_time_config(&time_xml)?,
+            video: parse_video_config(&video_xml)?,
+        })
+    }
+
+    async fn read_xml(&self, path: &str) -> Result<String> {
+        let body = soap_request_xml(&self.user_token, &self.pass_token, "");
+        xm_post(&self.client, &self.base_url, path, &body).await
+    }
+
+    async fn write_xml(&self, path: &str, body: &str) -> Result<String> {
+        let body = soap_request_xml(&self.user_token, &self.pass_token, body);
+        xm_post(&self.client, &self.base_url, path, &body).await
+    }
+}
+
+fn xm_http_client() -> Result<Client> {
+    Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(std::time::Duration::from_secs(4))
+        .build()
+        .context("failed building XM HTTP client")
+}
+
+async fn xm_post(client: &Client, base_url: &str, path: &str, body: &str) -> Result<String> {
+    let url = format!("{}{}", base_url.trim_end_matches('/'), path);
+    let response = client
+        .post(&url)
+        .headers(xm_headers()?)
+        .body(body.to_string())
+        .send()
+        .await
+        .with_context(|| format!("XM POST {} failed", url))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let payload = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "XM POST {} returned {}: {}",
+            url,
+            status,
+            truncate_payload(&payload)
+        ));
+    }
+    response
+        .text()
+        .await
+        .with_context(|| format!("XM POST {} returned unreadable body", url))
+}
+
+fn xm_headers() -> Result<HeaderMap> {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("application/x-www-form-urlencoded"),
+    );
+    headers.insert("X-Requested-With", HeaderValue::from_static("XMLHttpRequest"));
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("text/javascript, text/html, application/xml, text/xml, */*"),
+    );
+    Ok(headers)
+}
+
+fn truncate_payload(payload: &str) -> String {
+    let trimmed = payload.trim();
+    if trimmed.len() > 200 {
+        format!("{}...", &trimmed[..200])
+    } else {
+        trimmed.to_string()
+    }
+}
+
+fn soap_request_xml(user_token: &str, pass_token: &str, body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?><soap:Envelope xmlns:soap="http://www.w3.org/2001/12/soap-envelope"><soap:Header><userid>{}</userid><passwd>{}</passwd></soap:Header><soap:Body>{}</soap:Body></soap:Envelope>"#,
+        user_token, pass_token, body
+    )
+}
+
+fn encode_login_token(value: &str) -> Result<String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(String::new());
+    }
+    let mut bytes = value.as_bytes().to_vec();
+    let padding = (8 - (bytes.len() % 8)) % 8;
+    if padding > 0 {
+        bytes.resize(bytes.len() + padding, 0);
+    }
+    let cipher = Des::new_from_slice(XM_LOGIN_KEY).context("invalid XM DES key")?;
+    for chunk in bytes.chunks_mut(8) {
+        let block = GenericArray::from_mut_slice(chunk);
+        cipher.encrypt_block(block);
+    }
+    Ok(hex::encode(bytes))
+}
+
+fn parse_system_info(xml: &str) -> Result<XmSystemInfo> {
+    let doc = Document::parse(xml).context("invalid XM system info XML")?;
+    let version = doc
+        .descendants()
+        .find(|node| node.has_tag_name("VersionInfo"))
+        .ok_or_else(|| anyhow!("XM system info missing VersionInfo"))?;
+    let serial = doc
+        .descendants()
+        .find(|node| node.has_tag_name("SerialNumber"));
+    let firmware_version = version.attribute("fsVersion").unwrap_or_default().trim();
+    Ok(XmSystemInfo {
+        vendor: "XM/NetSurveillance".to_string(),
+        model_family: parse_model_family(firmware_version),
+        firmware_version: firmware_version.to_string(),
+        kernel_version: version
+            .attribute("kernelVersion")
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        serial_number: serial
+            .and_then(|node| node.attribute("serialNumber"))
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+    })
+}
+
+fn parse_model_family(fs_version: &str) -> String {
+    let trimmed = fs_version.trim();
+    let token = trimmed
+        .split(['_', ' '])
+        .find(|value| !value.trim().is_empty())
+        .unwrap_or_default();
+    if token.is_empty() {
+        "XM Camera".to_string()
+    } else {
+        token.to_string()
+    }
+}
+
+fn parse_time_config(xml: &str) -> Result<XmTimeConfig> {
+    let doc = Document::parse(xml).context("invalid XM time XML")?;
+    let root = doc
+        .descendants()
+        .find(|node| node.has_tag_name("TimeConfig"))
+        .ok_or_else(|| anyhow!("XM time XML missing TimeConfig"))?;
+    let ntp = root
+        .children()
+        .find(|node| node.has_tag_name("NTPConfig"));
+    let summer = root
+        .children()
+        .find(|node| node.has_tag_name("SummerTime"));
+    let timezone_code = root
+        .attribute("TimeZone")
+        .unwrap_or("720")
+        .trim()
+        .parse::<i32>()
+        .unwrap_or(720);
+    Ok(XmTimeConfig {
+        time_mode: root
+            .attribute("TimeMode")
+            .unwrap_or_default()
+            .trim()
+            .to_ascii_lowercase(),
+        current_time: root.attribute("CurTime").unwrap_or_default().trim().to_string(),
+        current_time_iso: normalize_time_value(root.attribute("CurTime").unwrap_or_default()),
+        timezone_code,
+        timezone_offset_minutes: timezone_code_to_offset_minutes(timezone_code),
+        timezone_offset_label: timezone_offset_label(timezone_code),
+        ntp_server: ntp
+            .and_then(|node| node.attribute("ServerIP"))
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        ntp_port: ntp
+            .and_then(|node| node.attribute("ServerPort"))
+            .unwrap_or("123")
+            .trim()
+            .parse::<u16>()
+            .unwrap_or(123),
+        refresh_interval_secs: ntp
+            .and_then(|node| node.attribute("RefreshInterval"))
+            .unwrap_or("60")
+            .trim()
+            .parse::<u32>()
+            .unwrap_or(60),
+        summer_time: parse_summer_time(summer),
+        raw_xml: xml.trim().to_string(),
+    })
+}
+
+fn parse_summer_time(node: Option<roxmltree::Node<'_, '_>>) -> XmSummerTime {
+    let Some(node) = node else {
+        return XmSummerTime::default();
+    };
+    let start = node.children().find(|child| child.has_tag_name("start"));
+    let end = node.children().find(|child| child.has_tag_name("end"));
+    XmSummerTime {
+        enabled: node.attribute("enable").unwrap_or("0").trim() == "1",
+        automatic: node.attribute("auto").unwrap_or("0").trim() == "1",
+        offset_minutes: node
+            .attribute("offset")
+            .unwrap_or("60")
+            .trim()
+            .parse::<i32>()
+            .unwrap_or(60),
+        start: parse_summer_time_point(start),
+        end: parse_summer_time_point(end),
+    }
+}
+
+fn parse_summer_time_point(node: Option<roxmltree::Node<'_, '_>>) -> XmSummerTimePoint {
+    let Some(node) = node else {
+        return XmSummerTimePoint::default();
+    };
+    XmSummerTimePoint {
+        month: node
+            .attribute("month")
+            .unwrap_or("0")
+            .trim()
+            .parse::<u8>()
+            .unwrap_or(0),
+        week: node
+            .attribute("week")
+            .unwrap_or("0")
+            .trim()
+            .parse::<u8>()
+            .unwrap_or(0),
+        weekday: node
+            .attribute("weekday")
+            .unwrap_or("0")
+            .trim()
+            .parse::<u8>()
+            .unwrap_or(0),
+        hour: node
+            .attribute("hour")
+            .unwrap_or("0")
+            .trim()
+            .parse::<u8>()
+            .unwrap_or(0),
+    }
+}
+
+fn parse_video_config(xml: &str) -> Result<XmVideoConfig> {
+    let doc = Document::parse(xml).context("invalid XM video XML")?;
+    let overlay = doc
+        .descendants()
+        .find(|node| node.has_tag_name("Overlay"))
+        .ok_or_else(|| anyhow!("XM video XML missing Overlay"))?;
+    let title = overlay
+        .children()
+        .find(|node| node.has_tag_name("TitleOverlay"))
+        .ok_or_else(|| anyhow!("XM video XML missing TitleOverlay"))?;
+    let time_overlay = overlay
+        .children()
+        .find(|node| node.has_tag_name("TimeOverlay"));
+    let mut main_stream_format = String::new();
+    let mut preview_stream_format = String::new();
+    for node in doc.descendants().filter(|node| node.has_tag_name("EncodeConfig")) {
+        match node.attribute("Stream").unwrap_or_default().trim() {
+            "1" => {
+                main_stream_format = node
+                    .attribute("EncodeFormat")
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string()
+            }
+            "2" => {
+                preview_stream_format = node
+                    .attribute("EncodeFormat")
+                    .unwrap_or_default()
+                    .trim()
+                    .to_string()
+            }
+            _ => {}
+        }
+    }
+    let title_hex = first_nonempty(
+        title.attribute("TitleUtf8").unwrap_or_default(),
+        title.attribute("Title").unwrap_or_default(),
+    );
+    let user_title = doc
+        .descendants()
+        .find(|node| node.has_tag_name("UserOverlay"))
+        .and_then(|node| node.children().find(|child| child.has_tag_name("UserOSD")));
+    let user_title_hex = user_title
+        .and_then(|node| node.attribute("TitleUtf8"))
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    Ok(XmVideoConfig {
+        overlay_enabled: overlay.attribute("Enable").unwrap_or("0").trim() == "1",
+        title_text: decode_title_hex(&title_hex),
+        title_hex,
+        user_title_text: decode_title_hex(&user_title_hex),
+        user_title_hex,
+        time_format: time_overlay
+            .and_then(|node| node.attribute("Format"))
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        time_24_or_12: overlay
+            .attribute("time24or12")
+            .unwrap_or_default()
+            .trim()
+            .to_string(),
+        show_weekday: overlay.attribute("Week").unwrap_or("0").trim() == "1",
+        main_stream_format: main_stream_format.clone(),
+        preview_stream_format: preview_stream_format.clone(),
+        preview_requires_transcode: !preview_stream_format.eq_ignore_ascii_case("H264"),
+        raw_xml: xml.trim().to_string(),
+    })
+}
+
+fn first_nonempty(preferred: &str, fallback: &str) -> String {
+    if !preferred.trim().is_empty() {
+        preferred.trim().to_string()
+    } else {
+        fallback.trim().to_string()
+    }
+}
+
+fn decode_title_hex(value: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed.len() % 2 != 0 {
+        return String::new();
+    }
+    hex::decode(trimmed)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string()
+}
+
+fn normalize_time_value(value: &str) -> String {
+    value.trim().replace(' ', "T")
+}
+
+fn render_overlay_config_xml(xml: &str, title: &str) -> Result<String> {
+    let mut overlay = extract_xml_section(xml, "<Overlay", "</Overlay>")?;
+    let title_hex = hex::encode(title.as_bytes());
+    overlay = replace_tag_attr(&overlay, "Week", "0")?;
+    overlay = replace_tag_attr(&overlay, "time24or12", "0")?;
+    overlay = replace_tag_attr_in_node(&overlay, "TimeOverlay", "Format", "mm-dd-yyyy hh:mm:ss")?;
+    overlay = replace_tag_attr_in_node(&overlay, "TitleOverlay", "TitleUtf8", &title_hex)?;
+    overlay = replace_tag_attr_in_node(&overlay, "TitleOverlay", "Title", &title_hex)?;
+    Ok(overlay)
+}
+
+fn render_user_overlay_config_xml(xml: &str, title: &str) -> Result<String> {
+    let mut overlay = extract_xml_section(xml, "<UserOverlay", "</UserOverlay>")?;
+    let title_hex = hex::encode(title.as_bytes());
+    overlay = replace_first_user_overlay_title(&overlay, &title_hex)?;
+    Ok(overlay)
+}
+
+fn clear_user_overlay_config_xml(xml: &str) -> Result<String> {
+    let mut overlay = extract_xml_section(xml, "<UserOverlay", "</UserOverlay>")?;
+    overlay = replace_all_attrs(&overlay, "enable", "0")?;
+    overlay = replace_all_attrs(&overlay, "TitleUtf8", "")?;
+    overlay = replace_all_attrs(&overlay, "Title", "")?;
+    Ok(overlay)
+}
+
+fn replace_tag_attr(tag: &str, name: &str, value: &str) -> Result<String> {
+    let re = Regex::new(&format!(r#"{name}="[^"]*""#)).context("invalid XM tag regex")?;
+    if re.is_match(tag) {
+        Ok(re
+            .replace(tag, format!(r#"{name}="{value}""#))
+            .into_owned())
+    } else if let Some(index) = tag.rfind("/>") {
+        let mut out = String::with_capacity(tag.len() + name.len() + value.len() + 4);
+        out.push_str(&tag[..index]);
+        out.push(' ');
+        out.push_str(name);
+        out.push_str("=\"");
+        out.push_str(value);
+        out.push('"');
+        out.push_str(&tag[index..]);
+        Ok(out)
+    } else {
+        Err(anyhow!("XM tag does not support attribute insertion"))
+    }
+}
+
+fn replace_tag_attr_in_node(xml: &str, node_name: &str, attr_name: &str, value: &str) -> Result<String> {
+    let start = xml
+        .find(&format!("<{node_name}"))
+        .ok_or_else(|| anyhow!("XM XML missing {node_name} tag"))?;
+    let end = xml[start..]
+        .find("/>")
+        .map(|offset| start + offset + 2)
+        .ok_or_else(|| anyhow!("XM {node_name} tag is not self-closing"))?;
+    let mut tag = xml[start..end].to_string();
+    tag = replace_tag_attr(&tag, attr_name, value)?;
+    Ok(format!("{}{}{}", &xml[..start], tag, &xml[end..]))
+}
+
+fn replace_first_user_overlay_title(xml: &str, title_hex: &str) -> Result<String> {
+    let start = xml
+        .find("<UserOSD")
+        .ok_or_else(|| anyhow!("XM XML missing UserOSD tag"))?;
+    let end = xml[start..]
+        .find("/>")
+        .map(|offset| start + offset + 2)
+        .ok_or_else(|| anyhow!("XM UserOSD tag is not self-closing"))?;
+    let mut tag = xml[start..end].to_string();
+    tag = replace_tag_attr(&tag, "TitleUtf8", title_hex)?;
+    Ok(format!("{}{}{}", &xml[..start], tag, &xml[end..]))
+}
+
+fn replace_all_attrs(xml: &str, name: &str, value: &str) -> Result<String> {
+    let re = Regex::new(&format!(r#"{name}="[^"]*""#)).context("invalid XM attr regex")?;
+    Ok(re
+        .replace_all(xml, format!(r#"{name}="{value}""#))
+        .into_owned())
+}
+
+fn extract_xml_section(xml: &str, start_tag: &str, end_tag: &str) -> Result<String> {
+    let start = xml
+        .find(start_tag)
+        .ok_or_else(|| anyhow!("XM XML missing {}", start_tag.trim_start_matches('<')))?;
+    let end = xml[start..]
+        .find(end_tag)
+        .map(|offset| start + offset + end_tag.len())
+        .ok_or_else(|| anyhow!("XM XML missing {}", end_tag.trim_start_matches("</")))?;
+    Ok(xml[start..end].trim().to_string())
+}
+
+fn user_overlay_requires_clear(xml: &str) -> Result<bool> {
+    let doc = Document::parse(xml).context("invalid XM user overlay XML")?;
+    Ok(doc
+        .descendants()
+        .filter(|node| node.has_tag_name("UserOSD"))
+        .any(|node| {
+            node.attribute("enable").unwrap_or("0").trim() == "1"
+                || !node.attribute("TitleUtf8").unwrap_or_default().trim().is_empty()
+                || !node.attribute("Title").unwrap_or_default().trim().is_empty()
+        }))
+}
+
+fn render_ntp_time_config_xml(current: &XmTimeConfig, policy: &XmSiteTimePolicy) -> String {
+    format!(
+        "<TimeConfig TimeMode=\"NTP\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"{}\" auto=\"{}\" offset=\"{}\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
+        xml_escape_attr(&policy.current_local_time),
+        policy.timezone_code,
+        xml_escape_attr(&policy.ntp_server),
+        current.ntp_port,
+        current.refresh_interval_secs,
+        if current.summer_time.enabled { 1 } else { 0 },
+        if current.summer_time.automatic { 1 } else { 0 },
+        current.summer_time.offset_minutes,
+        current.summer_time.start.month,
+        current.summer_time.start.week,
+        current.summer_time.start.weekday,
+        current.summer_time.start.hour,
+        current.summer_time.end.month,
+        current.summer_time.end.week,
+        current.summer_time.end.weekday,
+        current.summer_time.end.hour,
+    )
+}
+
+fn render_manual_time_config_xml(current: &XmTimeConfig, policy: &XmSiteTimePolicy) -> String {
+    format!(
+        "<TimeConfig TimeMode=\"MANUAL\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"{}\" auto=\"{}\" offset=\"{}\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
+        xml_escape_attr(&policy.current_local_time),
+        policy.timezone_code,
+        xml_escape_attr(&policy.ntp_server),
+        current.ntp_port,
+        current.refresh_interval_secs,
+        if current.summer_time.enabled { 1 } else { 0 },
+        if current.summer_time.automatic { 1 } else { 0 },
+        current.summer_time.offset_minutes,
+        current.summer_time.start.month,
+        current.summer_time.start.week,
+        current.summer_time.start.weekday,
+        current.summer_time.start.hour,
+        current.summer_time.end.month,
+        current.summer_time.end.week,
+        current.summer_time.end.weekday,
+        current.summer_time.end.hour,
+    )
+}
+
+fn xml_escape_attr(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('"', "&quot;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_login_token_matches_camera_vector() {
+        assert_eq!(encode_login_token("admin").unwrap(), "52851dbd7918bbae");
+        assert_eq!(encode_login_token("123456").unwrap(), "a17faccd02661e4c");
+    }
+
+    #[test]
+    fn parse_system_info_extracts_40e_family() {
+        let xml = r#"<SystemVersionInfo><VersionInfo kernelVersion="Linux" fsVersion="40E_19_DL_c1_V3-A-RTMP-H5 V3.4.0.3 build 2025-01-09 17:38:27 " /><SerialNumber serialNumber="EF123" /></SystemVersionInfo>"#;
+        let system = parse_system_info(xml).unwrap();
+        assert_eq!(system.vendor, "XM/NetSurveillance");
+        assert_eq!(system.model_family, "40E");
+        assert_eq!(system.serial_number, "EF123");
+    }
+
+    #[test]
+    fn parse_time_config_extracts_ntp_and_timezone_code() {
+        let xml = r#"<TimeConfig TimeMode="NTP" CurTime="2026-04-18 09:54:18" TimeZone="300"><NTPConfig ServerIP="192.168.0.2" ServerPort="123" RefreshInterval="60" /><SummerTime enable="0" auto="0" offset="60"><start month="3" week="3" weekday="0" hour="2" /><end month="11" week="2" weekday="0" hour="2" /></SummerTime></TimeConfig>"#;
+        let time = parse_time_config(xml).unwrap();
+        assert_eq!(time.time_mode, "ntp");
+        assert_eq!(time.current_time_iso, "2026-04-18T09:54:18");
+        assert_eq!(time.ntp_server, "192.168.0.2");
+        assert_eq!(time.timezone_code, 300);
+        assert_eq!(time.timezone_offset_label, "UTC-07:00");
+    }
+
+    #[test]
+    fn parse_video_config_extracts_title_and_formats() {
+        let xml = r#"<Video><Encode><EncodeConfig Stream="1" EncodeFormat="H265" /><EncodeConfig Stream="2" EncodeFormat="H265" /></Encode><Overlay Enable="1" time24or12="0" Week="1"><TimeOverlay Format="mm-dd-yyyy hh:mm:ss" /><TitleOverlay TitleUtf8="43616D657261" Title="43616D657261" /></Overlay><UserOverlay><UserOSD TitleUtf8="46726f6e7420446f6f72" /></UserOverlay></Video>"#;
+        let video = parse_video_config(xml).unwrap();
+        assert_eq!(video.title_text, "Camera");
+        assert_eq!(video.user_title_text, "Front Door");
+        assert_eq!(video.main_stream_format, "H265");
+        assert_eq!(video.preview_stream_format, "H265");
+        assert!(video.preview_requires_transcode);
+    }
+
+    #[test]
+    fn render_overlay_config_xml_extracts_overlay_payload() {
+        let xml = r#"<Video><Overlay Enable="1" time24or12="1" Week="1"><TimeOverlay Format="yyyy-mm-dd hh:mm:ss" /><TitleOverlay PosX="0" TitleUtf8="43616D657261" Title="43616D657261" /></Overlay><UserOverlay><UserOSD TitleUtf8="" /></UserOverlay></Video>"#;
+        let patched = render_overlay_config_xml(xml, "Carport").unwrap();
+        assert!(!patched.contains("<Video>"));
+        assert!(patched.contains(r#"Week="0""#));
+        assert!(patched.contains(r#"time24or12="0""#));
+        assert!(patched.contains(r#"Format="mm-dd-yyyy hh:mm:ss""#));
+        assert!(patched.contains(r#"TitleUtf8="436172706f7274""#));
+        assert!(patched.contains(r#"Title="436172706f7274""#));
+    }
+
+    #[test]
+    fn render_user_overlay_config_xml_updates_first_user_overlay() {
+        let xml = r#"<Video><Overlay><TitleOverlay TitleUtf8="43616D657261" /></Overlay><UserOverlay><UserOSD TitleUtf8="" /><UserOSD TitleUtf8="5061636B616765205A6F6E65" /></UserOverlay></Video>"#;
+        let patched = render_user_overlay_config_xml(xml, "Front Door").unwrap();
+        assert!(!patched.contains("<Video>"));
+        assert!(patched.contains(r#"TitleUtf8="46726f6e7420446f6f72""#));
+        assert!(patched.contains(r#"TitleUtf8="5061636B616765205A6F6E65""#));
+    }
+
+    #[test]
+    fn clear_user_overlay_config_xml_blanks_all_slots() {
+        let xml = r#"<Video><Overlay><TitleOverlay TitleUtf8="46726f6e7420446f6f72" /></Overlay><UserOverlay><UserOSD enable="1" TitleUtf8="683a6d6d3a7373" Title="683a6d6d3a7373" /><UserOSD enable="0" TitleUtf8="46726f6e7420446f6f72" /></UserOverlay></Video>"#;
+        let patched = clear_user_overlay_config_xml(xml).unwrap();
+        assert!(!patched.contains(r#"TitleUtf8="683a6d6d3a7373""#));
+        assert!(!patched.contains(r#"Title="683a6d6d3a7373""#));
+        assert_eq!(patched.matches(r#"enable="0""#).count(), 2);
+        assert_eq!(patched.matches(r#"TitleUtf8="""#).count(), 2);
+    }
+
+    #[test]
+    fn user_overlay_requires_clear_detects_hidden_text_or_enabled_slots() {
+        let xml = r#"<Video><UserOverlay><UserOSD enable="0" TitleUtf8="" /><UserOSD enable="1" TitleUtf8="" /><UserOSD enable="0" TitleUtf8="683a6d6d3a7373" /></UserOverlay></Video>"#;
+        assert!(user_overlay_requires_clear(xml).unwrap());
+        let clean = r#"<Video><UserOverlay><UserOSD enable="0" TitleUtf8="" /><UserOSD enable="0" TitleUtf8="" /></UserOverlay></Video>"#;
+        assert!(!user_overlay_requires_clear(clean).unwrap());
+    }
+
+    #[test]
+    fn render_ntp_time_config_xml_preserves_summer_shape() {
+        let current = parse_time_config(r#"<TimeConfig TimeMode="MANUAL" CurTime="2026-04-18 09:54:18" TimeZone="300"><NTPConfig ServerIP="192.168.0.2" ServerPort="123" RefreshInterval="60" /><SummerTime enable="1" auto="1" offset="60"><start month="3" week="3" weekday="0" hour="2" /><end month="11" week="2" weekday="0" hour="2" /></SummerTime></TimeConfig>"#).unwrap();
+        let policy = XmSiteTimePolicy {
+            ntp_server: "192.168.0.2".to_string(),
+            timezone_code: 300,
+            current_local_time: "2026-04-18 10:00:00".to_string(),
+        };
+        let rendered = render_ntp_time_config_xml(&current, &policy);
+        assert!(rendered.contains(r#"TimeMode="NTP""#));
+        assert!(rendered.contains(r#"ServerIP="192.168.0.2""#));
+        assert!(rendered.contains(r#"TimeZone="300""#));
+        assert!(rendered.contains(r#"<SummerTime enable="1" auto="1" offset="60">"#));
+    }
+
+    #[test]
+    fn render_manual_time_config_xml_switches_to_manual() {
+        let current = parse_time_config(r#"<TimeConfig TimeMode="NTP" CurTime="2026-04-18 09:54:18" TimeZone="300"><NTPConfig ServerIP="192.168.0.2" ServerPort="123" RefreshInterval="60" /><SummerTime enable="0" auto="0" offset="60"><start month="3" week="3" weekday="0" hour="2" /><end month="11" week="2" weekday="0" hour="2" /></SummerTime></TimeConfig>"#).unwrap();
+        let policy = XmSiteTimePolicy {
+            ntp_server: "192.168.0.2".to_string(),
+            timezone_code: 300,
+            current_local_time: "2026-04-18 10:00:00".to_string(),
+        };
+        let rendered = render_manual_time_config_xml(&current, &policy);
+        assert!(rendered.contains(r#"TimeMode="MANUAL""#));
+        assert!(rendered.contains(r#"CurTime="2026-04-18 10:00:00""#));
+    }
+}


### PR DESCRIPTION
## Summary
- add a specialized xm_40e driver instead of treating the device as generic XM RTSP
- implement XM 40E mount, probe, config migration, observed/apply/verify, and live/media handling
- update install and operator guidance for decoder-capable ffmpeg and the validated XM path

## Validation
- cargo test --quiet
- cargo build --quiet
- live lab validation on 10.0.30.44 for XM 40E and Reolink managed preview/runtime behavior

Closes #14