### PR TITLE
Align NVR logging envelopes

### DIFF
--- a/src/logging_surface.rs
+++ b/src/logging_surface.rs
@@ -64,6 +64,7 @@ pub async fn submit_safe_event(
         tags: tags.iter().map(|tag| (*tag).to_string()).collect(),
         safe_facts,
         detail_ref: None,
+        encrypted_detail_refs: Vec::new(),
         redaction: vec![LogRedactionClass::Safe],
     };
     event.event_id = match log_event_id(&event) {


### PR DESCRIPTION
Aligns NVR logging envelopes with the shared logging/privacy posture used by the convergence train. NVR remains the live media proof fixture while logging participates through shared contract shape.\n\nValidation: root docs/convergence/affected/browser/native/check:all passed before branch publication; live NVR and long-stream proof passed against the convergence train.