### PR TITLE
fix(preview): recover live preview and reassert camera drift after source reboot

### DIFF
--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -48,11 +48,13 @@ This file stays at operator/compatibility-summary level.
   - preview note:
     - live preview depends on host HEVC decode because the validated RTSP profiles are HEVC
     - installer/runtime now treat decoder-capable `ffmpeg` as part of the supported contract
+    - temporary hard down/up should resume live preview without relaunch once the camera becomes reachable again
   - XM-specific management notes:
     - baked feed title is controlled by `TitleOverlay.TitleUtf8`
     - site time is controlled by `/setTimeConfig` with manual seed -> NTP transition
     - the effective NTP alias for this camera is `192.168.0.2`
     - a second XM `UserOverlay` lane can leak stale text into the lower-left corner; the active driver now clears that lane on apply so the feed only shows the main title and clock
+    - service-side reconcile is expected to reassert baked title and site NTP/time settings after reboot-driven drift when the camera is reachable again
 - PTZ is not supported on this model
 - Recommended status: supported for discovery, ingest, live preview, baked title, and site time when an onboarding alias exists on the camera NIC
 
@@ -82,6 +84,7 @@ This file stays at operator/compatibility-summary level.
   - current verification matches that split:
     - `time_mode` / `ntp_server` verify from ONVIF
     - `timezone` verifies from the feed-facing CGI time payload
+  - service-side reconcile is expected to reoffer supported site-time settings after reboot-driven drift when the camera is reachable again
   - follow-up live proof on `2026-04-17`:
     - the lab Fedora host required `confdir /etc/chrony.d` in `/etc/chrony.conf` before the bootstrap-written chrony drop-in was actually loaded and UDP `123` was served on the camera NIC
     - Reolink apply now also seeds the current site-local wall clock in the CGI time payload while leaving NTP enabled, so the baked feed clock converges immediately instead of waiting for the camera's next poll

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -116,6 +116,8 @@ Notes:
 - `/health` is intentionally redacted; camera credentials and raw credential-bearing RTSP URLs are never returned.
 - `/health` uses `cameraDevices` as the active pre-prod NVR camera payload key.
 - `cameraNetwork` should reflect the provisioned camera NIC, DHCP range, and active site-time policy (`ntp_enabled`, `ntp_server`, `timezone`).
+- temporary live-preview source loss should self-heal inside the running service; routine camera/network blips should not require relaunching the NVR page to resume tiles
+- verified supported drift after camera reboot should self-heal inside the running service; drift should not remain a permanent operator burden when the device is reachable again
 
 ## 7) Camera Hardening Script
 Audit-only:

--- a/src/api.rs
+++ b/src/api.rs
@@ -27,10 +27,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
+use tokio::time::{Duration, MissedTickBehavior, interval};
 use tracing::{debug, info, warn};
 
 const INSECURE_HELLO_SECRET_HEX: &str =
     "0000000000000000000000000000000000000000000000000000000000000000";
+const CAMERA_RECONCILE_INITIAL_DELAY_SECS: u64 = 5;
+const CAMERA_RECONCILE_INTERVAL_SECS: u64 = 20;
 
 #[derive(Clone)]
 pub struct ApiState {
@@ -87,6 +90,7 @@ pub async fn run(
         storage,
         recorder,
     });
+    spawn_camera_reconcile_loop(Arc::clone(&state));
 
     let app = Router::new()
         .route("/health", get(health))
@@ -100,6 +104,53 @@ pub async fn run(
     let listener = TcpListener::bind(&bind).await?;
     info!(bind = %bind, "api listener ready");
     axum::serve(listener, app).await?;
+    Ok(())
+}
+
+fn spawn_camera_reconcile_loop(state: Arc<ApiState>) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(CAMERA_RECONCILE_INITIAL_DELAY_SECS)).await;
+        let mut ticker = interval(Duration::from_secs(CAMERA_RECONCILE_INTERVAL_SECS));
+        ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            if let Err(err) = run_camera_reconcile_cycle(state.as_ref()).await {
+                warn!(error = %err, "camera reconcile cycle failed");
+            }
+        }
+    });
+}
+
+async fn run_camera_reconcile_cycle(state: &ApiState) -> Result<()> {
+    let cfg = state.cfg.lock().await.clone();
+    for camera in cfg.camera_devices.iter().filter(|camera| camera.enabled).cloned() {
+        match camera_device::reconcile_camera_device(&cfg, &camera).await {
+            Ok(Some(outcome)) => {
+                let changed = camera_device::reconcile::camera_config_changed(
+                    &camera,
+                    &outcome.configured,
+                );
+                if changed {
+                    persist_camera_source(state, outcome.configured.clone()).await?;
+                }
+                info!(
+                    source = %camera.source_id,
+                    changed,
+                    drift_fields = ?outcome.initial_drift_fields,
+                    verification_status = %outcome.mounted.verification.status,
+                    "camera drift reconcile applied"
+                );
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    source = %camera.source_id,
+                    error = %err,
+                    "camera drift reconcile failed"
+                );
+            }
+        }
+    }
     Ok(())
 }
 

--- a/src/camera_device/mod.rs
+++ b/src/camera_device/mod.rs
@@ -6,6 +6,7 @@ pub mod identification;
 pub mod inventory;
 pub mod mount;
 pub mod protocol;
+pub mod reconcile;
 pub mod registry;
 pub mod types;
 
@@ -234,6 +235,7 @@ pub use apply::apply_camera_device_config;
 pub use control::control_camera_device;
 pub use inventory::{list_camera_device_inventory, read_camera_device};
 pub use mount::mount_camera_device;
+pub use reconcile::reconcile_camera_device;
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/camera_device/reconcile.rs
+++ b/src/camera_device/reconcile.rs
@@ -1,0 +1,156 @@
+use super::*;
+use anyhow::{Result, anyhow};
+
+#[derive(Clone, Debug)]
+pub struct CameraDriftReconcileOutcome {
+    pub initial_drift_fields: Vec<String>,
+    pub configured: CameraConfig,
+    pub mounted: MountedCamera,
+}
+
+pub async fn reconcile_camera_device(
+    cfg: &Config,
+    camera: &CameraConfig,
+) -> Result<Option<CameraDriftReconcileOutcome>> {
+    let mounted_before = inventory::read_mounted_camera_device(cfg, camera).await;
+    let initial_actionable_drift_fields =
+        actionable_drift_fields(camera, &mounted_before.verification.drift_fields);
+    if initial_actionable_drift_fields.is_empty() {
+        return Ok(None);
+    }
+
+    let initial_drift_fields = initial_actionable_drift_fields;
+    let configured = apply_driver_desired(cfg, camera, camera).await?;
+    let mounted = inventory::read_mounted_camera_device(cfg, &configured).await;
+    let remaining_actionable_drift =
+        actionable_drift_fields(&configured, &mounted.verification.drift_fields);
+
+    match mounted.verification.status.trim() {
+        "verified" => Ok(Some(CameraDriftReconcileOutcome {
+            initial_drift_fields,
+            configured,
+            mounted,
+        })),
+        "failed" => Err(anyhow!(
+            "camera drift reconcile did not restore readable state: {}",
+            mounted.verification.message
+        )),
+        "drift" if remaining_actionable_drift.is_empty() => Ok(Some(CameraDriftReconcileOutcome {
+            initial_drift_fields,
+            configured,
+            mounted,
+        })),
+        "drift" => Err(anyhow!(
+            "camera drift reconcile did not clear actionable drift: {}",
+            remaining_actionable_drift.join(", ")
+        )),
+        other => Err(anyhow!(
+            "camera drift reconcile ended in unexpected status {:?}",
+            other
+        )),
+    }
+}
+
+pub fn camera_config_changed(left: &CameraConfig, right: &CameraConfig) -> bool {
+    serde_json::to_value(left).ok() != serde_json::to_value(right).ok()
+}
+
+fn actionable_drift_fields(
+    camera: &CameraConfig,
+    drift_fields: &[String],
+) -> Vec<String> {
+    drift_fields
+        .iter()
+        .filter(|field| camera_field_is_reconcilable(camera, field))
+        .cloned()
+        .collect()
+}
+
+fn camera_field_is_reconcilable(camera: &CameraConfig, field: &str) -> bool {
+    if camera.driver_id.trim() == DRIVER_ID_REOLINK {
+        return matches!(
+            field,
+            "display_name"
+                | "time_mode"
+                | "ntp_server"
+                | "timezone"
+                | "time_clock"
+                | "overlay_text"
+                | "overlay_timestamp"
+        );
+    }
+    if driver_is_xm(&camera.driver_id) {
+        return matches!(
+            field,
+            "display_name" | "time_mode" | "ntp_server" | "timezone" | "time_clock"
+        );
+    }
+    if camera.driver_id.trim() == DRIVER_ID_GENERIC_ONVIF_RTSP {
+        return matches!(field, "time_mode" | "ntp_server" | "timezone" | "time_clock");
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_camera() -> CameraConfig {
+        CameraConfig {
+            source_id: "cam-1".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "192.168.0.201".to_string(),
+            onvif_port: 8000,
+            rtsp_url: "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=1.sdp?real_stream".to_string(),
+            username: "admin".to_string(),
+            password: "123456".to_string(),
+            driver_id: DRIVER_ID_XM_40E.to_string(),
+            vendor: "XM/NetSurveillance".to_string(),
+            model: "40E".to_string(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDesiredConfig {
+                display_name: "Front Door".to_string(),
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        }
+    }
+
+    #[test]
+    fn reconcile_gate_only_uses_actionable_drift() {
+        let mut xm_camera = sample_camera();
+        let generic = CameraConfig {
+            driver_id: DRIVER_ID_GENERIC_ONVIF_RTSP.to_string(),
+            ..xm_camera.clone()
+        };
+
+        assert_eq!(
+            actionable_drift_fields(&xm_camera, &["display_name".to_string()]),
+            vec!["display_name".to_string()]
+        );
+        assert!(
+            actionable_drift_fields(&generic, &["display_name".to_string()]).is_empty()
+        );
+        xm_camera.driver_id = DRIVER_ID_REOLINK.to_string();
+        assert_eq!(
+            actionable_drift_fields(
+                &xm_camera,
+                &["overlay_text".to_string(), "time_clock".to_string()]
+            ),
+            vec!["overlay_text".to_string(), "time_clock".to_string()]
+        );
+    }
+
+    #[test]
+    fn camera_config_changed_detects_meaningful_delta() {
+        let left = sample_camera();
+        let mut right = left.clone();
+        assert!(!camera_config_changed(&left, &right));
+        right.desired.display_name = "Driveway".to_string();
+        assert!(camera_config_changed(&left, &right));
+    }
+}

--- a/src/live/preview.rs
+++ b/src/live/preview.rs
@@ -2,6 +2,7 @@ use crate::camera_device::registry::driver_is_xm;
 use crate::config::{CameraDeviceConfig as CameraConfig, Config, LivePreviewConfig};
 use crate::media::{ffmpeg, planner, types::OutputCodec};
 use crate::nostr::{self, NostrEvent};
+use crate::recording::runtime::backoff_secs;
 use anyhow::{Context, Result, anyhow};
 use rtp::packet::Packet as RtpPacket;
 use serde::{Deserialize, Serialize};
@@ -12,6 +13,7 @@ use std::sync::Arc;
 use tokio::net::UdpSocket;
 use tokio::process::Command;
 use tokio::sync::{Mutex, watch};
+use tokio::time::{Duration, Instant, sleep, timeout};
 use tracing::{info, warn};
 use webrtc::api::APIBuilder;
 use webrtc::api::media_engine::{MIME_TYPE_H264, MIME_TYPE_VP8, MediaEngine};
@@ -795,63 +797,222 @@ async fn run_camera_forwarder(
             return;
         }
     };
-
-    let mut ffmpeg = Command::new("ffmpeg");
-    ffmpeg.args(ffmpeg::build_live_preview_ffmpeg_args(
-        &plan,
-        local_addr.port(),
-    ));
-
-    let mut child = match ffmpeg
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
-        Err(err) => {
-            warn!(source = %camera.source_id, error = %err, "failed to launch ffmpeg live preview");
-            return;
-        }
-    };
-
-    info!(
-        source = %camera.source_id,
-        url = %preview_url,
-        codec = codec.label(),
-        "live preview forwarder started"
-    );
     let mut buf = vec![0u8; 1600];
+    let mut restart_attempt = 0_u64;
+    let mut restart_deadline: Option<Instant> = None;
+    let mut continuity = PreviewRtpContinuity::default();
+
     loop {
-        tokio::select! {
-            _ = stop_rx.changed() => {
-                break;
-            }
-            recv = socket.recv_from(&mut buf) => {
-                let (len, _) = match recv {
-                    Ok(v) => v,
-                    Err(err) => {
-                        warn!(source = %camera.source_id, error = %err, "live preview RTP recv failed");
-                        break;
-                    }
-                };
-                let mut slice = &buf[..len];
-                let packet = match RtpPacket::unmarshal(&mut slice) {
-                    Ok(packet) => packet,
-                    Err(err) => {
-                        warn!(source = %camera.source_id, error = %err, "live preview RTP unmarshal failed");
-                        continue;
-                    }
-                };
-                if let Err(err) = track.write_rtp(&packet).await {
-                    warn!(source = %camera.source_id, error = %err, "live preview RTP write failed");
+        if *stop_rx.borrow() {
+            break;
+        }
+
+        if let Some(deadline) = restart_deadline.take() {
+            let mut stop_wait = stop_rx.clone();
+            tokio::select! {
+                _ = stop_wait.changed() => {
+                    break;
                 }
+                _ = sleep(deadline.saturating_duration_since(Instant::now())) => {}
+            }
+        }
+
+        let mut ffmpeg = Command::new("ffmpeg");
+        ffmpeg.args(ffmpeg::build_live_preview_ffmpeg_args(
+            &plan,
+            local_addr.port(),
+        ));
+
+        let mut child = match ffmpeg
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(err) => {
+                restart_attempt += 1;
+                let backoff = backoff_secs(restart_attempt);
+                warn!(
+                    source = %camera.source_id,
+                    error = %err,
+                    backoff_secs = backoff,
+                    "failed to launch ffmpeg live preview; will retry"
+                );
+                restart_deadline = Some(Instant::now() + Duration::from_secs(backoff));
+                continue;
+            }
+        };
+
+        info!(
+            source = %camera.source_id,
+            url = %preview_url,
+            codec = codec.label(),
+            restart_attempt,
+            "live preview forwarder started"
+        );
+
+        let exit_reason = loop {
+            tokio::select! {
+                _ = stop_rx.changed() => {
+                    break PreviewExitReason::Stopped;
+                }
+                status = child.wait() => {
+                    break match status {
+                        Ok(status) => PreviewExitReason::ChildExited(format!("ffmpeg exited with status {}", status)),
+                        Err(err) => PreviewExitReason::ChildWaitFailed(err.to_string()),
+                    };
+                }
+                recv = timeout(Duration::from_secs(preview_no_packet_timeout_secs()), socket.recv_from(&mut buf)) => {
+                    match recv {
+                        Ok(Ok((len, _))) => {
+                            restart_attempt = 0;
+                            let mut slice = &buf[..len];
+                            let mut packet = match RtpPacket::unmarshal(&mut slice) {
+                                Ok(packet) => packet,
+                                Err(err) => {
+                                    warn!(source = %camera.source_id, error = %err, "live preview RTP unmarshal failed");
+                                    continue;
+                                }
+                            };
+                            continuity.rewrite(&mut packet);
+                            if let Err(err) = track.write_rtp(&packet).await {
+                                warn!(source = %camera.source_id, error = %err, "live preview RTP write failed");
+                            }
+                        }
+                        Ok(Err(err)) => {
+                            break PreviewExitReason::SocketRecvFailed(err.to_string());
+                        }
+                        Err(_) => {
+                            break PreviewExitReason::NoPackets(preview_no_packet_timeout_secs());
+                        }
+                    }
+                }
+            }
+        };
+
+        let _ = child.kill().await;
+        let _ = child.wait().await;
+
+        match exit_reason {
+            PreviewExitReason::Stopped => break,
+            PreviewExitReason::ChildExited(message)
+            | PreviewExitReason::ChildWaitFailed(message)
+            | PreviewExitReason::SocketRecvFailed(message) => {
+                restart_attempt += 1;
+                let backoff = backoff_secs(restart_attempt);
+                warn!(
+                    source = %camera.source_id,
+                    message,
+                    backoff_secs = backoff,
+                    "live preview forwarder exited; restarting"
+                );
+                restart_deadline = Some(Instant::now() + Duration::from_secs(backoff));
+            }
+            PreviewExitReason::NoPackets(timeout_secs) => {
+                restart_attempt += 1;
+                let backoff = backoff_secs(restart_attempt);
+                warn!(
+                    source = %camera.source_id,
+                    idle_timeout_secs = timeout_secs,
+                    backoff_secs = backoff,
+                    "live preview forwarder stalled without RTP; restarting"
+                );
+                restart_deadline = Some(Instant::now() + Duration::from_secs(backoff));
             }
         }
     }
 
-    let _ = child.kill().await;
-    let _ = child.wait().await;
     info!(source = %camera.source_id, "live preview forwarder stopped");
+}
+
+#[derive(Debug)]
+enum PreviewExitReason {
+    Stopped,
+    ChildExited(String),
+    ChildWaitFailed(String),
+    SocketRecvFailed(String),
+    NoPackets(u64),
+}
+
+#[derive(Debug, Default)]
+struct PreviewRtpContinuity {
+    last_source_sequence: Option<u16>,
+    last_source_timestamp: Option<u32>,
+    last_output_sequence: Option<u16>,
+    last_output_timestamp: Option<u32>,
+    last_timestamp_step: u32,
+}
+
+impl PreviewRtpContinuity {
+    fn rewrite(&mut self, packet: &mut RtpPacket) {
+        let source_sequence = packet.header.sequence_number;
+        let source_timestamp = packet.header.timestamp;
+
+        match (
+            self.last_source_sequence,
+            self.last_source_timestamp,
+            self.last_output_sequence,
+            self.last_output_timestamp,
+        ) {
+            (Some(prev_src_seq), Some(prev_src_ts), Some(prev_out_seq), Some(prev_out_ts)) => {
+                let sequence_step = continuity_sequence_step(prev_src_seq, source_sequence);
+                let timestamp_step = continuity_timestamp_step(
+                    prev_src_ts,
+                    source_timestamp,
+                    self.last_timestamp_step,
+                );
+                let output_sequence = prev_out_seq.wrapping_add(sequence_step);
+                let output_timestamp = prev_out_ts.wrapping_add(timestamp_step);
+                packet.header.sequence_number = output_sequence;
+                packet.header.timestamp = output_timestamp;
+                self.last_output_sequence = Some(output_sequence);
+                self.last_output_timestamp = Some(output_timestamp);
+                self.last_timestamp_step = timestamp_step.max(1);
+            }
+            _ => {
+                packet.header.sequence_number = source_sequence;
+                packet.header.timestamp = source_timestamp;
+                self.last_output_sequence = Some(source_sequence);
+                self.last_output_timestamp = Some(source_timestamp);
+                self.last_timestamp_step = default_preview_timestamp_step();
+            }
+        }
+
+        self.last_source_sequence = Some(source_sequence);
+        self.last_source_timestamp = Some(source_timestamp);
+    }
+}
+
+fn continuity_sequence_step(previous: u16, current: u16) -> u16 {
+    let delta = current.wrapping_sub(previous);
+    if delta == 0 || delta > 4096 {
+        1
+    } else {
+        delta
+    }
+}
+
+fn continuity_timestamp_step(previous: u32, current: u32, last_step: u32) -> u32 {
+    let delta = current.wrapping_sub(previous);
+    if delta == 0 {
+        0
+    } else if delta > continuity_restart_timestamp_threshold() {
+        last_step.max(default_preview_timestamp_step())
+    } else {
+        delta
+    }
+}
+
+fn default_preview_timestamp_step() -> u32 {
+    3000
+}
+
+fn continuity_restart_timestamp_threshold() -> u32 {
+    90_000 * 5
+}
+
+fn preview_no_packet_timeout_secs() -> u64 {
+    8
 }
 
 #[cfg(test)]
@@ -1238,5 +1399,35 @@ mod tests {
         assert!(output.contains("a=msid-semantic:WMS *\r\n"));
         assert!(output.contains("a=mid:0\r\na=msid:session-1 cam-1\r\n"));
         assert!(output.contains("a=mid:1\r\na=msid:session-1 cam-2\r\n"));
+    }
+
+    #[test]
+    fn preview_no_packet_timeout_stays_short() {
+        assert_eq!(preview_no_packet_timeout_secs(), 8);
+    }
+
+    #[test]
+    fn preview_rtp_continuity_rewrites_large_restart_jumps() {
+        let mut continuity = PreviewRtpContinuity::default();
+        let mut first = RtpPacket::default();
+        first.header.sequence_number = 40_000;
+        first.header.timestamp = 120_000;
+        continuity.rewrite(&mut first);
+        assert_eq!(first.header.sequence_number, 40_000);
+        assert_eq!(first.header.timestamp, 120_000);
+
+        let mut second = RtpPacket::default();
+        second.header.sequence_number = 40_003;
+        second.header.timestamp = 123_000;
+        continuity.rewrite(&mut second);
+        assert_eq!(second.header.sequence_number, 40_003);
+        assert_eq!(second.header.timestamp, 123_000);
+
+        let mut restarted = RtpPacket::default();
+        restarted.header.sequence_number = 7;
+        restarted.header.timestamp = 9_000;
+        continuity.rewrite(&mut restarted);
+        assert_eq!(restarted.header.sequence_number, 40_004);
+        assert_eq!(restarted.header.timestamp, 126_000);
     }
 }


### PR DESCRIPTION
## Summary
- recover managed live preview after temporary camera/source loss without relaunching NVR
- add service-side drift reconcile so managed cameras reassert supported desired state automatically
- cover XM 40E reboot/config drift for baked title plus NTP/site time

## Validation
- `cargo test --quiet`
- `cargo build --quiet`
- live lab proof on `10.0.30.44`
  - forced XM drift outside policy and verified automatic recovery back to `Front Door` plus `192.168.0.2` NTP on the installed service
  - forced Reolink RTSP outage and verified preview packet flow resumed without relaunch after source recovery

Closes #18