### PR TITLE
Add camera convergence CAAC events

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,6 +24,7 @@ Future `constitute-physec` may consume NVR camera/media/history projections as a
 ### 2. Ingest Layer
 - ONVIF WS-Discovery probe support
 - camera source registry from config plus control-plane mutations
+- stable camera identity owns `source_id`; current IP/RTSP endpoints are driver-resolved transport state and may change after DHCP/power events
 - RTSP ingest execution via `ffmpeg` with explicit runtime state machine and restart/backoff
 - substream preference where camera capabilities allow
 
@@ -51,7 +52,7 @@ Media projection owns or is actively converging toward:
 
 It consumes `camera_device` stream truth and `media` plans.
 It feeds `live`, `recording`, and future encrypted storage output.
-It emits structured event truth through the NVR logging surface for `constitute-logging`.
+It emits structured event truth through the NVR logging surface for `constitute-logging`, including preview projection stalls, ffmpeg start/exit/socket failures, retry/backoff scheduling, and recovery after packets resume.
 It should expose posture facts cleanly enough for future `constitute-cybersec`.
 It must not become camera driver truth, gateway signaling, cybersecurity policy, Physical Security product workflow, or storage implementation.
 
@@ -91,7 +92,7 @@ Current service access authorization uses `constitute-protocol` CAAC service cap
 
 ## Logging Surface
 NVR exposes a durable cursor-based logging surface for `constitute-logging`.
-Current producer-owned event streams cover camera device state, media/session lifecycle, admin/control calls, projection recovery, recording lifecycle, and worker supervision.
+Current producer-owned event streams cover camera device state, camera drift convergence/failure, media/session lifecycle, admin/control calls, projection stall/retry/recovery, recording lifecycle, and worker supervision.
 
 NVR formulates safe facts from its own plaintext context and encrypts sensitive detail before exposing the log record.
 The logging surface intentionally excludes camera credentials, service capabilities, CAAC plaintext, raw admin/control payloads, decrypted request bodies, raw source secrets, credential-bearing RTSP URLs, and worker argv secrets from safe facts.

--- a/docs/CAMERA_COMPAT.md
+++ b/docs/CAMERA_COMPAT.md
@@ -53,6 +53,9 @@ This file stays at operator/compatibility-summary level.
     - baked feed title is controlled by `TitleOverlay.TitleUtf8`
     - site time is controlled by `/setTimeConfig` with manual seed -> NTP transition
     - the effective NTP alias for this camera is `192.168.0.2`
+    - `camera_network.ntp_server` is the site-time policy value; the driver resolves a reachable per-camera endpoint such as the onboarding alias
+    - host NTP serving and camera-NIC firewall ingress must allow both the managed camera subnet and onboarding alias subnets assigned to the camera NIC
+    - the driver must clear stale XM `SummerTime` offset state while applying Phoenix/site time, because feed-clock truth can diverge from the normalized `TimeConfig` summary
     - a second XM `UserOverlay` lane can leak stale text into the lower-left corner; the active driver now clears that lane on apply so the feed only shows the main title and clock
     - service-side reconcile is expected to reassert baked title and site NTP/time settings after reboot-driven drift when the camera is reachable again
 - PTZ is not supported on this model

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -103,6 +103,8 @@ Notes:
   - current recording uses video-only MP4 segmentation because the validated lab camera exposes `pcm_mulaw` audio that cannot be copied directly into MP4
   - live preview for this camera requires HEVC decode on the host because the validated RTSP profiles are HEVC, not H.264
   - site time for the lab XM camera is served from the host-side onboarding alias `192.168.0.2`
+  - chrony and the camera-NIC firewall must allow the managed camera subnet and any onboarding alias subnets on the camera NIC
+  - `camera_network.ntp_server` is policy; the driver resolves the reachable per-camera NTP endpoint
   - the baked feed title is driven through `TitleOverlay.TitleUtf8`
   - the hidden XM `UserOverlay` lane must stay cleared so stale lower-left text does not leak into the baked feed
 
@@ -138,6 +140,7 @@ sudo bash scripts/linux/harden-camera-interface.sh \
 Expected effect:
 - camera NIC zone target `DROP`
 - camera->host DHCP remains allowed on the isolated segment
+- camera->host NTP is allowed from the managed camera subnet and any IPv4 alias subnets assigned to the camera NIC
 - host egress on camera NIC restricted to DHCP/camera-control/RTSP (+ Reolink discovery UDP `2000/3000`, optional WS-Discovery, optional NTP); default control allowlist includes Reolink `9000/tcp`
 
 ## 8) Manual Session Protocol Test (Identity-bound)

--- a/scripts/linux/bootstrap-camera-network.sh
+++ b/scripts/linux/bootstrap-camera-network.sh
@@ -410,15 +410,66 @@ EOF
   run_sudo systemctl restart dnsmasq >/dev/null
 }
 
+chrony_allow_networks() {
+  {
+    printf '%s\n' "$CAMERA_CIDR"
+    ip -4 -o addr show dev "$CAMERA_IFACE" scope global 2>/dev/null | awk '{ print $4 }'
+    for alias in "${ONBOARDING_ALIASES[@]}"; do
+      ALIAS_CIDR="$alias" python3 - <<'PY'
+import ipaddress
+import os
+import sys
+
+value = os.environ.get("ALIAS_CIDR", "").strip()
+if not value:
+    sys.exit(0)
+try:
+    print(ipaddress.ip_interface(value).network)
+except ValueError:
+    try:
+        print(ipaddress.ip_network(value, strict=False))
+    except ValueError:
+        print(f"invalid onboarding alias CIDR: {value}", file=sys.stderr)
+        sys.exit(1)
+PY
+    done
+  } | python3 -c '
+import ipaddress
+import sys
+
+seen = set()
+for raw in sys.stdin:
+    value = raw.strip()
+    if not value:
+        continue
+    try:
+        network = ipaddress.ip_interface(value).network
+    except ValueError:
+        try:
+            network = ipaddress.ip_network(value, strict=False)
+        except ValueError:
+            print(f"invalid camera network CIDR: {value}", file=sys.stderr)
+            sys.exit(1)
+    normalized = str(network)
+    if normalized not in seen:
+        seen.add(normalized)
+        print(normalized)
+'
+}
+
 write_chrony_config() {
   detect_chrony_dropin
   ensure_chrony_dropin_loaded
   run_sudo mkdir -p "$(dirname "$CHRONY_DROPIN")"
-  cat <<EOF | run_sudo tee "$CHRONY_DROPIN" >/dev/null
+  {
+    cat <<EOF
 # Managed by constitute-nvr camera bootstrap.
-allow ${CAMERA_CIDR}
+EOF
+    chrony_allow_networks | awk '{ print "allow " $0 }'
+    cat <<EOF
 local stratum 10
 EOF
+  } | run_sudo tee "$CHRONY_DROPIN" >/dev/null
   restart_chrony
 }
 

--- a/scripts/linux/harden-camera-interface.sh
+++ b/scripts/linux/harden-camera-interface.sh
@@ -214,6 +214,39 @@ if ! ip link show "$IFACE" >/dev/null 2>&1; then
   exit 1
 fi
 
+mapfile -t CAMERA_NETWORK_CIDRS < <(
+  {
+    printf '%s\n' "$CAMERA_CIDR"
+    ip -4 -o addr show dev "$IFACE" scope global 2>/dev/null | awk '{ print $4 }'
+  } | python3 -c '
+import ipaddress
+import sys
+
+seen = set()
+for raw in sys.stdin:
+    value = raw.strip()
+    if not value:
+        continue
+    try:
+        network = ipaddress.ip_interface(value).network
+    except ValueError:
+        try:
+            network = ipaddress.ip_network(value, strict=False)
+        except ValueError:
+            print(f"invalid camera network CIDR: {value}", file=sys.stderr)
+            sys.exit(1)
+    normalized = str(network)
+    if normalized not in seen:
+        seen.add(normalized)
+        print(normalized)
+'
+)
+if [[ "${#CAMERA_NETWORK_CIDRS[@]}" -eq 0 ]]; then
+  echo "No camera networks resolved for $IFACE" >&2
+  exit 1
+fi
+log "camera networks: ${CAMERA_NETWORK_CIDRS[*]}"
+
 if ! run_sudo firewall-cmd --permanent --get-zones | tr ' ' '\n' | grep -qx "$ZONE_NAME"; then
   log "creating firewalld zone: $ZONE_NAME"
   run_sudo firewall-cmd --permanent --new-zone="$ZONE_NAME" >/dev/null
@@ -227,7 +260,6 @@ if ! run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --query-interface="$I
   run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-interface="$IFACE" >/dev/null
 fi
 
-ntp_rule="rule family=\"ipv4\" source address=\"${CAMERA_CIDR}\" port protocol=\"udp\" port=\"123\" accept"
 while IFS= read -r existing_rule; do
   [[ -z "$existing_rule" ]] && continue
   if [[ "$existing_rule" == *'port port="67" protocol="udp"'* || "$existing_rule" == *'port port="123" protocol="udp"'* ]]; then
@@ -238,10 +270,12 @@ done < <(run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --list-rich-rules
 log "allowing camera->host DHCP bootstrap (udp/67) on $IFACE"
 run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-port=67/udp >/dev/null 2>&1 || true
 
-run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --remove-rich-rule="$ntp_rule" >/dev/null 2>&1 || true
 if [[ "$ALLOW_NTP_HOST" -eq 1 ]]; then
-  log "allowing camera->host NTP (udp/123) from $CAMERA_CIDR"
-  run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-rich-rule="$ntp_rule" >/dev/null
+  for cidr in "${CAMERA_NETWORK_CIDRS[@]}"; do
+    ntp_rule="rule family=\"ipv4\" source address=\"${cidr}\" port protocol=\"udp\" port=\"123\" accept"
+    log "allowing camera->host NTP (udp/123) from $cidr"
+    run_sudo firewall-cmd --permanent --zone="$ZONE_NAME" --add-rich-rule="$ntp_rule" >/dev/null
+  done
 fi
 
 log "reloading firewalld"
@@ -252,18 +286,20 @@ run_sudo nft "add table inet ${NFT_TABLE}" >/dev/null 2>&1 || true
 run_sudo nft "delete chain inet ${NFT_TABLE} output" >/dev/null 2>&1 || true
 run_sudo nft "add chain inet ${NFT_TABLE} output { type filter hook output priority 0; policy accept; }"
 
-run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} tcp dport { ${ALLOWED_TCP_PORTS//,/ , } } accept"
-run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport 68 accept"
-run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport { 2000, 3000 } accept"
-if [[ "$ALLOW_ONVIF_DISCOVERY" -eq 1 ]]; then
-  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport 3702 accept"
-fi
-if [[ "$ALLOW_NTP_HOST" -eq 1 ]]; then
-  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} udp dport 123 accept"
-fi
-if [[ "$NO_EGRESS_LOCK" -eq 0 ]]; then
-  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${CAMERA_CIDR} drop"
-fi
+for cidr in "${CAMERA_NETWORK_CIDRS[@]}"; do
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} tcp dport { ${ALLOWED_TCP_PORTS//,/ , } } accept"
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} udp dport 68 accept"
+  run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} udp dport { 2000, 3000 } accept"
+  if [[ "$ALLOW_ONVIF_DISCOVERY" -eq 1 ]]; then
+    run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} udp dport 3702 accept"
+  fi
+  if [[ "$ALLOW_NTP_HOST" -eq 1 ]]; then
+    run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} udp dport 123 accept"
+  fi
+  if [[ "$NO_EGRESS_LOCK" -eq 0 ]]; then
+    run_sudo nft "add rule inet ${NFT_TABLE} output oifname \"${IFACE}\" ip daddr ${cidr} drop"
+  fi
+done
 
 log "applied"
 run_sudo firewall-cmd --zone="$ZONE_NAME" --list-all || true

--- a/src/api.rs
+++ b/src/api.rs
@@ -132,6 +132,36 @@ async fn run_camera_reconcile_cycle(state: &ApiState) -> Result<()> {
         .filter(|camera| camera.enabled)
         .cloned()
     {
+        let mut camera = camera;
+        match camera_device::reconcile_camera_identity_and_endpoint(&cfg, &camera).await {
+            Ok(Some(outcome)) => {
+                persist_camera_source_replacing(
+                    state,
+                    &outcome.previous_source_id,
+                    &outcome.previous_host,
+                    outcome.configured.clone(),
+                )
+                .await?;
+                submit_camera_identity_reconcile_event(&outcome).await;
+                info!(
+                    previous_source = %outcome.previous_source_id,
+                    source = %outcome.configured.source_id,
+                    match_kind = %outcome.match_kind,
+                    confidence = outcome.confidence,
+                    "camera identity endpoint reconcile applied"
+                );
+                camera = outcome.configured;
+            }
+            Ok(None) => {}
+            Err(err) => {
+                warn!(
+                    source = %camera.source_id,
+                    error = %err,
+                    "camera identity endpoint reconcile failed"
+                );
+            }
+        }
+
         match camera_device::reconcile_camera_device(&cfg, &camera).await {
             Ok(Some(outcome)) => {
                 let changed =
@@ -139,6 +169,7 @@ async fn run_camera_reconcile_cycle(state: &ApiState) -> Result<()> {
                 if changed {
                     persist_camera_source(state, outcome.configured.clone()).await?;
                 }
+                submit_camera_drift_reconcile_event(&outcome, changed).await;
                 info!(
                     source = %camera.source_id,
                     changed,
@@ -149,6 +180,7 @@ async fn run_camera_reconcile_cycle(state: &ApiState) -> Result<()> {
             }
             Ok(None) => {}
             Err(err) => {
+                submit_camera_drift_reconcile_failed_event(&camera).await;
                 warn!(
                     source = %camera.source_id,
                     error = %err,
@@ -158,6 +190,100 @@ async fn run_camera_reconcile_cycle(state: &ApiState) -> Result<()> {
         }
     }
     Ok(())
+}
+
+async fn submit_camera_identity_reconcile_event(
+    outcome: &camera_device::reconcile::CameraIdentityReconcileOutcome,
+) {
+    crate::logging_surface::submit_safe_event(
+        "camera_device",
+        LogCategory::CameraDevice,
+        LogSeverity::Notice,
+        LogOutcome::Recovered,
+        LogSubjectRef {
+            kind: "camera".to_string(),
+            id: Some(outcome.configured.source_id.clone()),
+            display: Some(outcome.configured.name.clone()),
+        },
+        &["nvr", "camera_device", "identity_reconcile"],
+        json!({
+            "eventType": "camera_identity_endpoint_reconciled",
+            "sourceId": outcome.configured.source_id,
+            "previousSourceId": outcome.previous_source_id,
+            "driverId": outcome.configured.driver_id,
+            "vendor": outcome.configured.vendor,
+            "model": outcome.configured.model,
+            "matchKind": outcome.match_kind,
+            "confidence": outcome.confidence,
+            "endpointChanged": outcome.previous_host != outcome.configured.onvif_host,
+        }),
+    )
+    .await;
+}
+
+async fn submit_camera_drift_reconcile_event(
+    outcome: &camera_device::reconcile::CameraDriftReconcileOutcome,
+    changed: bool,
+) {
+    crate::logging_surface::submit_safe_event(
+        "camera_device",
+        LogCategory::CameraDevice,
+        LogSeverity::Notice,
+        LogOutcome::Recovered,
+        camera_log_subject(&outcome.configured),
+        &["nvr", "camera_device", "drift_reconcile"],
+        camera_drift_reconcile_safe_facts(outcome, changed),
+    )
+    .await;
+}
+
+async fn submit_camera_drift_reconcile_failed_event(camera: &CameraDeviceConfig) {
+    crate::logging_surface::submit_safe_event(
+        "camera_device",
+        LogCategory::CameraDevice,
+        LogSeverity::Warning,
+        LogOutcome::Failed,
+        camera_log_subject(camera),
+        &["nvr", "camera_device", "drift_reconcile", "repair_needed"],
+        json!({
+            "eventType": "camera_drift_reconcile_failed",
+            "sourceId": camera.source_id,
+            "cameraName": camera.name,
+            "driverId": camera.driver_id,
+            "vendor": camera.vendor,
+            "model": camera.model,
+            "repairNeeded": true,
+            "errorClass": "camera_drift_reconcile_failed",
+        }),
+    )
+    .await;
+}
+
+fn camera_log_subject(camera: &CameraDeviceConfig) -> LogSubjectRef {
+    LogSubjectRef {
+        kind: "camera".to_string(),
+        id: Some(camera.source_id.clone()),
+        display: Some(camera.name.clone()),
+    }
+}
+
+fn camera_drift_reconcile_safe_facts(
+    outcome: &camera_device::reconcile::CameraDriftReconcileOutcome,
+    changed: bool,
+) -> Value {
+    json!({
+        "eventType": "camera_drift_reconciled",
+        "sourceId": outcome.configured.source_id,
+        "cameraName": outcome.configured.name,
+        "driverId": outcome.configured.driver_id,
+        "vendor": outcome.configured.vendor,
+        "model": outcome.configured.model,
+        "driftFields": outcome.initial_drift_fields,
+        "changed": changed,
+        "verificationStatus": outcome.mounted.verification.status,
+        "remainingDriftFields": outcome.mounted.verification.drift_fields,
+        "repairNeeded": false,
+    })
 }
 
 async fn health(State(state): State<Arc<ApiState>>) -> Json<Value> {
@@ -1087,12 +1213,21 @@ async fn handle_command(
                 .as_ref()
                 .map(|d| d.uid.clone())
                 .unwrap_or_default();
+            let mac = discovered_entry
+                .as_ref()
+                .map(|d| d.mac.clone())
+                .unwrap_or_default();
             let model = discovered_entry
                 .as_ref()
                 .map(|d| d.model.clone())
                 .unwrap_or_default();
 
-            let source_id = build_reolink_source_id(&uid, &request.ip);
+            let source_id =
+                camera_device::reolink_stable_source_id(&uid, &mac).ok_or_else(|| {
+                    anyhow!(
+                        "Reolink setup did not discover a stable UID or MAC for source identity"
+                    )
+                })?;
             let source_name = if model.trim().is_empty() {
                 format!("Reolink {}", request.ip)
             } else {
@@ -1115,10 +1250,7 @@ async fn handle_command(
                     .as_ref()
                     .map(|entry| entry.model.clone())
                     .unwrap_or_default(),
-                mac_address: discovered_entry
-                    .as_ref()
-                    .map(|entry| entry.mac.clone())
-                    .unwrap_or_default(),
+                mac_address: mac,
                 rtsp_port,
                 ptz_capable: source_id.contains("e1") || source_id.contains("ptz"),
                 enabled: true,
@@ -1263,45 +1395,46 @@ async fn handle_command(
 }
 
 async fn persist_camera_source(state: &ApiState, camera_cfg: CameraDeviceConfig) -> Result<()> {
-    let storage_root =
-        {
-            let mut guard = state.cfg.lock().await;
-            if let Some(existing) = guard.camera_devices.iter_mut().find(|c| {
-                c.source_id == camera_cfg.source_id || c.onvif_host == camera_cfg.onvif_host
-            }) {
-                *existing = camera_cfg.clone();
-            } else {
-                guard.camera_devices.push(camera_cfg.clone());
-            }
-            guard.apply_defaults();
-            let snapshot = guard.clone();
-            snapshot.persist(&state.cfg_path)?;
-            let _ = hosted_registry::persist_hosted_service_manifest(&snapshot);
-            snapshot.storage_root()
-        };
+    persist_camera_source_replacing(state, "", "", camera_cfg).await
+}
 
+async fn persist_camera_source_replacing(
+    state: &ApiState,
+    previous_source_id: &str,
+    previous_host: &str,
+    camera_cfg: CameraDeviceConfig,
+) -> Result<()> {
+    let storage_root = {
+        let mut guard = state.cfg.lock().await;
+        if let Some(index) = guard.camera_devices.iter().position(|c| {
+            (!previous_source_id.trim().is_empty()
+                && c.source_id.trim() == previous_source_id.trim())
+                || c.source_id == camera_cfg.source_id
+                || (!previous_host.trim().is_empty() && c.onvif_host.trim() == previous_host.trim())
+                || c.onvif_host == camera_cfg.onvif_host
+        }) {
+            guard.camera_devices[index] = camera_cfg.clone();
+        } else {
+            guard.camera_devices.push(camera_cfg.clone());
+        }
+        guard.apply_defaults();
+        let snapshot = guard.clone();
+        snapshot.persist(&state.cfg_path)?;
+        let _ = hosted_registry::persist_hosted_service_manifest(&snapshot);
+        snapshot.storage_root()
+    };
+
+    if !previous_source_id.trim().is_empty()
+        && previous_source_id.trim() != camera_cfg.source_id.trim()
+    {
+        state
+            .recorder
+            .remove_camera(previous_source_id.trim())
+            .await;
+    }
     state.recorder.upsert_camera(storage_root, camera_cfg).await;
 
     Ok(())
-}
-
-fn build_reolink_source_id(uid: &str, ip: &str) -> String {
-    let key = if uid.trim().is_empty() {
-        ip.trim()
-    } else {
-        uid.trim()
-    };
-    let sanitized = key
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
-    format!("reolink-{}", sanitized.trim_matches('-'))
 }
 
 async fn send_cipher_error(socket: &mut WebSocket, key: &[u8], message: &str) -> Result<()> {
@@ -1335,4 +1468,65 @@ fn default_enabled() -> bool {
 
 fn default_segment_secs() -> u64 {
     10
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_camera() -> CameraDeviceConfig {
+        CameraDeviceConfig {
+            source_id: "xm-40e-front-door".to_string(),
+            name: "Front Door".to_string(),
+            onvif_host: "192.0.2.10".to_string(),
+            onvif_port: 80,
+            rtsp_url: "rtsp://example.invalid/redacted".to_string(),
+            username: "admin".to_string(),
+            password: "redacted".to_string(),
+            driver_id: "xm_40e".to_string(),
+            vendor: "XM".to_string(),
+            model: "40E".to_string(),
+            mac_address: "00:00:00:00:00:00".to_string(),
+            rtsp_port: 554,
+            ptz_capable: false,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDeviceDesiredConfig::default(),
+            credentials: Default::default(),
+        }
+    }
+
+    #[test]
+    fn camera_drift_reconcile_safe_facts_do_not_expose_transport_or_secrets() {
+        let camera = test_camera();
+        let mut mounted = camera_device::MountedCamera {
+            source_id: camera.source_id.clone(),
+            driver_id: camera.driver_id.clone(),
+            display_name: camera.name.clone(),
+            vendor: camera.vendor.clone(),
+            model: camera.model.clone(),
+            ..Default::default()
+        };
+        mounted.verification.status = "verified".to_string();
+        mounted.verification.drift_fields = vec!["time_clock".to_string()];
+        let outcome = camera_device::reconcile::CameraDriftReconcileOutcome {
+            initial_drift_fields: vec!["timezone".to_string(), "time_clock".to_string()],
+            configured: camera,
+            mounted,
+        };
+
+        let facts = camera_drift_reconcile_safe_facts(&outcome, true);
+
+        assert_eq!(facts["eventType"], json!("camera_drift_reconciled"));
+        assert_eq!(facts["driverId"], json!("xm_40e"));
+        assert_eq!(facts["driftFields"][0], json!("timezone"));
+        assert_eq!(facts["changed"], json!(true));
+        assert_eq!(facts["repairNeeded"], json!(false));
+        assert!(facts.get("rtsp_url").is_none());
+        assert!(facts.get("rtspUrl").is_none());
+        assert!(facts.get("password").is_none());
+        assert!(facts.get("username").is_none());
+        assert!(facts.get("onvifHost").is_none());
+        assert!(facts.get("macAddress").is_none());
+    }
 }

--- a/src/camera_device/drivers/xm_40e/driver.rs
+++ b/src/camera_device/drivers/xm_40e/driver.rs
@@ -721,15 +721,12 @@ fn user_overlay_requires_clear(xml: &str) -> Result<bool> {
 
 fn render_ntp_time_config_xml(current: &XmTimeConfig, policy: &XmSiteTimePolicy) -> String {
     format!(
-        "<TimeConfig TimeMode=\"NTP\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"{}\" auto=\"{}\" offset=\"{}\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
+        "<TimeConfig TimeMode=\"NTP\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"0\" auto=\"0\" offset=\"0\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
         xml_escape_attr(&policy.current_local_time),
         policy.timezone_code,
         xml_escape_attr(&policy.ntp_server),
         current.ntp_port,
         current.refresh_interval_secs,
-        if current.summer_time.enabled { 1 } else { 0 },
-        if current.summer_time.automatic { 1 } else { 0 },
-        current.summer_time.offset_minutes,
         current.summer_time.start.month,
         current.summer_time.start.week,
         current.summer_time.start.weekday,
@@ -743,15 +740,12 @@ fn render_ntp_time_config_xml(current: &XmTimeConfig, policy: &XmSiteTimePolicy)
 
 fn render_manual_time_config_xml(current: &XmTimeConfig, policy: &XmSiteTimePolicy) -> String {
     format!(
-        "<TimeConfig TimeMode=\"MANUAL\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"{}\" auto=\"{}\" offset=\"{}\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
+        "<TimeConfig TimeMode=\"MANUAL\" CurTime=\"{}\" TimeZone=\"{}\"><NTPConfig ServerIP=\"{}\" ServerPort=\"{}\" RefreshInterval=\"{}\" /><SummerTime enable=\"0\" auto=\"0\" offset=\"0\"><start month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /><end month=\"{}\" week=\"{}\" weekday=\"{}\" hour=\"{}\" /></SummerTime></TimeConfig>",
         xml_escape_attr(&policy.current_local_time),
         policy.timezone_code,
         xml_escape_attr(&policy.ntp_server),
         current.ntp_port,
         current.refresh_interval_secs,
-        if current.summer_time.enabled { 1 } else { 0 },
-        if current.summer_time.automatic { 1 } else { 0 },
-        current.summer_time.offset_minutes,
         current.summer_time.start.month,
         current.summer_time.start.week,
         current.summer_time.start.weekday,
@@ -852,7 +846,7 @@ mod tests {
     }
 
     #[test]
-    fn render_ntp_time_config_xml_preserves_summer_shape() {
+    fn render_ntp_time_config_xml_clears_summer_offset_for_site_policy() {
         let current = parse_time_config(r#"<TimeConfig TimeMode="MANUAL" CurTime="2026-04-18 09:54:18" TimeZone="300"><NTPConfig ServerIP="192.168.0.2" ServerPort="123" RefreshInterval="60" /><SummerTime enable="1" auto="1" offset="60"><start month="3" week="3" weekday="0" hour="2" /><end month="11" week="2" weekday="0" hour="2" /></SummerTime></TimeConfig>"#).unwrap();
         let policy = XmSiteTimePolicy {
             ntp_server: "192.168.0.2".to_string(),
@@ -863,7 +857,7 @@ mod tests {
         assert!(rendered.contains(r#"TimeMode="NTP""#));
         assert!(rendered.contains(r#"ServerIP="192.168.0.2""#));
         assert!(rendered.contains(r#"TimeZone="300""#));
-        assert!(rendered.contains(r#"<SummerTime enable="1" auto="1" offset="60">"#));
+        assert!(rendered.contains(r#"<SummerTime enable="0" auto="0" offset="0">"#));
     }
 
     #[test]
@@ -877,5 +871,6 @@ mod tests {
         let rendered = render_manual_time_config_xml(&current, &policy);
         assert!(rendered.contains(r#"TimeMode="MANUAL""#));
         assert!(rendered.contains(r#"CurTime="2026-04-18 10:00:00""#));
+        assert!(rendered.contains(r#"<SummerTime enable="0" auto="0" offset="0">"#));
     }
 }

--- a/src/camera_device/mod.rs
+++ b/src/camera_device/mod.rs
@@ -234,7 +234,7 @@ pub use apply::apply_camera_device_config;
 pub use control::control_camera_device;
 pub use inventory::{list_camera_device_inventory, read_camera_device};
 pub use mount::mount_camera_device;
-pub use reconcile::reconcile_camera_device;
+pub use reconcile::{reconcile_camera_device, reconcile_camera_identity_and_endpoint};
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -3145,10 +3145,51 @@ fn candidate_id(candidate: &DiscoveredCameraCandidate) -> String {
     })
 }
 
+pub(crate) fn reolink_stable_source_id(uid: &str, mac: &str) -> Option<String> {
+    let key = if !uid.trim().is_empty() {
+        uid.trim()
+    } else if !mac.trim().is_empty() {
+        mac.trim()
+    } else {
+        ""
+    };
+    if key.is_empty() {
+        None
+    } else {
+        Some(format!("reolink-{}", sanitize_id(key)))
+    }
+}
+
+pub(crate) fn reolink_candidate_stable_source_id(
+    candidate: &DiscoveredCameraCandidate,
+) -> Option<String> {
+    reolink_stable_source_id(&candidate.signatures.reolink_uid, &candidate.mac)
+}
+
+pub(crate) fn reolink_source_id_is_ip_derived(source_id: &str) -> bool {
+    let Some(suffix) = source_id.trim().strip_prefix("reolink-") else {
+        return false;
+    };
+    looks_like_sanitized_ipv4(suffix)
+}
+
+fn looks_like_sanitized_ipv4(value: &str) -> bool {
+    let parts = value.split('-').collect::<Vec<_>>();
+    parts.len() == 4
+        && parts.iter().all(|part| {
+            !part.is_empty()
+                && part.len() <= 3
+                && part.chars().all(|ch| ch.is_ascii_digit())
+                && part.parse::<u8>().is_ok()
+        })
+}
+
 fn build_source_id(candidate: &DiscoveredCameraCandidate, driver_id: &str) -> String {
     let raw =
         if driver_id == DRIVER_ID_REOLINK && !candidate.signatures.reolink_uid.trim().is_empty() {
             format!("reolink-{}", candidate.signatures.reolink_uid.trim())
+        } else if driver_id == DRIVER_ID_REOLINK && !candidate.mac.trim().is_empty() {
+            format!("reolink-{}", candidate.mac.trim())
         } else if driver_id == DRIVER_ID_REOLINK {
             format!("reolink-{}", candidate.ip.trim())
         } else if driver_is_xm(driver_id) {
@@ -3243,6 +3284,22 @@ fn derive_rtsp_url(
         );
     }
     format!("rtsp://{auth}{}:554/", candidate.ip.trim())
+}
+
+pub(crate) fn rewrite_rtsp_url_host(rtsp_url: &str, host: &str, fallback_port: u16) -> String {
+    let host = host.trim();
+    if host.is_empty() {
+        return rtsp_url.trim().to_string();
+    }
+    if let Ok(mut url) = Url::parse(rtsp_url.trim()) {
+        if url.set_host(Some(host)).is_ok() {
+            if url.port().is_none() && fallback_port > 0 {
+                let _ = url.set_port(Some(fallback_port));
+            }
+            return url.to_string();
+        }
+    }
+    rtsp_url.trim().to_string()
 }
 
 fn xm_preview_rtsp_url(url: &str) -> String {
@@ -3481,6 +3538,7 @@ async fn active_scan_candidate(ip: &str) -> Option<DiscoveredCameraCandidate> {
         return None;
     }
     let mut candidate = blank_candidate(ip);
+    candidate.mac = neighbor_mac_for_ip(ip);
     candidate.transports.http = ports.http;
     candidate.transports.https = ports.https;
     candidate.transports.rtsp = ports.rtsp;
@@ -3488,6 +3546,28 @@ async fn active_scan_candidate(ip: &str) -> Option<DiscoveredCameraCandidate> {
     candidate.transports.proprietary_9000 = ports.proprietary_9000;
     push_unique_string(&mut candidate.discovered_via, "interface_scan");
     Some(candidate)
+}
+
+fn neighbor_mac_for_ip(ip: &str) -> String {
+    let output = match Command::new("ip")
+        .args(["neigh", "show", "to", ip.trim()])
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return String::new(),
+    };
+    let raw = String::from_utf8_lossy(&output.stdout);
+    let parts = raw.split_whitespace().collect::<Vec<_>>();
+    parts
+        .windows(2)
+        .find_map(|window| {
+            if window[0] == "lladdr" {
+                Some(window[1].trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default()
 }
 
 fn host_and_port_from_xaddr(value: &str) -> Option<(String, u16)> {
@@ -3743,6 +3823,51 @@ mod tests {
         assert_eq!(
             derive_rtsp_url(&candidate, DRIVER_ID_XM_40E, "admin", "123456", ""),
             "rtsp://admin:123456@192.168.0.201:554/user=admin_password=123456_channel=1_stream=0.sdp?real_stream"
+        );
+    }
+
+    #[test]
+    fn reolink_source_id_prefers_uid_then_mac_over_ip() {
+        let uid_candidate = DiscoveredCameraCandidate {
+            ip: "192.168.250.98".to_string(),
+            mac: "ec:71:db:32:0a:8f".to_string(),
+            signatures: CameraSignatureSet {
+                reolink_uid: "95270001ABC".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mac_candidate = DiscoveredCameraCandidate {
+            ip: "192.168.250.98".to_string(),
+            mac: "ec:71:db:32:0a:8f".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            build_source_id(&uid_candidate, DRIVER_ID_REOLINK),
+            "reolink-95270001abc"
+        );
+        assert_eq!(
+            build_source_id(&mac_candidate, DRIVER_ID_REOLINK),
+            "reolink-ec-71-db-32-0a-8f"
+        );
+        assert_eq!(
+            reolink_stable_source_id("", "ec:71:db:32:0a:8f").as_deref(),
+            Some("reolink-ec-71-db-32-0a-8f")
+        );
+    }
+
+    #[test]
+    fn rewrite_rtsp_url_host_preserves_credentials_and_path() {
+        let rewritten = rewrite_rtsp_url_host(
+            "rtsp://admin:secret@192.168.250.97:554/h264Preview_01_main",
+            "192.168.250.98",
+            554,
+        );
+
+        assert_eq!(
+            rewritten,
+            "rtsp://admin:secret@192.168.250.98:554/h264Preview_01_main"
         );
     }
 

--- a/src/camera_device/reconcile.rs
+++ b/src/camera_device/reconcile.rs
@@ -8,6 +8,90 @@ pub struct CameraDriftReconcileOutcome {
     pub mounted: MountedCamera,
 }
 
+#[derive(Clone, Debug)]
+pub struct CameraIdentityReconcileOutcome {
+    pub previous_source_id: String,
+    pub previous_host: String,
+    pub configured: CameraDeviceConfig,
+    pub match_kind: String,
+    pub confidence: u8,
+}
+
+#[derive(Clone, Debug)]
+struct ReolinkIdentityMatch {
+    candidate: DiscoveredCameraCandidate,
+    confidence: u8,
+    match_kind: String,
+}
+
+#[derive(Clone, Debug)]
+struct AuthenticatedReolinkCandidate {
+    candidate: DiscoveredCameraCandidate,
+    strong_context_match: bool,
+}
+
+pub async fn reconcile_camera_identity_and_endpoint(
+    cfg: &Config,
+    camera: &CameraDeviceConfig,
+) -> Result<Option<CameraIdentityReconcileOutcome>> {
+    if camera.driver_id.trim() != DRIVER_ID_REOLINK {
+        return Ok(None);
+    }
+
+    let source_is_noncompliant = !camera.source_id.trim().starts_with("reolink-")
+        || reolink_source_id_is_ip_derived(&camera.source_id);
+    let host_is_reachable = current_reolink_host_is_reachable(camera).await;
+    if !source_is_noncompliant && host_is_reachable {
+        return Ok(None);
+    }
+
+    let discovered = discover_candidates(cfg).await?;
+    let mut candidates = discovered
+        .into_iter()
+        .filter(|candidate| candidate.driver_match.driver_id.trim() == DRIVER_ID_REOLINK)
+        .collect::<Vec<_>>();
+    if let Some(current) = current_host_reolink_candidate(camera).await? {
+        if !candidates
+            .iter()
+            .any(|candidate| candidate.ip.trim() == current.ip.trim())
+        {
+            candidates.push(current);
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(None);
+    }
+
+    let mut matches = candidates
+        .iter()
+        .filter_map(|candidate| {
+            known_reolink_identity_match(camera, candidate, source_is_noncompliant)
+        })
+        .collect::<Vec<_>>();
+
+    if matches
+        .iter()
+        .all(|candidate_match| candidate_match.confidence < 85)
+    {
+        matches.extend(authenticated_reolink_matches(camera, &candidates).await?);
+    }
+
+    let Some(selected) = select_unique_reolink_identity_match(matches)? else {
+        return Ok(None);
+    };
+    let configured = reolink_config_resolved_to_candidate(cfg, camera, &selected.candidate);
+    if !camera_config_changed(camera, &configured) {
+        return Ok(None);
+    }
+    Ok(Some(CameraIdentityReconcileOutcome {
+        previous_source_id: camera.source_id.clone(),
+        previous_host: camera.onvif_host.clone(),
+        configured,
+        match_kind: selected.match_kind,
+        confidence: selected.confidence,
+    }))
+}
+
 pub async fn reconcile_camera_device(
     cfg: &Config,
     camera: &CameraDeviceConfig,
@@ -91,6 +175,266 @@ fn camera_field_is_reconcilable(camera: &CameraDeviceConfig, field: &str) -> boo
     false
 }
 
+async fn current_reolink_host_is_reachable(camera: &CameraDeviceConfig) -> bool {
+    let host = camera.onvif_host.trim();
+    if host.is_empty() {
+        return false;
+    }
+    let ports = probe_common_ports(host).await;
+    ports.http || ports.https || ports.rtsp || ports.onvif || ports.proprietary_9000
+}
+
+async fn current_host_reolink_candidate(
+    camera: &CameraDeviceConfig,
+) -> Result<Option<DiscoveredCameraCandidate>> {
+    let host = camera.onvif_host.trim();
+    if host.is_empty() {
+        return Ok(None);
+    }
+    let ports = probe_common_ports(host).await;
+    if !(ports.http || ports.https || ports.rtsp || ports.onvif || ports.proprietary_9000) {
+        return Ok(None);
+    }
+
+    let mut candidate = blank_candidate(host);
+    candidate.mac = neighbor_mac_for_ip(host);
+    candidate.transports.http = ports.http;
+    candidate.transports.https = ports.https;
+    candidate.transports.rtsp = ports.rtsp;
+    candidate.transports.onvif = ports.onvif;
+    candidate.transports.proprietary_9000 = ports.proprietary_9000;
+    push_unique_string(&mut candidate.discovered_via, "configured_endpoint_probe");
+
+    if let Some(discovered) = reolink::discover_with_hint(host, 2)
+        .await
+        .unwrap_or_default()
+        .into_iter()
+        .find(|entry| entry.ip.trim() == host)
+    {
+        candidate.mac = first_nonempty(&candidate.mac, &discovered.mac);
+        candidate.signatures.vendor = "Reolink".to_string();
+        candidate.signatures.model = first_nonempty(&candidate.signatures.model, &discovered.model);
+        candidate.signatures.reolink_uid =
+            first_nonempty(&candidate.signatures.reolink_uid, &discovered.uid);
+        push_unique_string(&mut candidate.discovered_via, &discovered.from);
+    }
+
+    hydrate_candidate(&mut candidate, &http_client()?).await?;
+    candidate.driver_match = match_candidate(&candidate);
+    if candidate.driver_match.driver_id.trim() != DRIVER_ID_REOLINK {
+        return Ok(None);
+    }
+    candidate.candidate_id = candidate_id(&candidate);
+    Ok(Some(candidate))
+}
+
+fn known_reolink_identity_match(
+    camera: &CameraDeviceConfig,
+    candidate: &DiscoveredCameraCandidate,
+    source_is_noncompliant: bool,
+) -> Option<ReolinkIdentityMatch> {
+    let candidate_uid_source = reolink_stable_source_id(&candidate.signatures.reolink_uid, "");
+    let candidate_mac_source = reolink_stable_source_id("", &candidate.mac);
+    let candidate_stable_source = reolink_candidate_stable_source_id(candidate);
+    let configured_source = camera.source_id.trim();
+
+    if candidate_uid_source
+        .as_deref()
+        .is_some_and(|source| source == configured_source)
+    {
+        return Some(identity_match(candidate, 100, "reolink_uid_source_id"));
+    }
+    if candidate_mac_source
+        .as_deref()
+        .is_some_and(|source| source == configured_source)
+    {
+        return Some(identity_match(candidate, 96, "reolink_mac_source_id"));
+    }
+    if !camera.mac_address.trim().is_empty()
+        && !candidate.mac.trim().is_empty()
+        && sanitize_id(&camera.mac_address) == sanitize_id(&candidate.mac)
+    {
+        return Some(identity_match(candidate, 95, "reolink_mac_config"));
+    }
+    if source_is_noncompliant
+        && candidate_stable_source.is_some()
+        && !camera.onvif_host.trim().is_empty()
+        && camera.onvif_host.trim() == candidate.ip.trim()
+    {
+        return Some(identity_match(
+            candidate,
+            88,
+            "reolink_current_endpoint_identity_convergence",
+        ));
+    }
+    None
+}
+
+async fn authenticated_reolink_matches(
+    camera: &CameraDeviceConfig,
+    candidates: &[DiscoveredCameraCandidate],
+) -> Result<Vec<ReolinkIdentityMatch>> {
+    let mut authenticated = Vec::new();
+    for candidate in candidates {
+        if let Some(authenticated_candidate) =
+            authenticate_reolink_candidate(camera, candidate).await?
+        {
+            authenticated.push(authenticated_candidate);
+        }
+    }
+
+    let strong = authenticated
+        .iter()
+        .filter(|candidate| candidate.strong_context_match)
+        .cloned()
+        .collect::<Vec<_>>();
+    if strong.len() == 1 {
+        return Ok(vec![identity_match(
+            &strong[0].candidate,
+            90,
+            "reolink_authenticated_context_match",
+        )]);
+    }
+    if authenticated.len() == 1 {
+        return Ok(vec![identity_match(
+            &authenticated[0].candidate,
+            86,
+            "reolink_authenticated_single_candidate",
+        )]);
+    }
+    Ok(Vec::new())
+}
+
+async fn authenticate_reolink_candidate(
+    camera: &CameraDeviceConfig,
+    candidate: &DiscoveredCameraCandidate,
+) -> Result<Option<AuthenticatedReolinkCandidate>> {
+    for password in crate::config::camera_device_credential_candidates(camera) {
+        let request = ProbeCameraRequest {
+            source_id: String::new(),
+            ip: candidate.ip.clone(),
+            username: camera.username.clone(),
+            password,
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+        };
+        if let Ok(probe) = probe_reolink_candidate(candidate, &request).await
+            && probe
+                .get("status")
+                .and_then(Value::as_str)
+                .is_some_and(|status| status == "ok")
+        {
+            return Ok(Some(AuthenticatedReolinkCandidate {
+                candidate: candidate.clone(),
+                strong_context_match: reolink_probe_matches_config(camera, &probe),
+            }));
+        }
+    }
+    Ok(None)
+}
+
+fn reolink_probe_matches_config(camera: &CameraDeviceConfig, probe: &Value) -> bool {
+    let observed_model = probe
+        .get("observed")
+        .unwrap_or(&Value::Null)
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let observed_overlay = probe
+        .get("observed")
+        .unwrap_or(&Value::Null)
+        .get("overlayText")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    labels_match(&camera.model, observed_model)
+        || labels_match(&camera.name, observed_overlay)
+        || labels_match(&camera.desired.display_name, observed_overlay)
+        || labels_match(&camera.desired.overlay_text, observed_overlay)
+}
+
+fn labels_match(left: &str, right: &str) -> bool {
+    let left = left.trim().to_ascii_lowercase();
+    let right = right.trim().to_ascii_lowercase();
+    !left.is_empty() && !right.is_empty() && (left.contains(&right) || right.contains(&left))
+}
+
+fn select_unique_reolink_identity_match(
+    mut matches: Vec<ReolinkIdentityMatch>,
+) -> Result<Option<ReolinkIdentityMatch>> {
+    matches.sort_by(|left, right| right.confidence.cmp(&left.confidence));
+    let Some(best) = matches.first().cloned() else {
+        return Ok(None);
+    };
+    if best.confidence < 85 {
+        return Ok(None);
+    }
+    if matches
+        .iter()
+        .skip(1)
+        .any(|candidate_match| candidate_match.confidence == best.confidence)
+    {
+        return Err(anyhow!(
+            "ambiguous Reolink identity relocation match at confidence {}",
+            best.confidence
+        ));
+    }
+    Ok(Some(best))
+}
+
+fn identity_match(
+    candidate: &DiscoveredCameraCandidate,
+    confidence: u8,
+    match_kind: &str,
+) -> ReolinkIdentityMatch {
+    ReolinkIdentityMatch {
+        candidate: candidate.clone(),
+        confidence,
+        match_kind: match_kind.to_string(),
+    }
+}
+
+fn reolink_config_resolved_to_candidate(
+    cfg: &Config,
+    camera: &CameraDeviceConfig,
+    candidate: &DiscoveredCameraCandidate,
+) -> CameraDeviceConfig {
+    let mut updated = camera.clone();
+    if let Some(stable_source_id) = reolink_candidate_stable_source_id(candidate) {
+        updated.source_id = stable_source_id;
+    }
+    if !candidate.ip.trim().is_empty() {
+        updated.onvif_host = candidate.ip.trim().to_string();
+        if !updated.rtsp_url.trim().is_empty() {
+            updated.rtsp_url =
+                rewrite_rtsp_url_host(&updated.rtsp_url, &updated.onvif_host, updated.rtsp_port);
+        } else {
+            updated.rtsp_url = derive_rtsp_url(
+                candidate,
+                DRIVER_ID_REOLINK,
+                &updated.username,
+                &updated.password,
+                "",
+            );
+        }
+    }
+    updated.onvif_port = derive_onvif_port(candidate);
+    updated.rtsp_port = derive_rtsp_port(candidate, &updated.rtsp_url);
+    if !candidate.mac.trim().is_empty() {
+        updated.mac_address = candidate.mac.trim().to_string();
+    }
+    if !candidate.signatures.vendor.trim().is_empty() {
+        updated.vendor = candidate.signatures.vendor.trim().to_string();
+    } else if updated.vendor.trim().is_empty() {
+        updated.vendor = "Reolink".to_string();
+    }
+    if !candidate.signatures.model.trim().is_empty() {
+        updated.model = candidate.signatures.model.trim().to_string();
+    }
+    updated.ptz_capable = updated.ptz_capable || candidate_ptz_capable(candidate);
+    normalize_camera_defaults(cfg, &mut updated);
+    updated
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,5 +494,107 @@ mod tests {
         assert!(!camera_config_changed(&left, &right));
         right.desired.display_name = "Driveway".to_string();
         assert!(camera_config_changed(&left, &right));
+    }
+
+    fn reolink_candidate(ip: &str, uid: &str, mac: &str) -> DiscoveredCameraCandidate {
+        DiscoveredCameraCandidate {
+            candidate_id: sanitize_id(if mac.is_empty() { ip } else { mac }),
+            ip: ip.to_string(),
+            mac: mac.to_string(),
+            signatures: CameraSignatureSet {
+                vendor: "Reolink".to_string(),
+                model: "E1 Outdoor SE".to_string(),
+                reolink_uid: uid.to_string(),
+                ..Default::default()
+            },
+            transports: CameraTransportFacts {
+                rtsp: true,
+                onvif: true,
+                proprietary_9000: true,
+                ..Default::default()
+            },
+            driver_match: DriverMatch {
+                driver_id: DRIVER_ID_REOLINK.to_string(),
+                confidence: 100,
+                mountable: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn legacy_reolink_camera() -> CameraDeviceConfig {
+        CameraDeviceConfig {
+            source_id: "reolink-192-168-250-97".to_string(),
+            name: "Reolink Patio".to_string(),
+            onvif_host: "192.168.250.97".to_string(),
+            onvif_port: 8000,
+            rtsp_url: "rtsp://admin:secret@192.168.250.97:554/h264Preview_01_main".to_string(),
+            username: "admin".to_string(),
+            password: "secret".to_string(),
+            driver_id: DRIVER_ID_REOLINK.to_string(),
+            vendor: "Reolink".to_string(),
+            model: "E1 Outdoor SE".to_string(),
+            mac_address: String::new(),
+            rtsp_port: 554,
+            ptz_capable: true,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDeviceDesiredConfig {
+                display_name: "Reolink Patio".to_string(),
+                overlay_text: "Reolink Patio".to_string(),
+                overlay_timestamp: true,
+                ..Default::default()
+            },
+            credentials: Default::default(),
+        }
+    }
+
+    fn sample_config() -> Config {
+        let path = std::env::temp_dir().join(format!(
+            "constitute-nvr-reconcile-test-{}-{}.json",
+            std::process::id(),
+            crate::util::now_ms()
+        ));
+        let (cfg, _) = Config::load_or_create(&path).expect("config");
+        let _ = std::fs::remove_file(path);
+        cfg
+    }
+
+    #[test]
+    fn reolink_source_id_detects_ip_derived_legacy() {
+        assert!(reolink_source_id_is_ip_derived("reolink-192-168-250-97"));
+        assert!(!reolink_source_id_is_ip_derived("reolink-95270001abc"));
+        assert!(!reolink_source_id_is_ip_derived(
+            "reolink-ec-71-db-32-0a-8f"
+        ));
+    }
+
+    #[test]
+    fn reolink_resolved_config_prefers_uid_source_id_and_rewrites_endpoint() {
+        let cfg = sample_config();
+        let camera = legacy_reolink_camera();
+        let candidate = reolink_candidate("192.168.250.98", "95270001ABC", "ec:71:db:32:0a:8f");
+
+        let updated = reolink_config_resolved_to_candidate(&cfg, &camera, &candidate);
+
+        assert_eq!(updated.source_id, "reolink-95270001abc");
+        assert_eq!(updated.onvif_host, "192.168.250.98");
+        assert_eq!(updated.mac_address, "ec:71:db:32:0a:8f");
+        assert!(updated.rtsp_url.contains("192.168.250.98"));
+        assert!(!updated.rtsp_url.contains("192.168.250.97"));
+    }
+
+    #[test]
+    fn reolink_identity_match_accepts_existing_mac_source_id() {
+        let mut camera = legacy_reolink_camera();
+        camera.source_id = "reolink-ec-71-db-32-0a-8f".to_string();
+        let candidate = reolink_candidate("192.168.250.98", "", "ec:71:db:32:0a:8f");
+
+        let matched = known_reolink_identity_match(&camera, &candidate, false)
+            .expect("mac source id should match");
+
+        assert_eq!(matched.confidence, 96);
+        assert_eq!(matched.match_kind, "reolink_mac_source_id");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -750,8 +750,15 @@ fn apply_camera_device_defaults(
         camera.driver_id = "generic_onvif_rtsp".to_string();
         changed = true;
     }
-    if camera.vendor.trim().is_empty() && camera.driver_id == "reolink" {
+    if camera.driver_id == "reolink" && camera.vendor.trim() != "Reolink" {
         camera.vendor = "Reolink".to_string();
+        changed = true;
+    }
+    if camera.driver_id == "reolink"
+        && reolink_source_id_is_ip_derived(&camera.source_id)
+        && !camera.mac_address.trim().is_empty()
+    {
+        camera.source_id = reolink_mac_source_id(&camera.mac_address);
         changed = true;
     }
     if camera.vendor.trim().is_empty() && camera.driver_id == "xm_40e" {
@@ -846,6 +853,36 @@ fn normalize_site_timezone_candidate(value: &str) -> Option<String> {
         return Some(trimmed);
     }
     None
+}
+
+fn reolink_source_id_is_ip_derived(source_id: &str) -> bool {
+    let Some(suffix) = source_id.trim().strip_prefix("reolink-") else {
+        return false;
+    };
+    let parts = suffix.split('-').collect::<Vec<_>>();
+    parts.len() == 4
+        && parts.iter().all(|part| {
+            !part.is_empty()
+                && part.len() <= 3
+                && part.chars().all(|ch| ch.is_ascii_digit())
+                && part.parse::<u8>().is_ok()
+        })
+}
+
+fn reolink_mac_source_id(mac: &str) -> String {
+    let sanitized = mac
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+    format!("reolink-{sanitized}")
 }
 
 fn infer_camera_device_model(camera: &CameraDeviceConfig) -> String {
@@ -1331,7 +1368,7 @@ mod tests {
             username: "admin".to_string(),
             password: "old-secret".to_string(),
             driver_id: "reolink".to_string(),
-            vendor: "Reolink".to_string(),
+            vendor: "ONVIF/RTSP".to_string(),
             model: "E1 Outdoor".to_string(),
             mac_address: String::new(),
             rtsp_port: 554,
@@ -1502,5 +1539,33 @@ mod tests {
         let camera = &cfg.camera_devices[0];
         assert_eq!(camera.driver_id, "generic_onvif_rtsp");
         assert_eq!(camera.desired.display_name, "Manual Camera");
+    }
+
+    #[test]
+    fn apply_defaults_converges_reolink_ip_source_id_when_mac_is_known() {
+        let mut cfg = Config::default_generated();
+        cfg.camera_devices.push(CameraDeviceConfig {
+            source_id: "reolink-192-168-250-97".to_string(),
+            name: "Reolink Patio".to_string(),
+            onvif_host: "192.168.250.98".to_string(),
+            onvif_port: 8000,
+            rtsp_url: "rtsp://admin:secret@192.168.250.98:554/h264Preview_01_main".to_string(),
+            username: "admin".to_string(),
+            password: "secret".to_string(),
+            driver_id: "reolink".to_string(),
+            vendor: "Reolink".to_string(),
+            model: "E1 Outdoor SE".to_string(),
+            mac_address: "ec:71:db:32:0a:8f".to_string(),
+            rtsp_port: 554,
+            ptz_capable: true,
+            enabled: true,
+            segment_secs: 10,
+            desired: CameraDeviceDesiredConfig::default(),
+            credentials: CameraCredentialState::default(),
+        });
+
+        assert!(cfg.apply_defaults());
+        assert_eq!(cfg.camera_devices[0].source_id, "reolink-ec-71-db-32-0a-8f");
+        assert_eq!(cfg.camera_devices[0].vendor, "Reolink");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -472,7 +472,14 @@ async fn run_reolink_autoprovision(cfg: &mut Config, cfg_path: &Path) -> Result<
             554
         };
 
-        let source_id = reolink_source_id(&device.uid, &ip);
+        let Some(source_id) = camera_device::reolink_stable_source_id(&device.uid, &device.mac)
+        else {
+            warn!(
+                ip = %ip,
+                "reolink auto-provision skipped candidate without stable UID or MAC"
+            );
+            continue;
+        };
         let source_name = if device.model.trim().is_empty() {
             format!("Reolink {}", ip)
         } else {
@@ -538,25 +545,6 @@ async fn run_reolink_autoprovision(cfg: &mut Config, cfg_path: &Path) -> Result<
     }
 
     Ok(())
-}
-
-fn reolink_source_id(uid: &str, ip: &str) -> String {
-    let key = if uid.trim().is_empty() {
-        ip.trim()
-    } else {
-        uid.trim()
-    };
-    let sanitized = key
-        .chars()
-        .map(|ch| {
-            if ch.is_ascii_alphanumeric() {
-                ch.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>();
-    format!("reolink-{}", sanitized.trim_matches('-'))
 }
 
 fn init_logging(level: &str) {

--- a/src/media_projection/mod.rs
+++ b/src/media_projection/mod.rs
@@ -2,8 +2,10 @@ use crate::camera_device::registry::driver_is_xm;
 use crate::config::{CameraDeviceConfig, Config};
 use crate::media::{ffmpeg, planner, types::OutputCodec};
 use crate::recording::runtime::backoff_secs;
+use constitute_protocol::{LogCategory, LogOutcome, LogSeverity, LogSubjectRef};
 use rtp::packet::Packet as RtpPacket;
 use serde::Serialize;
+use serde_json::{Map, Value, json};
 use std::collections::HashMap;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -276,12 +278,14 @@ async fn run_projection_worker(
         Ok(socket) => socket,
         Err(err) => {
             set_projection_error(&state, format!("udp bind failed: {err}")).await;
+            submit_projection_runtime_error(&camera, codec, "udp_bind_failed").await;
             warn!(source = %camera.source_id, error = %err, "media projection UDP bind failed");
             return;
         }
     };
     if let Err(err) = std_socket.set_nonblocking(true) {
         set_projection_error(&state, format!("udp nonblocking setup failed: {err}")).await;
+        submit_projection_runtime_error(&camera, codec, "udp_nonblocking_failed").await;
         warn!(source = %camera.source_id, error = %err, "media projection UDP nonblocking setup failed");
         return;
     }
@@ -289,6 +293,7 @@ async fn run_projection_worker(
         Ok(addr) => addr,
         Err(err) => {
             set_projection_error(&state, format!("udp local addr failed: {err}")).await;
+            submit_projection_runtime_error(&camera, codec, "udp_local_addr_failed").await;
             warn!(source = %camera.source_id, error = %err, "media projection UDP local addr failed");
             return;
         }
@@ -297,6 +302,7 @@ async fn run_projection_worker(
         Ok(socket) => socket,
         Err(err) => {
             set_projection_error(&state, format!("udp socket init failed: {err}")).await;
+            submit_projection_runtime_error(&camera, codec, "udp_socket_init_failed").await;
             warn!(source = %camera.source_id, error = %err, "media projection UDP socket init failed");
             return;
         }
@@ -327,14 +333,24 @@ async fn run_projection_worker(
             Err(err) => {
                 let backoff =
                     note_projection_backoff(&state, format!("ffmpeg start failed: {err}")).await;
+                submit_projection_backoff_event(
+                    &camera,
+                    codec,
+                    LogSeverity::Error,
+                    "projection_start_failed",
+                    "ffmpeg_start_failed",
+                    backoff,
+                    None,
+                )
+                .await;
                 warn!(
                     source = %camera.source_id,
                     codec = codec.label(),
                     error = %err,
-                    backoff_secs = backoff,
+                    backoff_secs = backoff.backoff_secs,
                     "media projection worker failed to start; will retry"
                 );
-                wait_or_stop(Duration::from_secs(backoff), &mut stop_rx).await;
+                wait_or_stop(Duration::from_secs(backoff.backoff_secs), &mut stop_rx).await;
                 continue;
             }
         };
@@ -368,12 +384,20 @@ async fn run_projection_worker(
                                 }
                             };
                             continuity.rewrite(&mut packet);
+                            let mut recovered_restart_attempt = None;
                             {
                                 let mut current = state.lock().await;
+                                if current.restart_attempt > 0 {
+                                    recovered_restart_attempt = Some(current.restart_attempt);
+                                }
                                 current.state = "ready".to_string();
                                 current.restart_attempt = 0;
                                 current.last_packet_timestamp = Some(crate::util::now_ms());
                                 current.last_error = None;
+                            }
+                            if let Some(restart_attempt) = recovered_restart_attempt {
+                                submit_projection_recovered_event(&camera, codec, restart_attempt)
+                                    .await;
                             }
                             let _ = sender.send(packet);
                         }
@@ -393,30 +417,90 @@ async fn run_projection_worker(
 
         match exit_reason {
             ProjectionExitReason::Stopped => break,
-            ProjectionExitReason::ChildExited(message)
-            | ProjectionExitReason::ChildWaitFailed(message)
-            | ProjectionExitReason::SocketRecvFailed(message) => {
+            ProjectionExitReason::ChildExited(message) => {
                 let backoff = note_projection_backoff(&state, message.clone()).await;
+                submit_projection_backoff_event(
+                    &camera,
+                    codec,
+                    LogSeverity::Warning,
+                    "projection_worker_restarting",
+                    "ffmpeg_exited",
+                    backoff,
+                    None,
+                )
+                .await;
                 warn!(
                     source = %camera.source_id,
                     codec = codec.label(),
                     message,
-                    backoff_secs = backoff,
+                    backoff_secs = backoff.backoff_secs,
                     "media projection worker exited; restarting"
                 );
-                wait_or_stop(Duration::from_secs(backoff), &mut stop_rx).await;
+                wait_or_stop(Duration::from_secs(backoff.backoff_secs), &mut stop_rx).await;
+            }
+            ProjectionExitReason::ChildWaitFailed(message) => {
+                let backoff = note_projection_backoff(&state, message.clone()).await;
+                submit_projection_backoff_event(
+                    &camera,
+                    codec,
+                    LogSeverity::Warning,
+                    "projection_worker_restarting",
+                    "ffmpeg_wait_failed",
+                    backoff,
+                    None,
+                )
+                .await;
+                warn!(
+                    source = %camera.source_id,
+                    codec = codec.label(),
+                    message,
+                    backoff_secs = backoff.backoff_secs,
+                    "media projection worker wait failed; restarting"
+                );
+                wait_or_stop(Duration::from_secs(backoff.backoff_secs), &mut stop_rx).await;
+            }
+            ProjectionExitReason::SocketRecvFailed(message) => {
+                let backoff = note_projection_backoff(&state, message.clone()).await;
+                submit_projection_backoff_event(
+                    &camera,
+                    codec,
+                    LogSeverity::Warning,
+                    "projection_worker_restarting",
+                    "socket_receive_failed",
+                    backoff,
+                    None,
+                )
+                .await;
+                warn!(
+                    source = %camera.source_id,
+                    codec = codec.label(),
+                    message,
+                    backoff_secs = backoff.backoff_secs,
+                    "media projection worker exited; restarting"
+                );
+                wait_or_stop(Duration::from_secs(backoff.backoff_secs), &mut stop_rx).await;
             }
             ProjectionExitReason::NoPackets(timeout_secs) => {
                 let message = format!("no RTP packets for {timeout_secs}s");
                 let backoff = note_projection_backoff(&state, message).await;
+                submit_projection_backoff_event(
+                    &camera,
+                    codec,
+                    LogSeverity::Warning,
+                    "projection_stalled",
+                    "no_rtp_packets",
+                    backoff,
+                    Some(timeout_secs),
+                )
+                .await;
                 warn!(
                     source = %camera.source_id,
                     codec = codec.label(),
                     idle_timeout_secs = timeout_secs,
-                    backoff_secs = backoff,
+                    backoff_secs = backoff.backoff_secs,
                     "media projection worker stalled; restarting"
                 );
-                wait_or_stop(Duration::from_secs(backoff), &mut stop_rx).await;
+                wait_or_stop(Duration::from_secs(backoff.backoff_secs), &mut stop_rx).await;
             }
         }
     }
@@ -441,12 +525,155 @@ async fn set_projection_error(state: &Arc<Mutex<ProjectionState>>, message: Stri
     current.last_error = Some(message);
 }
 
-async fn note_projection_backoff(state: &Arc<Mutex<ProjectionState>>, message: String) -> u64 {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ProjectionBackoff {
+    restart_attempt: u64,
+    backoff_secs: u64,
+}
+
+async fn note_projection_backoff(
+    state: &Arc<Mutex<ProjectionState>>,
+    message: String,
+) -> ProjectionBackoff {
     let mut current = state.lock().await;
     current.restart_attempt = current.restart_attempt.saturating_add(1);
     current.state = "backoff".to_string();
     current.last_error = Some(message);
-    backoff_secs(current.restart_attempt)
+    ProjectionBackoff {
+        restart_attempt: current.restart_attempt,
+        backoff_secs: backoff_secs(current.restart_attempt),
+    }
+}
+
+async fn submit_projection_runtime_error(
+    camera: &CameraDeviceConfig,
+    codec: ProjectionCodec,
+    event_type: &str,
+) {
+    submit_projection_event(
+        camera,
+        LogSeverity::Error,
+        LogOutcome::Failed,
+        "projection_runtime_error",
+        projection_safe_facts(
+            camera,
+            codec,
+            event_type,
+            None,
+            None,
+            None,
+            false,
+            "operator_repair_required",
+        ),
+    )
+    .await;
+}
+
+async fn submit_projection_backoff_event(
+    camera: &CameraDeviceConfig,
+    codec: ProjectionCodec,
+    severity: LogSeverity,
+    event_tag: &str,
+    event_type: &str,
+    backoff: ProjectionBackoff,
+    idle_timeout_secs: Option<u64>,
+) {
+    submit_projection_event(
+        camera,
+        severity,
+        LogOutcome::Degraded,
+        event_tag,
+        projection_safe_facts(
+            camera,
+            codec,
+            event_type,
+            Some(backoff.restart_attempt),
+            Some(backoff.backoff_secs),
+            idle_timeout_secs,
+            true,
+            "projection_worker_restart_scheduled",
+        ),
+    )
+    .await;
+}
+
+async fn submit_projection_recovered_event(
+    camera: &CameraDeviceConfig,
+    codec: ProjectionCodec,
+    restart_attempt: u64,
+) {
+    submit_projection_event(
+        camera,
+        LogSeverity::Info,
+        LogOutcome::Recovered,
+        "projection_recovered",
+        projection_safe_facts(
+            camera,
+            codec,
+            "rtp_packets_resumed",
+            Some(restart_attempt),
+            None,
+            None,
+            false,
+            "projection_worker_receiving_packets",
+        ),
+    )
+    .await;
+}
+
+async fn submit_projection_event(
+    camera: &CameraDeviceConfig,
+    severity: LogSeverity,
+    outcome: LogOutcome,
+    event_tag: &str,
+    safe_facts: Value,
+) {
+    crate::logging_surface::submit_safe_event(
+        "media_projection",
+        LogCategory::MediaProjection,
+        severity,
+        outcome,
+        LogSubjectRef {
+            kind: "cameraDevice".to_string(),
+            id: Some(camera.source_id.clone()),
+            display: Some(camera.name.clone()),
+        },
+        &["nvr", "media_projection", event_tag],
+        safe_facts,
+    )
+    .await;
+}
+
+fn projection_safe_facts(
+    camera: &CameraDeviceConfig,
+    codec: ProjectionCodec,
+    event_type: &str,
+    restart_attempt: Option<u64>,
+    backoff_secs: Option<u64>,
+    idle_timeout_secs: Option<u64>,
+    repair_needed: bool,
+    mitigation: &str,
+) -> Value {
+    let mut facts = Map::new();
+    facts.insert("eventType".to_string(), json!(event_type));
+    facts.insert("sourceId".to_string(), json!(camera.source_id.as_str()));
+    facts.insert("cameraName".to_string(), json!(camera.name.as_str()));
+    facts.insert("driverId".to_string(), json!(camera.driver_id.as_str()));
+    facts.insert("vendor".to_string(), json!(camera.vendor.as_str()));
+    facts.insert("codec".to_string(), json!(codec.label()));
+    facts.insert("selectedStream".to_string(), json!("preview"));
+    facts.insert("repairNeeded".to_string(), json!(repair_needed));
+    facts.insert("mitigation".to_string(), json!(mitigation));
+    if let Some(restart_attempt) = restart_attempt {
+        facts.insert("restartAttempt".to_string(), json!(restart_attempt));
+    }
+    if let Some(backoff_secs) = backoff_secs {
+        facts.insert("backoffSecs".to_string(), json!(backoff_secs));
+    }
+    if let Some(idle_timeout_secs) = idle_timeout_secs {
+        facts.insert("idleTimeoutSecs".to_string(), json!(idle_timeout_secs));
+    }
+    Value::Object(facts)
 }
 
 fn projection_no_packet_timeout_secs() -> u64 {
@@ -569,6 +796,36 @@ mod tests {
     #[test]
     fn projection_no_packet_timeout_stays_short() {
         assert_eq!(projection_no_packet_timeout_secs(), 8);
+    }
+
+    #[test]
+    fn projection_logging_safe_facts_omit_credential_material() {
+        let mut camera = test_camera("reolink-carport", "reolink_e1_outdoor_se");
+        camera.name = "Carport".to_string();
+        camera.vendor = "Reolink".to_string();
+        camera.username = "admin".to_string();
+        camera.password = "supersecret".to_string();
+        camera.rtsp_url = "rtsp://admin:supersecret@192.168.42.50/h264Preview_01_sub".to_string();
+
+        let facts = projection_safe_facts(
+            &camera,
+            ProjectionCodec::H264,
+            "no_rtp_packets",
+            Some(3),
+            Some(8),
+            Some(8),
+            true,
+            "projection_worker_restart_scheduled",
+        );
+        let rendered = serde_json::to_string(&facts).expect("safe facts should serialize");
+
+        assert!(!rendered.contains("rtsp://"));
+        assert!(!rendered.contains("supersecret"));
+        assert!(!rendered.contains("h264Preview"));
+        assert_eq!(facts["selectedStream"], "preview");
+        assert_eq!(facts["restartAttempt"], 3);
+        assert_eq!(facts["backoffSecs"], 8);
+        assert_eq!(facts["idleTimeoutSecs"], 8);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds explicit CAAC logging events for camera drift convergence and failure.
- Adds stable Reolink identity/endpoint convergence and camera-network NTP/firewall repair from the tested lab work.
- Extends media projection safe event coverage for stall/retry/recovery.

## Verification
- cargo fmt --check
- cargo test
- Lab: service rebuilt/restarted; /health ok; both sources present; mediaProjection ready.